### PR TITLE
docs(coaligned-invariant): deepen build-kit and rule-kit API references

### DIFF
--- a/.claude/skills/coaligned-invariant/references/build-kit.md
+++ b/.claude/skills/coaligned-invariant/references/build-kit.md
@@ -1,50 +1,109 @@
 # The build kit
 
-The engine binds a kit per run to the repo `root`, the module's own `dir` (for
-co-located config), and the `runtime` bag. The module declares policy; the kit
-owns the mechanism. Destructure what you need:
+The engine binds one kit per run to the repo `root`, the module's own `dir`
+(co-located config), and the `runtime` bag that fs and ripgrep route through.
+The module declares policy; the kit owns the mechanism. Destructure what you
+need:
 
 ```js
-build({ scan, scanAst, grep, config, root }) { … }
+build({ scan, scanAst, walk, grep, config, root }) { … }
 ```
+
+Two standing rules:
+
+- Never import `fs`, `node:child_process`, the package itself, or any ambient
+  dependency. A module loads via npx in consumer repos where none resolve.
+- Return plain data from `build`. The rules decide pass or fail. The one
+  exception is when the build step is the natural place to compute the violation
+  set; then pair it with `failAll`.
 
 ## File collection
 
-- `scan({ dirs, match, skip?, under?, read? })` — collect files as
-  `{ path, rel, text? }`. `match(name)` selects by filename; `skip` prunes
-  directories; `under: "src"` restricts to the per-package `src`/`test` shape;
-  `read: false` skips reading file text when you only need paths.
-- `scanAst({ dirs, match, extract, locations?, … })` — read and parse each
-  file, merging `extract(ast)` into the subject. A parse failure yields
-  `{ path, rel, parseError }` — pair with the `parseError` rule helper.
-- `parse(src, path, opts?)`, `walk(ast, visit)` — the lower-level AST seam when
-  you need to traverse yourself.
+`scan({ dirs, match, skip?, under?, read? })` → `[{ path, rel, text? }]`
+
+- `dirs` — repo-relative root directories to walk.
+- `match(name)` — filename predicate selecting which files become subjects.
+- `skip` — directory *names* pruned during recursion (`["node_modules",
+  "dist", "test"]`). Names, not globs.
+- `under: "src"` — restrict each `dirs` entry to the per-package
+  `<dir>/<child>/src/**` shape. This is how you scan `src` but not its `test`
+  sibling.
+- `read: false` — return paths only, with no `text`.
+
+`scanAst({ ...scan, extract, locations? })` → reads, parses, and merges
+`extract(ast)` into each subject.
+
+- A file that fails to parse becomes `{ path, rel, parseError }` instead. Always
+  guard that scope with the `parseError` rule so a syntax error surfaces as a
+  finding rather than a silently dropped file.
+- `locations: true` attaches `node.loc`. Use `loc.start.line` for a finding's
+  `lineNo`.
+
+`parse(src, path, opts?)` and `walk(ast, visit)` are the lower-level seam. The
+AST is **acorn** (`ecmaVersion: latest`, `sourceType: module`). `walk` is
+depth-first over every typed node, skipping `loc`/`start`/`end`. Accumulate into
+a closure:
+
+```js
+extract: (ast) => {
+  const hits = [];
+  walk(ast, (n) => { if (isBad(n)) hits.push(n.start); });
+  return { hits };
+}
+```
 
 ## Search and agreement
 
-- `grep({ pattern | patterns, paths?, globs?, caseSensitive?, onlyMatching?,
-  dedupe? })` — ripgrep matches as `{ path, lineNo, text, reason? }`, with
-  per-entry `exclude` and built-in de-duplication.
-- `restatementDrift({ entries, equal })` — the shared "single source restated
-  across consumers" scan and compare (a URL, a version, any scalar that must
-  agree in many places).
+`grep({ pattern | patterns, paths?, globs?, caseSensitive?, onlyMatching?,
+dedupe? })` → `[{ path, lineNo, text, reason? }]`. Every match is a violation;
+pair it with `failAll`.
 
-## Reading and listing
+- Matching is **case-insensitive unless `caseSensitive`** is set.
+- `patterns` entries are strings, or objects `{ pattern, reason?, globs?,
+  caseSensitive?, onlyMatching?, exclude? }`. Per-entry options override the call
+  defaults, and `globs` merge.
+- `exclude` — a RegExp tested against the raw `rel:lineNo:text` line, to drop
+  false positives.
+- `dedupe` — `false`, `true` (key on the raw line), or a key function over
+  `{ path, rel, lineNo, text, raw, reason }`.
 
-- `readText(path)`, `readJson(path)` — read a file; `readJson` returns the
-  parsed object or a falsy value on failure.
-- `config(name, fallback?)` — read co-located JSON or YAML next to the module
-  (deny-lists, allow-lists). Returns `fallback` when absent.
-- `listDir(path, { dirsOnly? })` — list a directory's entries.
-- `lineAt(text, offset)` — line number for a character offset.
-- `glob(pattern)` — compile a glob to a `RegExp` for matching `rel` paths.
+`restatementDrift({ entries, equal })` → the "one source restated across
+consumers" scan (URLs, versions, any scalar).
 
-## Rules
+- Each `entry` is `{ key, expected, consumers: [{ path, pattern }] }`.
+- It matches each consumer line by line — native, not ripgrep, so colons in URLs
+  survive — and emits one subject per match:
+  `{ key, path, lineNo, restated, expected, ok }`.
+- `restated` is capture group 1 (else the whole match), trimmed. `ok` is
+  `equal(restated, expected, key)`. Gate a `failAll` on `when: (s) => !s.ok`.
 
-- Never import `fs`, `node:child_process`, or any ambient runtime dependency.
-  Everything routes through the kit so the module stays portable across repos.
-- Return plain data from `build`. Decisions belong in the rules, not here —
-  except where the build step is the natural place to compute a violation set
-  (then pair with `failAll`).
-- Keep co-located config (`*.yml`, `*.json`) beside the module so the rule and
-  its data version together.
+## Enumeration drift
+
+`enumDrift.build(registry)` and `enumDrift.seed(registry)` assert (or seed) that
+every consumer's fenced `<!-- enum:TOPIC:PROPERTY -->` block matches its source
+set. Pass the parsed registry (`config(topicsFile)`); expose the rule set with
+`rules: (kit) => kit.enumDriftRules`.
+
+A registry is `{ topics: [{ id, source, consumers }] }`:
+
+- `source` is one of:
+  - `{ type: "fs-glob", pattern, id: dirname|basename|basename-noext, exclude? }`
+  - `{ type: "md-table", file, section, column, filter }`
+- each consumer is `{ path, property: "count" | "list" | "both" }`.
+
+Adding a topic of an existing source kind is a one-line registry edit, no code.
+
+## Reading, config, listing
+
+- `readText(path)` → text, or `null` when missing.
+- `readJson(path)` → parsed object, or `null` when missing or invalid.
+  (Both take a repo-relative or absolute path.)
+- `config(name, fallback?)` → JSON/YAML read **beside the module** (resolved
+  against `dir`, parsed by extension). Returns `fallback` (default `null`) when
+  absent, empty, or unparseable. Keep deny/allow lists here so the rule and its
+  data version together.
+- `listDir(path, { dirsOnly?, filesOnly? })` → entry names, `[]` when missing.
+- `lineAt(text, offset)` → the 1-based line for a char offset (pair with a
+  `walk`-collected `node.start`).
+- `glob(pattern)` → an anchored `RegExp` for matching `rel` (`**` spans
+  segments, `*` a non-slash run).

--- a/.claude/skills/coaligned-invariant/references/rule-kit.md
+++ b/.claude/skills/coaligned-invariant/references/rule-kit.md
@@ -7,42 +7,57 @@ factory that builds them from the helpers below.
 
 ```js
 {
-  id: "my-rule.no-foo",          // stable identifier, shows in findings
+  id: "no-foo.import",           // stable identifier, shows in findings
   scope: "src-file",             // which subject group this rule judges
   severity: "fail",              // any finding fails the run
-  when: (s) => !s.parseError,    // optional guard; skip subjects that fail it
-  check: (s, ctx) =>             // return a truthy report on violation, else null
+  when: (s, ctx) => !s.parseError,   // optional guard; falsy skips the subject
+  check: (s, ctx) =>             // null = clean; an item, or an array of items
     s.usesFoo ? { detail: s.foo } : null,
-  message: (s, report) =>        // one-line finding text
-    `imports foo [${report.detail}]`,
-  hint: "import bar instead",    // optional remediation line
+  message: (s, item, ctx) =>     // one-line finding text
+    `imports foo [${item.detail}]`,
+  hint: "import bar instead",    // string, or (s, item, ctx) => string
 }
 ```
 
-- `check` receives the subject and the shared `ctx` returned from `build`. A
-  non-null return is a violation; the returned value is passed to `message` as
-  the report.
-- `message` and `hint` may be strings or `(subject, report) => string`.
+- `check` returns `null` when clean, or a truthy **item** that becomes the
+  finding. It may also return an **array of items** — one subject then yields
+  many findings (e.g. one per offending line). `message`/`hint` run once per
+  item and receive `(subject, item, ctx)`.
+- The finding's **location** is `path: subject.path ?? null` and
+  `lineNo: item.lineNo ?? subject.lineNo ?? null`. A subject with no `path`
+  renders as `(no path)`, so carry `path`/`lineNo` on the subject, or set
+  `lineNo` on the returned item to point at a specific line.
+- `ctx` is the object `build` returned as `ctx`, passed unchanged to every rule.
+  The engine groups rules by scope and iterates subjects in stable order, so
+  `ctx` doubles as **shared mutable state** for cross-subject checks — seed a
+  `Map` in `ctx` and have `check` record-then-compare to flag duplicates or a
+  missing counterpart.
 - Keep one concern per rule. Two failure modes on one scope are two rules with
   two ids — that is what makes a finding attributable.
 
 ## Helpers (when `rules` is a factory)
 
 ```js
-rules: ({ parseError, failAll }) => [ … ]
+rules: ({ parseError, failAll, enumDriftRules }) => [ … ]
 ```
 
 - `parseError(scope, { id?, hint? })` — fails any subject carrying a
-  `parseError`. Pair with `scanAst`, which sets `parseError` on unparseable
-  files. Always include this when a scope is AST-derived, so a syntax error
-  surfaces as a finding instead of silently dropping the file.
+  `parseError` string. Pairs with `scanAst`, which sets `parseError` on
+  unparseable files; default `id` is `<scope>.parse-error`. Always include it
+  when a scope is AST-derived, so a syntax error becomes a finding instead of a
+  silently dropped file.
 - `failAll(scope, { id, message, hint?, when? })` — fails every subject in the
-  scope. Use when the build step already decided each subject is a violation
-  (for example, every `grep` match is a finding).
+  scope (its `check` always reports). Use when the build step already decided
+  each subject is a violation: every `grep` match, or a `restatementDrift`
+  subject gated by `when: (s) => !s.ok`. `message`/`hint` still receive
+  `(subject, item, ctx)`.
+- `enumDriftRules` — the enumeration-drift rule set, paired with the build kit's
+  `enumDrift`; expose verbatim via `rules: (kit) => kit.enumDriftRules`.
 
 ## Output
 
-Findings render in the same ESLint-style format as the other subcommands; pass
-`--json` for machine output. Severity `fail` is the norm — any finding fails
-the run. There is no "warn that passes"; if it should not block, it is not an
-invariant.
+Findings render in the same ESLint-style format as the other subcommands
+(`error  <message>  <id>` then `→ <hint>`); `--json` gives
+`{ result, failures, warnings }`. Severity `fail` is the norm — any finding
+fails the run. There is no "warn that passes"; if it should not block, it is not
+an invariant.


### PR DESCRIPTION
## Summary

- Rewrite the `coaligned-invariant` skill's two L6 references so a rule author can work with the invariant kit from the docs alone.
- `build-kit.md`: every kit function now has a scannable shape (signature line, one parameter per sub-bullet) and documents previously-missing semantics — `scan`'s `skip`/`under`/`read`, the acorn AST + `walk` idiom, `grep`'s per-entry `exclude`/`dedupe` and case rules, the `restatementDrift` and `enumDrift` registry shapes, and `config` co-location.
- `rule-kit.md`: adds the engine facts — `check` may return an array (many findings per subject), the finding-location rules, the `(subject, item, ctx)` signatures, and `ctx` as shared cross-subject state.
- Both references stay within the L6 cap (109/706 and 63/474 against 128 lines / 768 words).

## Test plan

- [x] `bunx coaligned instructions` passes (L6 caps hold)
- [x] `bunx coaligned invariants` passes (skill-governing rules hold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)