### PR TITLE
refactor(ci): simplify workflows and actions, move logic into fit-* CLIs

### DIFF
--- a/.github/actions/audit/action.yml
+++ b/.github/actions/audit/action.yml
@@ -34,15 +34,7 @@ runs:
 
     - name: Install gitleaks
       if: inputs.secret-scanning == 'true'
-      shell: bash
-      run: |
-        GITLEAKS_VERSION="8.24.3"
-        GITLEAKS_SHA256="9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c"
-        curl -sSfL -o gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-        echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
-        tar xzf gitleaks.tar.gz
-        rm gitleaks.tar.gz
-        sudo mv gitleaks /usr/local/bin/
+      uses: ./.github/actions/install-gitleaks
 
     - name: Secret scanning
       if: inputs.secret-scanning == 'true'

--- a/.github/actions/coaligned-check/action.yml
+++ b/.github/actions/coaligned-check/action.yml
@@ -29,31 +29,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Validate inputs
-      shell: bash
-      env:
-        COMMAND: ${{ inputs.command }}
-        FIX: ${{ inputs.fix }}
-      run: |
-        case "$COMMAND" in
-          ""|instructions|jtbd|invariants) ;;
-          *)
-            echo "::error::coaligned-check: unknown command \"$COMMAND\". Expected one of: \"\" (run every check), instructions, jtbd, invariants."
-            exit 2
-            ;;
-        esac
-        case "$FIX" in
-          true|false) ;;
-          *)
-            echo "::error::coaligned-check: fix must be \"true\" or \"false\", got \"$FIX\"."
-            exit 2
-            ;;
-        esac
-        if [ "$FIX" = "true" ] && [ "$COMMAND" != "jtbd" ]; then
-          echo "::error::coaligned-check: fix=true is only supported for command=jtbd."
-          exit 2
-        fi
-
     - name: Run coaligned
       shell: bash
       working-directory: ${{ inputs.working-directory }}
@@ -61,17 +36,9 @@ runs:
         COMMAND: ${{ inputs.command }}
         FIX: ${{ inputs.fix }}
       run: |
-        # coaligned is a pinned gear binary on PATH, installed by bootstrap
-        # as a default tool. No bunx/npx fallback — fail hard if it is missing.
-        if ! command -v coaligned &>/dev/null; then
-          echo "::error::coaligned not found on PATH. Bootstrap with forwardimpact/bootstrap (installs coaligned as a default gear binary) before this step. No bunx/npx fallback." >&2
-          exit 1
-        fi
+        # coaligned is a pinned gear binary on PATH (a default bootstrap tool) —
+        # assumed present. It validates its own command/flag set.
         args=()
-        if [ -n "$COMMAND" ]; then
-          args+=("$COMMAND")
-        fi
-        if [ "$FIX" = "true" ]; then
-          args+=("--fix")
-        fi
+        [ -n "$COMMAND" ] && args+=("$COMMAND")
+        [ "$FIX" = "true" ] && args+=("--fix")
         coaligned "${args[@]}"

--- a/.github/workflows/curate-wiki.yml
+++ b/.github/workflows/curate-wiki.yml
@@ -32,39 +32,11 @@ jobs:
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki
-      - id: audit
-        # `fit-wiki audit` exits non-zero when the wiki is dirty; capture that
-        # so the routing step still runs. The `dirty` flag (not stdout parsing)
-        # gates routing; the JSON rides through a random-delimiter heredoc
-        # because audit findings are untrusted text.
-        run: |
-          set +e
-          out="$(fit-wiki audit --format json)"; code=$?
-          set -e
-          # `fit-wiki audit` returns exactly 1 when the wiki is dirty (findings).
-          # 0 = clean; any other code = the audit itself failed — fail the job
-          # so the break is visible rather than routed as a spurious issue.
-          case "$code" in
-            0) dirty=false ;;
-            1) dirty=true ;;
-            *) echo "::error::fit-wiki audit exited $code (not a findings verdict)"; exit "$code" ;;
-          esac
-          delim="EOF_$(openssl rand -hex 8)"
-          { echo "json<<$delim"; printf '%s\n' "$out"; echo "$delim"; } >> "$GITHUB_OUTPUT"
-          echo "dirty=$dirty" >> "$GITHUB_OUTPUT"
-      - name: Route findings to the technical-writer
-        if: steps.audit.outputs.dirty == 'true'
+      # Audit the shared wiki and, when dirty, route findings to the single
+      # wiki-curation issue (create or comment). The label/search/create-or-
+      # comment logic lives in `fit-wiki curate`, not here.
+      - name: Audit and route findings
         env:
           GH_TOKEN: ${{ github.token }}
-          FINDINGS: ${{ steps.audit.outputs.json }}
-        run: |
-          gh label create wiki-curation --color BFD4F2 \
-            --description "Shared-wiki audit findings from scheduled curation" 2>/dev/null || true
-          title="Wiki curation: shared-state audit findings"
-          body=$'Scheduled `curate-wiki` audit found shared-wiki violations.\n\nOwner: **technical-writer** (service these via the curation shift; the per-PR `wiki` gate no longer reads shared wiki state).\n\n```json\n'"$FINDINGS"$'\n```'
-          num="$(gh issue list --search "$title in:title" --state open --json number --jq '.[0].number')"
-          if [ -n "$num" ]; then
-            gh issue comment "$num" --body "$body"
-          else
-            gh issue create --title "$title" --body "$body" --label wiki-curation
-          fi
+          FIT_GH_REPO: ${{ github.repository }}
+        run: fit-wiki curate

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -23,47 +23,16 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
-      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
-      # truthy value. Lets an operator halt every kata-* workflow from one
-      # place without disabling each one individually. Kept as the first step
-      # so the run fails before any token minting, checkout, or agent work.
-      - name: Kata killswitch
-        shell: bash
-        env:
-          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
-        run: |
-          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off)
-              echo "Kata killswitch not engaged; proceeding." ;;
-            *)
-              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
-              exit 1 ;;
-          esac
-
+      # kata-agent runs the killswitch first and reports run cost last.
       - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
-        id: agent
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          killswitch: ${{ vars.KATA_KILLSWITCH }}
           mode: "facilitate"
           task-text: >-
             Facilitate a one-on-one Kata coaching session with "${{ inputs.agent }}".
           lead-profile: "improvement-coach"
           agent-profiles: "${{ inputs.agent }}"
           task-amend: ${{ inputs.task-amend }}
-
-      # Sum spend across every participant from the trace kata-agent exposes.
-      # Cost logic lives in the `fit-trace` CLI; this step only reads the
-      # path and redirects the markdown summary.
-      - name: Report run cost
-        if: always()
-        shell: bash
-        env:
-          TRACE_FILE: ${{ steps.agent.outputs.trace-file }}
-        run: |
-          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
-            fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No trace file produced — cost not reported."
-          fi

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -83,21 +83,16 @@ jobs:
       github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && (github.event.action == 'opened' || (github.event.action == 'labeled' && (startsWith(github.event.label.name, 'agent:') || endsWith(github.event.label.name, ':approved'))))) || github.event_name == 'issue_comment' || (github.event_name == 'pull_request_target' && ((github.event.action == 'labeled' && (startsWith(github.event.label.name, 'agent:') || endsWith(github.event.label.name, ':approved'))) || (github.event.action == 'closed' && github.event.pull_request.merged == true))) || github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     steps:
-      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
-      # truthy value. Lets an operator halt every kata-* workflow from one
-      # place without disabling each one individually. Kept as the first step
-      # so the run fails before any token minting, checkout, or agent work.
+      # Killswitch first: fail before any token minting or agent work so one
+      # repository variable halts every kata-* workflow at once.
       - name: Kata killswitch
         shell: bash
         env:
           KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
         run: |
           case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off)
-              echo "Kata killswitch not engaged; proceeding." ;;
-            *)
-              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
-              exit 1 ;;
+            ""|0|false|no|off) ;;
+            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH})." >&2; exit 1 ;;
           esac
 
       - name: Generate installation token
@@ -177,17 +172,13 @@ jobs:
           discussion-id: ${{ inputs.discussion_id }}
           resume-context: ${{ inputs.resume_context }}
 
+      # fit-trace cost tolerates a missing trace, so no file guard is needed.
       - name: Report run cost
         if: always()
         shell: bash
         env:
           TRACE_FILE: ${{ steps.assess.outputs.trace-file }}
-        run: |
-          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
-            fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No trace file produced — cost not reported."
-          fi
+        run: fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
 
       # Push agent memory back with a freshly minted token — the token from
       # job start expires after an hour and this run can take up to five.

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -33,21 +33,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 50
     steps:
-      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
-      # truthy value. Lets an operator halt every kata-* workflow from one
-      # place without disabling each one individually. Kept as the first step
-      # so the run fails before any token minting, checkout, or agent work.
+      # Killswitch first: fail before any token minting or agent work so one
+      # repository variable halts every kata-* workflow at once.
       - name: Kata killswitch
         shell: bash
         env:
           KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
         run: |
           case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off)
-              echo "Kata killswitch not engaged; proceeding." ;;
-            *)
-              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
-              exit 1 ;;
+            ""|0|false|no|off) ;;
+            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH})." >&2; exit 1 ;;
           esac
 
       - name: Generate installation token
@@ -165,17 +160,13 @@ jobs:
           supervisor-allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,Skill,TodoWrite"
           task-amend: ${{ steps.amend.outputs.amend }}
 
+      # fit-trace cost tolerates a missing trace, so no file guard is needed.
       - name: Report run cost
         if: always()
         shell: bash
         env:
           TRACE_FILE: ${{ steps.interview.outputs.trace-file }}
-        run: |
-          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
-            fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No trace file produced — cost not reported."
-          fi
+        run: fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
 
       - name: Push wiki changes
         if: always()

--- a/.github/workflows/kata-shift.yml
+++ b/.github/workflows/kata-shift.yml
@@ -36,29 +36,13 @@ jobs:
           - { name: release-engineer }
           - { name: improvement-coach }
     steps:
-      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
-      # truthy value. Lets an operator halt every kata-* workflow from one
-      # place without disabling each one individually. Kept as the first step
-      # so the run fails before any token minting, checkout, or agent work.
-      - name: Kata killswitch
-        shell: bash
-        env:
-          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
-        run: |
-          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off)
-              echo "Kata killswitch not engaged; proceeding." ;;
-            *)
-              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
-              exit 1 ;;
-          esac
-
+      # kata-agent runs the killswitch first and reports run cost last.
       - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
-        id: agent
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          killswitch: ${{ vars.KATA_KILLSWITCH }}
           agent-profile: ${{ matrix.agent.name }}
           case: ${{ matrix.agent.name }}
           max-turns: ${{ matrix.agent.max-turns || '1500' }}
@@ -66,18 +50,3 @@ jobs:
           task-text: >-
             Assess the current state of your domain and act on the highest-priority finding.
           task-amend: ${{ inputs.task-amend }}
-
-      # Sum spend across every participant from the trace kata-agent exposes.
-      # Each matrix cell reports its own cost. Cost logic lives in the
-      # `fit-trace` CLI; this step only reads the path and redirects the summary.
-      - name: Report run cost
-        if: always()
-        shell: bash
-        env:
-          TRACE_FILE: ${{ steps.agent.outputs.trace-file }}
-        run: |
-          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
-            fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No trace file produced — cost not reported."
-          fi

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -22,47 +22,16 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
-      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
-      # truthy value. Lets an operator halt every kata-* workflow from one
-      # place without disabling each one individually. Kept as the first step
-      # so the run fails before any token minting, checkout, or agent work.
-      - name: Kata killswitch
-        shell: bash
-        env:
-          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
-        run: |
-          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off)
-              echo "Kata killswitch not engaged; proceeding." ;;
-            *)
-              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
-              exit 1 ;;
-          esac
-
+      # kata-agent runs the killswitch first and reports run cost last.
       - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
-        id: agent
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          killswitch: ${{ vars.KATA_KILLSWITCH }}
           mode: "discuss"
           task-text: >-
             Facilitate a team Kata storyboard session.
           lead-profile: "improvement-coach"
           agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
           task-amend: ${{ inputs.task-amend }}
-
-      # Sum spend across every participant from the trace kata-agent exposes.
-      # Cost logic lives in the `fit-trace` CLI; this step only reads the
-      # path and redirects the markdown summary.
-      - name: Report run cost
-        if: always()
-        shell: bash
-        env:
-          TRACE_FILE: ${{ steps.agent.outputs.trace-file }}
-        run: |
-          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
-            fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No trace file produced — cost not reported."
-          fi

--- a/.github/workflows/website-coaligned.yaml
+++ b/.github/workflows/website-coaligned.yaml
@@ -7,56 +7,15 @@ on:
       - "websites/coaligned/**"
       - "libraries/libdoc/**"
       - ".github/workflows/website-coaligned.yaml"
+      - ".github/workflows/website.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: "website-coaligned"
-  cancel-in-progress: false
-
 jobs:
   publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - uses: forwardimpact/bootstrap@2bebda7abaffe16b79a6a5c4e3e82eddc1f7c7d1 # v1.0.7
-        with:
-          clis: fit-doc
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-
-      - uses: ./.github/actions/audit
-
-      - name: Build website
-        run: fit-doc build --src=websites/coaligned --out=dist
-
-      - name: Copy CNAME file
-        run: cp websites/coaligned/CNAME dist/
-
-      - name: Upload site artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: coaligned-pages
-          path: dist
-
-      - name: Generate installation token
-        id: ci-app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.KATA_APP_ID }}
-          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-          repositories: coaligned-pages
-
-      - name: Trigger deployment
-        env:
-          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-        run: |
-          gh api repos/forwardimpact/coaligned-pages/dispatches \
-            -f event_type=deploy \
-            -f "client_payload[run_id]=${{ github.run_id }}"
+    uses: ./.github/workflows/website.yml
+    with:
+      site: coaligned
+    secrets: inherit

--- a/.github/workflows/website-fit.yaml
+++ b/.github/workflows/website-fit.yaml
@@ -8,63 +8,16 @@ on:
       - "design/fit/**"
       - "libraries/libdoc/**"
       - ".github/workflows/website-fit.yaml"
+      - ".github/workflows/website.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: "website-fit"
-  cancel-in-progress: false
-
 jobs:
   publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - uses: forwardimpact/bootstrap@2bebda7abaffe16b79a6a5c4e3e82eddc1f7c7d1 # v1.0.7
-        with:
-          clis: fit-doc
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-
-      - uses: ./.github/actions/audit
-
-      - name: Build website
-        run: fit-doc build --src=websites/fit --out=dist
-
-      - name: Copy schema files
-        run: |
-          mkdir -p dist/schema/json
-          cp products/map/schema/json/*.json dist/schema/json/
-          mkdir -p dist/schema/rdf
-          cp products/map/schema/rdf/*.ttl dist/schema/rdf/
-
-      - name: Copy CNAME file
-        run: cp websites/fit/CNAME dist/
-
-      - name: Upload site artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: fit-pages
-          path: dist
-
-      - name: Generate installation token
-        id: ci-app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.KATA_APP_ID }}
-          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-          repositories: fit-pages
-
-      - name: Trigger deployment
-        env:
-          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-        run: |
-          gh api repos/forwardimpact/fit-pages/dispatches \
-            -f event_type=deploy \
-            -f "client_payload[run_id]=${{ github.run_id }}"
+    uses: ./.github/workflows/website.yml
+    with:
+      site: fit
+      copy-schema: true
+    secrets: inherit

--- a/.github/workflows/website-kata.yaml
+++ b/.github/workflows/website-kata.yaml
@@ -8,56 +8,15 @@ on:
       - "design/kata/**"
       - "libraries/libdoc/**"
       - ".github/workflows/website-kata.yaml"
+      - ".github/workflows/website.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: "website-kata"
-  cancel-in-progress: false
-
 jobs:
   publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - uses: forwardimpact/bootstrap@2bebda7abaffe16b79a6a5c4e3e82eddc1f7c7d1 # v1.0.7
-        with:
-          clis: fit-doc
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-
-      - uses: ./.github/actions/audit
-
-      - name: Build website
-        run: fit-doc build --src=websites/kata --out=dist
-
-      - name: Copy CNAME file
-        run: cp websites/kata/CNAME dist/
-
-      - name: Upload site artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: kata-pages
-          path: dist
-
-      - name: Generate installation token
-        id: ci-app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.KATA_APP_ID }}
-          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-          repositories: kata-pages
-
-      - name: Trigger deployment
-        env:
-          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-        run: |
-          gh api repos/forwardimpact/kata-pages/dispatches \
-            -f event_type=deploy \
-            -f "client_payload[run_id]=${{ github.run_id }}"
+    uses: ./.github/workflows/website.yml
+    with:
+      site: kata
+    secrets: inherit

--- a/.github/workflows/website-monorepo.yaml
+++ b/.github/workflows/website-monorepo.yaml
@@ -7,56 +7,15 @@ on:
       - "websites/monorepo/**"
       - "libraries/libdoc/**"
       - ".github/workflows/website-monorepo.yaml"
+      - ".github/workflows/website.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: "website-monorepo"
-  cancel-in-progress: false
-
 jobs:
   publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - uses: forwardimpact/bootstrap@2bebda7abaffe16b79a6a5c4e3e82eddc1f7c7d1 # v1.0.7
-        with:
-          clis: fit-doc
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-
-      - uses: ./.github/actions/audit
-
-      - name: Build website
-        run: fit-doc build --src=websites/monorepo --out=dist
-
-      - name: Copy CNAME file
-        run: cp websites/monorepo/CNAME dist/
-
-      - name: Upload site artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: monorepo-pages
-          path: dist
-
-      - name: Generate installation token
-        id: ci-app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.KATA_APP_ID }}
-          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-          repositories: monorepo-pages
-
-      - name: Trigger deployment
-        env:
-          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-        run: |
-          gh api repos/forwardimpact/monorepo-pages/dispatches \
-            -f event_type=deploy \
-            -f "client_payload[run_id]=${{ github.run_id }}"
+    uses: ./.github/workflows/website.yml
+    with:
+      site: monorepo
+    secrets: inherit

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,76 @@
+name: "Website"
+
+# One reusable publisher for every docs site. A caller workflow declares its
+# own `on: push paths` trigger and calls this with `site:` (and `copy-schema:`
+# for fit). Everything else — build src, artifact name, CNAME path, deploy
+# dispatch repo, concurrency group — derives from `site`.
+on:
+  workflow_call:
+    inputs:
+      site:
+        description: "Site directory under websites/ (fit, monorepo, kata, coaligned)"
+        required: true
+        type: string
+      copy-schema:
+        description: "Copy products/map/schema into dist/schema (fit only)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "website-${{ inputs.site }}"
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: forwardimpact/bootstrap@2bebda7abaffe16b79a6a5c4e3e82eddc1f7c7d1 # v1.0.7
+        with:
+          clis: fit-doc
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - uses: ./.github/actions/audit
+
+      - name: Build website
+        run: fit-doc build --src=websites/${{ inputs.site }} --out=dist
+
+      - name: Copy schema files
+        if: inputs.copy-schema
+        run: |
+          mkdir -p dist/schema/json dist/schema/rdf
+          cp products/map/schema/json/*.json dist/schema/json/
+          cp products/map/schema/rdf/*.ttl dist/schema/rdf/
+
+      - name: Copy CNAME file
+        run: cp websites/${{ inputs.site }}/CNAME dist/
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ inputs.site }}-pages
+          path: dist
+
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+          repositories: ${{ inputs.site }}-pages
+
+      - name: Trigger deployment
+        env:
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+        run: |
+          gh api repos/forwardimpact/${{ inputs.site }}-pages/dispatches \
+            -f event_type=deploy \
+            -f "client_payload[run_id]=${{ github.run_id }}"

--- a/libraries/libharness/actions/benchmark/action.yml
+++ b/libraries/libharness/actions/benchmark/action.yml
@@ -157,16 +157,8 @@ runs:
         SHARD_TOTAL: ${{ inputs.shard-total }}
         TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
       run: |
-        # fit-benchmark must be on PATH as a pinned gear binary, installed by
-        # forwardimpact/bootstrap with `clis: fit-benchmark`. No bunx/npx
-        # fallback — a missing binary fails hard rather than silently resolving
-        # a different (registry) build.
-        if ! command -v fit-benchmark &>/dev/null; then
-          echo "::error::fit-benchmark not found on PATH. Install it as a gear binary via forwardimpact/bootstrap with 'clis: fit-benchmark' before this step. No bunx/npx fallback." >&2
-          exit 1
-        fi
-        BENCH_CMD="fit-benchmark"
-
+        # fit-benchmark is a pinned gear binary on PATH, installed by
+        # forwardimpact/bootstrap (clis: fit-benchmark) — assumed present.
         args=()
         args+=("--family=$FAMILY")
         args+=("--output=$OUTPUT_DIR")
@@ -199,7 +191,7 @@ runs:
           args+=("--judge-profile=$JUDGE_PROFILE")
         fi
 
-        timeout "${TIMEOUT_MINUTES}m" $BENCH_CMD run "${args[@]}"
+        timeout "${TIMEOUT_MINUTES}m" fit-benchmark run "${args[@]}"
 
     - name: Report (run)
       if: always() && inputs.mode == 'run' && inputs.summary == 'true'
@@ -209,21 +201,13 @@ runs:
         K_VALUES: ${{ inputs.k }}
         FORMAT: ${{ inputs.format }}
       run: |
-        # fit-benchmark must be on PATH as a pinned gear binary (fit-bootstrap
-        # clis: fit-benchmark). No bunx/npx fallback — fail hard if missing.
-        if ! command -v fit-benchmark &>/dev/null; then
-          echo "::error::fit-benchmark not found on PATH. Install it as a gear binary via forwardimpact/bootstrap with 'clis: fit-benchmark' before this step. No bunx/npx fallback." >&2
-          exit 1
-        fi
-        BENCH_CMD="fit-benchmark"
-
         RESULTS="$OUTPUT_DIR/results.jsonl"
         if [ ! -s "$RESULTS" ]; then
           echo "::warning::results.jsonl missing or empty — skipping summary"
           exit 0
         fi
 
-        $BENCH_CMD report \
+        fit-benchmark report \
           --input="$OUTPUT_DIR" \
           --k="$K_VALUES" \
           --format="$FORMAT" >> "$GITHUB_STEP_SUMMARY"
@@ -253,18 +237,10 @@ runs:
         FORMAT: ${{ inputs.format }}
         SUMMARY: ${{ inputs.summary }}
       run: |
-        # fit-benchmark must be on PATH as a pinned gear binary (fit-bootstrap
-        # clis: fit-benchmark). No bunx/npx fallback — fail hard if missing.
-        if ! command -v fit-benchmark &>/dev/null; then
-          echo "::error::fit-benchmark not found on PATH. Install it as a gear binary via forwardimpact/bootstrap with 'clis: fit-benchmark' before this step. No bunx/npx fallback." >&2
-          exit 1
-        fi
-        BENCH_CMD="fit-benchmark"
-
         # report --input discovers every results.jsonl under the directory
         # recursively and unions them — one combined pass@k over all shards.
         if [ "$SUMMARY" = "true" ]; then
-          $BENCH_CMD report \
+          fit-benchmark report \
             --input="$MERGE_INPUT" \
             --k="$K_VALUES" \
             --format="$FORMAT" >> "$GITHUB_STEP_SUMMARY"

--- a/libraries/libharness/actions/harness/action.yml
+++ b/libraries/libharness/actions/harness/action.yml
@@ -83,10 +83,6 @@ inputs:
     description: Case identifier embedded in trace artifact filenames (use the matrix case id for matrix runs; defaults to "default")
     required: false
     default: "default"
-  artifact-suffix:
-    description: (Deprecated — pass `case` instead) Legacy alias for `case`; honored with a warning when set
-    required: false
-    default: ""
 
 outputs:
   trace-dir:
@@ -106,7 +102,7 @@ outputs:
       summary) should read this path directly.
     value: ${{ steps.setup.outputs.trace-file }}
   case:
-    description: Effective case identifier (after resolving `case` / legacy `artifact-suffix`).
+    description: Effective case identifier (the `case` input, or "default").
     value: ${{ steps.setup.outputs.case }}
 
 runs:
@@ -117,27 +113,18 @@ runs:
       id: setup
       shell: bash
       env:
-        CASE_INPUT: ${{ inputs.case }}
-        SUFFIX_INPUT: ${{ inputs.artifact-suffix }}
+        CASE: ${{ inputs.case }}
       run: |
         TRACE_DIR=$(mktemp -d)
-        echo "trace-dir=$TRACE_DIR" >> "$GITHUB_OUTPUT"
-        # Resolve effective case. Explicit `case` (non-default) wins; legacy
-        # `artifact-suffix` is honored with a deprecation warning; otherwise
-        # fall through to "default".
-        if [ -n "$CASE_INPUT" ] && [ "$CASE_INPUT" != "default" ]; then
-          EFFECTIVE_CASE="$CASE_INPUT"
-        elif [ -n "$SUFFIX_INPUT" ]; then
-          echo "::warning::artifact-suffix is deprecated; pass case=<id> instead"
-          EFFECTIVE_CASE="$SUFFIX_INPUT"
-        else
-          EFFECTIVE_CASE="default"
-        fi
-        echo "case=$EFFECTIVE_CASE" >> "$GITHUB_OUTPUT"
-        # Publish the raw trace file path so downstream steps can read it
-        # without globbing /tmp. Kept in sync with the --output path passed
-        # to the CLI in the "Run fit-harness" step below.
-        echo "trace-file=$TRACE_DIR/trace--$EFFECTIVE_CASE.raw.ndjson" >> "$GITHUB_OUTPUT"
+        CASE="${CASE:-default}"
+        # Publish the trace dir, effective case, and raw trace file path so
+        # downstream steps read them without globbing /tmp. The trace-file path
+        # is kept in sync with the --output passed in "Run fit-harness".
+        {
+          echo "trace-dir=$TRACE_DIR"
+          echo "case=$CASE"
+          echo "trace-file=$TRACE_DIR/trace--$CASE.raw.ndjson"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Run fit-harness
       shell: bash
@@ -173,130 +160,71 @@ runs:
         TRACE_CASE: ${{ steps.setup.outputs.case }}
         TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
       run: |
-        # fit-harness must already be on PATH as a pinned gear binary, installed
-        # by forwardimpact/bootstrap with `clis: fit-harness fit-trace`.
-        # There is no bunx/npx fallback: the binary distribution is the only
-        # supported path, so a missing binary fails hard rather than silently
-        # resolving a different (registry) build.
-        if ! command -v fit-harness &>/dev/null; then
-          echo "::error::fit-harness not found on PATH. Install it as a gear binary via forwardimpact/bootstrap with 'clis: fit-harness fit-trace' before this step. No bunx/npx fallback." >&2
-          exit 1
-        fi
-        HARNESS_CMD="fit-harness"
-
-        args=()
-
-        # Resolve task source — exactly one of task-file, task-text, task-event
-        # is required. task-event hands the runner's native event JSON to the
-        # CLI; libharness composes the task from the (event_name, action) template
-        # and lifts payload.inputs.prompt into the amendment.
-        task_sources=0
-        [ -n "$TASK_FILE" ] && task_sources=$((task_sources + 1))
-        [ -n "$TASK_TEXT" ] && task_sources=$((task_sources + 1))
-        [ -n "$TASK_EVENT" ] && task_sources=$((task_sources + 1))
-
-        if [ "$task_sources" -eq 0 ]; then
-          echo "::error::One of task-file, task-text, task-event is required"
-          exit 1
-        elif [ "$task_sources" -gt 1 ]; then
-          echo "::error::task-file, task-text, task-event are mutually exclusive"
-          exit 1
-        fi
-
-        if [ -n "$TASK_FILE" ]; then
-          args+=("--task-file=$TASK_FILE")
-        elif [ -n "$TASK_TEXT" ]; then
-          args+=("--task-text=$TASK_TEXT")
-        else
-          args+=("--task-event=$TASK_EVENT")
-        fi
-
-        if [ -n "$TASK_AMEND" ]; then
-          args+=("--task-amend=$TASK_AMEND")
-        fi
-
-        if [ -n "$MCP_SERVER" ]; then
-          args+=("--mcp-server=$MCP_SERVER")
-        fi
-
+        # fit-harness + fit-trace are pinned gear binaries on PATH, installed by
+        # forwardimpact/bootstrap (clis: fit-harness fit-trace) — assumed present.
+        #
+        # Flags accepted by every mode. Empty values are forwarded verbatim: the
+        # CLI treats an empty flag as unset and falls back to its own default, so
+        # no per-flag `if [ -n ]` guards are needed. The CLI also enforces
+        # task-source mutual exclusivity (exactly one of file/text/event), so the
+        # workflow just forwards all three and lets it select.
+        base=(
+          "--task-file=$TASK_FILE"
+          "--task-text=$TASK_TEXT"
+          "--task-event=$TASK_EVENT"
+          "--task-amend=$TASK_AMEND"
+          "--agent-model=$AGENT_MODEL"
+          "--max-turns=$MAX_TURNS"
+        )
         if [ "$TRACE_ENABLED" = "true" ] && [ -n "$TRACE_DIR" ]; then
-          args+=("--output=$TRACE_DIR/trace--${TRACE_CASE}.raw.ndjson")
+          base+=("--output=$TRACE_DIR/trace--${TRACE_CASE}.raw.ndjson")
         fi
 
-        # Mode-invariant flags. --max-turns is always forwarded; the CLI
-        # treats "0" as unlimited, while omitting the flag silently falls
-        # back to the SDK's ~50-turn cap.
-        args+=("--max-turns=$MAX_TURNS")
-        # Model flags are omitted when empty so the CLI defaults
-        # (@forwardimpact/libutil/models) stay the single source of truth.
-        if [ -n "$AGENT_MODEL" ]; then
-          args+=("--agent-model=$AGENT_MODEL")
-        fi
-
-        if [ "$MODE" = "supervise" ]; then
-          if [ -n "$LEAD_MODEL" ]; then
-            args+=("--lead-model=$LEAD_MODEL")
-          fi
-          if [ -n "$LEAD_PROFILE" ]; then
-            args+=("--lead-profile=$LEAD_PROFILE")
-          fi
-          if [ -n "$SUPERVISOR_TOOLS" ]; then
-            args+=("--supervisor-allowed-tools=$SUPERVISOR_TOOLS")
-          fi
-          if [ -n "$AGENT_PROFILE" ]; then
-            args+=("--agent-profile=$AGENT_PROFILE")
-          fi
-
-          # Composite action steps can't use the GitHub `timeout-minutes`
-          # field, so enforce the cap with the shell `timeout` command.
-          timeout "${TIMEOUT_MINUTES}m" $HARNESS_CMD supervise \
-            --supervisor-cwd="$SUPERVISOR_CWD" \
-            --agent-cwd="$AGENT_CWD" \
-            --allowed-tools="$TOOLS" \
-            "${args[@]}"
-        elif [ "$MODE" = "facilitate" ]; then
-          if [ -n "$LEAD_MODEL" ]; then
-            args+=("--lead-model=$LEAD_MODEL")
-          fi
-          if [ -n "$LEAD_PROFILE" ]; then
-            args+=("--lead-profile=$LEAD_PROFILE")
-          fi
-
-          timeout "${TIMEOUT_MINUTES}m" $HARNESS_CMD facilitate \
-            --facilitator-cwd="." \
-            --agent-profiles="$AGENT_PROFILES" \
-            --agent-cwd="$AGENT_CWD" \
-            "${args[@]}"
-        elif [ "$MODE" = "discuss" ]; then
-          if [ -n "$LEAD_MODEL" ]; then
-            args+=("--lead-model=$LEAD_MODEL")
-          fi
-          if [ -n "$LEAD_PROFILE" ]; then
-            args+=("--lead-profile=$LEAD_PROFILE")
-          fi
-          if [ -n "$AGENT_PROFILES" ]; then
-            args+=("--agent-profiles=$AGENT_PROFILES")
-          fi
-          if [ -n "$DISCUSSION_ID" ]; then
-            args+=("--discussion-id=$DISCUSSION_ID")
-          fi
-          if [ -n "$RESUME_CONTEXT" ]; then
-            args+=("--resume-context=$RESUME_CONTEXT")
-          fi
-
-          timeout "${TIMEOUT_MINUTES}m" $HARNESS_CMD discuss \
-            --agent-cwd="$AGENT_CWD" \
-            "${args[@]}"
-        else
-          if [ -n "$AGENT_PROFILE" ]; then
-            args+=("--agent-profile=$AGENT_PROFILE")
-          fi
-
-          timeout "${TIMEOUT_MINUTES}m" $HARNESS_CMD run \
-            --cwd="$CWD" \
-            --allowed-tools="$TOOLS" \
-            "${args[@]}"
-        fi
+        # Composite action steps can't use the GitHub `timeout-minutes` field, so
+        # enforce the cap with the shell `timeout` command. One branch per mode —
+        # each subcommand declares its own flag set, so the flags are scoped to
+        # the mode that accepts them.
+        case "$MODE" in
+          supervise)
+            timeout "${TIMEOUT_MINUTES}m" fit-harness supervise \
+              --supervisor-cwd="$SUPERVISOR_CWD" \
+              --agent-cwd="$AGENT_CWD" \
+              --allowed-tools="$TOOLS" \
+              --supervisor-allowed-tools="$SUPERVISOR_TOOLS" \
+              --lead-profile="$LEAD_PROFILE" \
+              --lead-model="$LEAD_MODEL" \
+              --agent-profile="$AGENT_PROFILE" \
+              --mcp-server="$MCP_SERVER" \
+              "${base[@]}"
+            ;;
+          facilitate)
+            timeout "${TIMEOUT_MINUTES}m" fit-harness facilitate \
+              --facilitator-cwd="." \
+              --agent-profiles="$AGENT_PROFILES" \
+              --agent-cwd="$AGENT_CWD" \
+              --lead-profile="$LEAD_PROFILE" \
+              --lead-model="$LEAD_MODEL" \
+              "${base[@]}"
+            ;;
+          discuss)
+            timeout "${TIMEOUT_MINUTES}m" fit-harness discuss \
+              --agent-cwd="$AGENT_CWD" \
+              --agent-profiles="$AGENT_PROFILES" \
+              --lead-profile="$LEAD_PROFILE" \
+              --lead-model="$LEAD_MODEL" \
+              --discussion-id="$DISCUSSION_ID" \
+              --resume-context="$RESUME_CONTEXT" \
+              "${base[@]}"
+            ;;
+          *)
+            timeout "${TIMEOUT_MINUTES}m" fit-harness run \
+              --cwd="$CWD" \
+              --allowed-tools="$TOOLS" \
+              --agent-profile="$AGENT_PROFILE" \
+              --mcp-server="$MCP_SERVER" \
+              "${base[@]}"
+            ;;
+        esac
 
     - name: Split trace
       if: always() && inputs.trace == 'true' && steps.setup.outputs.trace-dir != ''
@@ -306,23 +234,11 @@ runs:
         MODE: ${{ inputs.mode }}
         TRACE_CASE: ${{ steps.setup.outputs.case }}
       run: |
-        # fit-trace is a pinned gear binary on PATH (fit-bootstrap clis:
-        # fit-trace). No bunx/npx fallback — fail hard if it is missing.
-        if ! command -v fit-trace &>/dev/null; then
-          echo "::error::fit-trace not found on PATH. Install it as a gear binary via forwardimpact/bootstrap with 'clis: fit-trace' before this step. No bunx/npx fallback." >&2
-          exit 1
-        fi
-        TRACE_CMD="fit-trace"
-        # `fit-trace split` only accepts run|supervise|facilitate today, but
-        # the splitter itself is mode-agnostic (it buckets by envelope
-        # `source`). Discuss runs have the same lead + N-participants shape
-        # as facilitate, so map them onto `facilitate` for the splitter.
-        SPLIT_MODE="$MODE"
-        if [ "$SPLIT_MODE" = "discuss" ]; then
-          SPLIT_MODE="facilitate"
-        fi
-        $TRACE_CMD split "$TRACE_DIR/trace--${TRACE_CASE}.raw.ndjson" \
-          --mode="$SPLIT_MODE" \
+        # fit-trace accepts `discuss` directly (it buckets by envelope source,
+        # mapping discuss onto the facilitate shape internally), so the mode is
+        # forwarded as-is.
+        fit-trace split "$TRACE_DIR/trace--${TRACE_CASE}.raw.ndjson" \
+          --mode="$MODE" \
           --case="$TRACE_CASE" \
           --output-dir="$TRACE_DIR"
 

--- a/libraries/libharness/bin/fit-trace.js
+++ b/libraries/libharness/bin/fit-trace.js
@@ -350,7 +350,7 @@ const definition = {
       options: {
         mode: {
           type: "string",
-          description: "Execution mode: run, supervise, or facilitate",
+          description: "Execution mode: run, supervise, facilitate, or discuss",
         },
         case: {
           type: "string",

--- a/libraries/libharness/src/commands/discuss.js
+++ b/libraries/libharness/src/commands/discuss.js
@@ -29,9 +29,11 @@ export function parseDiscussOptions(values, runtime) {
   );
 
   const profilesRaw = values["agent-profiles"];
-  const agentCwd = resolve(values["agent-cwd"] ?? ".");
+  // `||` (not `??`) so an empty-string flag from a CI forwarder falls back to
+  // the default rather than overriding it with "".
+  const agentCwd = resolve(values["agent-cwd"] || ".");
 
-  const maxTurnsRaw = values["max-turns"] ?? "40";
+  const maxTurnsRaw = values["max-turns"] || "40";
   const maxTurns = maxTurnsRaw === "0" ? 0 : parseInt(maxTurnsRaw, 10);
 
   const agentConfigs = parseAgentProfiles(profilesRaw, agentCwd, maxTurns);
@@ -46,21 +48,21 @@ export function parseDiscussOptions(values, runtime) {
     }
   }
 
-  const maxLeadTurnsRaw = values["max-lead-turns"] ?? "200";
+  const maxLeadTurnsRaw = values["max-lead-turns"] || "200";
   const maxLeadTurns = parseInt(maxLeadTurnsRaw, 10);
 
   return {
     taskContent,
     taskAmend,
     agentConfigs,
-    leadProfile: values["lead-profile"] ?? undefined,
+    leadProfile: values["lead-profile"] || undefined,
     leadModel: values["lead-model"] || LEAD_MODEL,
     agentModel: values["agent-model"] || AGENT_MODEL,
     maxTurns,
     maxLeadTurns,
     outputPath: values.output,
     workTracker: resolveWorkTracker(values, runtime?.proc?.env),
-    discussionId: values["discussion-id"] ?? null,
+    discussionId: values["discussion-id"] || null,
     resumeContext,
     callbackUrl: runtime.proc.env.CALLBACK_URL ?? null,
     inboxUrl: runtime.proc.env.INBOX_URL ?? null,

--- a/libraries/libharness/src/commands/facilitate.js
+++ b/libraries/libharness/src/commands/facilitate.js
@@ -36,9 +36,11 @@ export function parseFacilitateOptions(values, runtime) {
 
   const profilesRaw = values["agent-profiles"];
   if (!profilesRaw) throw new Error("--agent-profiles is required");
-  const agentCwd = resolve(values["agent-cwd"] ?? ".");
+  // `||` (not `??`) so an empty-string flag from a CI forwarder falls back to
+  // the default rather than overriding it with "".
+  const agentCwd = resolve(values["agent-cwd"] || ".");
 
-  const maxTurnsRaw = values["max-turns"] ?? "20";
+  const maxTurnsRaw = values["max-turns"] || "20";
   const maxTurns = maxTurnsRaw === "0" ? 0 : parseInt(maxTurnsRaw, 10);
 
   // Thread --max-turns into each participant: without this, every facilitated
@@ -51,12 +53,12 @@ export function parseFacilitateOptions(values, runtime) {
     taskContent,
     taskAmend,
     agentConfigs,
-    facilitatorCwd: resolve(values["facilitator-cwd"] ?? "."),
+    facilitatorCwd: resolve(values["facilitator-cwd"] || "."),
     agentModel: values["agent-model"] || AGENT_MODEL,
     facilitatorModel: values["lead-model"] || LEAD_MODEL,
     maxTurns,
     outputPath: values.output,
-    facilitatorProfile: values["lead-profile"] ?? undefined,
+    facilitatorProfile: values["lead-profile"] || undefined,
     workTracker: resolveWorkTracker(values, runtime?.proc?.env),
   };
 }

--- a/libraries/libharness/src/commands/run.js
+++ b/libraries/libharness/src/commands/run.js
@@ -22,22 +22,24 @@ export function parseRunOptions(values, runtime) {
     values,
     runtime,
   );
-  const maxTurnsRaw = values["max-turns"] ?? "50";
+  // `||` (not `??`) so an empty-string flag from a CI forwarder falls back to
+  // the default, rather than overriding it with "".
+  const maxTurnsRaw = values["max-turns"] || "50";
 
   return {
     taskContent,
     taskAmend,
-    cwd: resolve(values.cwd ?? "."),
+    cwd: resolve(values.cwd || "."),
     agentModel: values["agent-model"] || AGENT_MODEL,
     maxTurns: maxTurnsRaw === "0" ? 0 : parseInt(maxTurnsRaw, 10),
     outputPath: values.output,
-    agentProfile: values["agent-profile"] ?? undefined,
+    agentProfile: values["agent-profile"] || undefined,
     workTracker: resolveWorkTracker(values, runtime?.proc?.env),
     allowedTools: (
-      values["allowed-tools"] ??
+      values["allowed-tools"] ||
       "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"
     ).split(","),
-    mcpServer: values["mcp-server"] ?? undefined,
+    mcpServer: values["mcp-server"] || undefined,
   };
 }
 

--- a/libraries/libharness/src/commands/supervise.js
+++ b/libraries/libharness/src/commands/supervise.js
@@ -21,35 +21,37 @@ export async function parseSuperviseOptions(values, runtime) {
   );
   const supervisorAllowedToolsRaw = values["supervisor-allowed-tools"];
 
+  // `||` (not `??`) throughout so an empty-string flag from a CI forwarder
+  // falls back to the default rather than overriding it with "".
   const tmpRoot = runtime.proc.env.TMPDIR ?? "/tmp";
   const agentCwd = resolve(
-    values["agent-cwd"] ??
+    values["agent-cwd"] ||
       (await runtime.fs.mkdtemp(join(tmpRoot, "fit-harness-agent-"))),
   );
 
   return {
     taskContent,
     taskAmend,
-    supervisorCwd: resolve(values["supervisor-cwd"] ?? "."),
+    supervisorCwd: resolve(values["supervisor-cwd"] || "."),
     agentCwd,
     agentModel: values["agent-model"] || AGENT_MODEL,
     supervisorModel: values["lead-model"] || LEAD_MODEL,
     maxTurns: (() => {
-      const raw = values["max-turns"] ?? "200";
+      const raw = values["max-turns"] || "200";
       return raw === "0" ? 0 : parseInt(raw, 10);
     })(),
     outputPath: values.output,
-    supervisorProfile: values["lead-profile"] ?? undefined,
-    agentProfile: values["agent-profile"] ?? undefined,
+    supervisorProfile: values["lead-profile"] || undefined,
+    agentProfile: values["agent-profile"] || undefined,
     workTracker: resolveWorkTracker(values, runtime?.proc?.env),
     allowedTools: (
-      values["allowed-tools"] ??
+      values["allowed-tools"] ||
       "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"
     ).split(","),
     supervisorAllowedTools: supervisorAllowedToolsRaw
       ? supervisorAllowedToolsRaw.split(",")
       : undefined,
-    mcpServer: values["mcp-server"] ?? undefined,
+    mcpServer: values["mcp-server"] || undefined,
   };
 }
 

--- a/libraries/libharness/src/commands/trace.js
+++ b/libraries/libharness/src/commands/trace.js
@@ -367,9 +367,12 @@ export async function runStatsCommand(ctx) {
  */
 export async function runCostCommand(ctx) {
   const { runtime } = ctx.deps;
-  const cost = computeTraceCost(
-    runtime.fsSync.readFileSync(ctx.args.file, "utf8"),
-  );
+  // Tolerate a missing/empty trace: a CI step reports cost under `always()`,
+  // so the trace may not exist (the run failed before producing one). Print
+  // nothing and exit 0 rather than throwing — the caller needs no `if [ -f ]`.
+  const file = ctx.args.file;
+  if (!file || !runtime.fsSync.existsSync(file)) return { ok: true };
+  const cost = computeTraceCost(runtime.fsSync.readFileSync(file, "utf8"));
   if (ctx.options.markdown) {
     runtime.proc.stdout.write(renderCostMarkdown(cost));
   } else {
@@ -512,9 +515,12 @@ export async function runSplitCommand(ctx) {
   const file = ctx.args.file;
   if (!file) return { ok: false, code: 1, error: "split: missing input file" };
 
+  // `discuss` has the same lead + N-participants shape as `facilitate`, and the
+  // splitter buckets purely by envelope `source` (mode-independent), so it is
+  // accepted alongside the structural modes — the CLI owns this, not callers.
   const mode = ctx.options.mode;
   if (!mode) return { ok: false, code: 1, error: "split: --mode is required" };
-  if (!["run", "supervise", "facilitate"].includes(mode)) {
+  if (!["run", "supervise", "facilitate", "discuss"].includes(mode)) {
     return { ok: false, code: 1, error: `split: invalid --mode "${mode}"` };
   }
 

--- a/libraries/libharness/test/trace-cost.test.js
+++ b/libraries/libharness/test/trace-cost.test.js
@@ -50,4 +50,27 @@ describe("fit-trace cost", () => {
     assert.match(out, /\| supervisor \| 0\.0500 \|/);
     assert.match(out, /\| agent \| 0\.0200 \|/);
   });
+
+  test("a missing trace file exits ok and prints nothing", async () => {
+    // A CI cost step runs under always(); the trace may not exist when the
+    // run failed before producing one. The handler must not throw.
+    const fsSync = createMockFs({});
+    let out = "";
+    const result = await runCostCommand({
+      options: { markdown: true },
+      args: { file: "/traces/absent.ndjson" },
+      deps: {
+        runtime: { fsSync, proc: { stdout: { write: (s) => (out += s) } } },
+      },
+    });
+    assert.deepStrictEqual(result, { ok: true });
+    assert.strictEqual(out, "");
+  });
+
+  test("an empty trace file reports zero cost", async () => {
+    const out = await cost({}, []);
+    const parsed = JSON.parse(out);
+    assert.strictEqual(parsed.totalCostUsd, 0);
+    assert.deepStrictEqual(parsed.bySource, {});
+  });
 });

--- a/libraries/libharness/test/trace-split.test.js
+++ b/libraries/libharness/test/trace-split.test.js
@@ -368,6 +368,32 @@ describe("fit-trace split", () => {
     });
   });
 
+  describe("discuss mode", () => {
+    test("is accepted and buckets by source like facilitate", () => {
+      const event = {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "hi" }] },
+      };
+      const { fs, dir, file } = setupTrace([
+        { source: "facilitator", seq: 0, event },
+        { source: "staff-engineer", seq: 1, event },
+      ]);
+
+      const result = split({ mode: "discuss", case: "demo" }, [file], fs);
+      assert.notStrictEqual(result?.ok, false);
+      assert.ok(
+        fs.existsSync(
+          path.join(dir, "trace--demo--facilitator.facilitator.ndjson"),
+        ),
+      );
+      assert.ok(
+        fs.existsSync(
+          path.join(dir, "trace--demo--staff-engineer.agent.ndjson"),
+        ),
+      );
+    });
+  });
+
   describe("invalid mode", () => {
     test("rejects unknown --mode values", async () => {
       const { fs, file } = setupTrace([

--- a/libraries/libwiki/actions/wiki/action.yml
+++ b/libraries/libwiki/actions/wiki/action.yml
@@ -65,13 +65,6 @@ runs:
         if [ -d "$WIKI_PATH/.git" ]; then
           git -C "$WIKI_PATH" config --unset-all 'http.https://github.com/.extraheader' 2>/dev/null || true
         fi
-        # fit-wiki must already be on PATH as a pinned gear binary, installed by
-        # forwardimpact/bootstrap with `clis: fit-wiki`. There is no
-        # bunx/npx fallback: the binary distribution is the only supported path,
-        # so a missing binary fails hard rather than silently resolving a
-        # different (registry) build.
-        if ! command -v fit-wiki &>/dev/null; then
-          echo "::error::fit-wiki not found on PATH. Install it as a gear binary via forwardimpact/bootstrap with 'clis: fit-wiki' before this step. No bunx/npx fallback." >&2
-          exit 1
-        fi
+        # fit-wiki is a pinned gear binary on PATH, installed by
+        # forwardimpact/bootstrap (clis: fit-wiki) — assumed present.
         fit-wiki $COMMAND

--- a/libraries/libwiki/src/cli-definition.js
+++ b/libraries/libwiki/src/cli-definition.js
@@ -9,6 +9,7 @@ import { runClaimCommand, runReleaseCommand } from "./commands/claim.js";
 import { runInboxCommand } from "./commands/inbox.js";
 import { runRotateCommand } from "./commands/rotate.js";
 import { runAuditCommand } from "./commands/audit.js";
+import { runCurateCommand } from "./commands/curate.js";
 import { runFixCommand } from "./commands/fix.js";
 import { runLedgerCommand } from "./commands/ledger.js";
 
@@ -175,6 +176,25 @@ export function createDefinition() {
         },
       },
       {
+        name: "curate",
+        description:
+          "Audit the shared wiki and route any findings to the single wiki-curation issue (create or comment), addressed to the technical-writer",
+        handler: runCurateCommand,
+        options: {
+          ...wikiRootOpt,
+          ...todayOpt,
+          repo: {
+            type: "string",
+            description: "owner/repo slug (default: origin remote)",
+          },
+          "dry-run": {
+            type: "boolean",
+            description:
+              "Print the issue body and intended action without calling gh",
+          },
+        },
+      },
+      {
         name: "fix",
         description:
           "Auto-fix wiki audit findings: rotate weekly logs, fix the rest with an AI agent (technical-writer, Haiku), flag the unresolvable",
@@ -335,6 +355,7 @@ export function createDefinition() {
       "fit-wiki inbox list --agent staff-engineer",
       "fit-wiki rotate --agent staff-engineer",
       "fit-wiki audit",
+      "fit-wiki curate",
       "fit-wiki fix",
       'fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"',
       "fit-wiki refresh",

--- a/libraries/libwiki/src/commands/audit.js
+++ b/libraries/libwiki/src/commands/audit.js
@@ -9,8 +9,14 @@ import { buildContext, resolveScope } from "../audit/scopes.js";
 import { currentDayIso } from "../util/clock.js";
 import { resolveProjectRoot } from "../util/wiki-dir.js";
 
-/** Run the wiki audit and emit findings. JSON via --format json. */
-export function runAuditCommand(ctx) {
+/**
+ * Run the wiki audit and return its findings plus the resolved project root.
+ * Shared by `runAuditCommand` (emits them) and `runCurateCommand` (routes
+ * them to an issue) so the two cannot drift.
+ * @param {import("@forwardimpact/libcli").InvocationContext} ctx
+ * @returns {{ findings: object[], projectRoot: string }}
+ */
+export function auditWiki(ctx) {
   const { runtime } = ctx.deps;
   const options = ctx.options;
   const projectRoot = resolveProjectRoot(runtime);
@@ -23,7 +29,14 @@ export function runAuditCommand(ctx) {
     fs: runtime.fsSync,
     subprocess: runtime.subprocess,
   });
-  const findings = runRules(RULES, auditCtx, { resolveScope });
+  return { findings: runRules(RULES, auditCtx, { resolveScope }), projectRoot };
+}
+
+/** Run the wiki audit and emit findings. JSON via --format json. */
+export function runAuditCommand(ctx) {
+  const { runtime } = ctx.deps;
+  const options = ctx.options;
+  const { findings, projectRoot } = auditWiki(ctx);
 
   runtime.proc.stdout.write(
     options.format === "json"

--- a/libraries/libwiki/src/commands/curate.js
+++ b/libraries/libwiki/src/commands/curate.js
@@ -1,0 +1,185 @@
+import path from "node:path";
+import { emitFindingsJson } from "@forwardimpact/libutil";
+import { createLogger } from "@forwardimpact/libtelemetry";
+import { createScriptConfig } from "@forwardimpact/libconfig";
+import { parseRepoSlug } from "../issue-list-renderer.js";
+import { resolveProjectRoot } from "../util/wiki-dir.js";
+import { auditWiki } from "./audit.js";
+
+// The routing contract: a single open issue, addressed to the technical-writer,
+// holding the audit findings. The title is matched verbatim on every run so a
+// dirty wiki appends to one issue rather than opening a new one each day.
+const LABEL = {
+  name: "wiki-curation",
+  color: "BFD4F2",
+  description: "Shared-wiki audit findings from scheduled curation",
+};
+const TITLE = "Wiki curation: shared-state audit findings";
+
+/**
+ * Compose the issue body from the audit's JSON findings. The findings ride a
+ * fenced ```json block; the body is passed to `gh` via `--body-file` (a temp
+ * file), never argv, so untrusted finding text cannot be misread as a flag.
+ * @param {string} findingsJson
+ * @returns {string}
+ */
+function buildBody(findingsJson) {
+  return [
+    "Scheduled `curate-wiki` audit found shared-wiki violations.",
+    "",
+    "Owner: **technical-writer** (service these via the curation shift; the per-PR `wiki` gate no longer reads shared wiki state).",
+    "",
+    "```json",
+    findingsJson,
+    "```",
+    "",
+  ].join("\n");
+}
+
+// Resolve the monorepo's `owner/repo` slug the way refresh.js/product-mix.js
+// do: an explicit FIT_GH_REPO override (sandbox proxy URLs), else the origin
+// remote parsed via the injected git client. Null lets `gh` fall back to its
+// own cwd resolution.
+async function deriveRepo(gitClient, cwd, env) {
+  if (env.FIT_GH_REPO) return env.FIT_GH_REPO;
+  if (!gitClient) return null;
+  try {
+    return parseRepoSlug(await gitClient.remoteGetUrl("origin", { cwd }));
+  } catch {
+    return null;
+  }
+}
+
+// A missing token is non-fatal: `gh` may still resolve ambient auth.
+async function resolveToken() {
+  try {
+    return (await createScriptConfig("wiki")).ghToken();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Audit the shared wiki and, when it is dirty, route the findings to the
+ * single `wiki-curation` issue (create or comment) addressed to the
+ * technical-writer. This is the SOLE home of the shared-wiki audit verdict; the
+ * per-PR `wiki` gate no longer reads live wiki state. A clean wiki routes
+ * nothing. The label/search/create-or-comment logic lives here, not in the
+ * workflow, so the curation step is one CLI call.
+ *
+ * @param {import("@forwardimpact/libcli").InvocationContext} ctx
+ * @returns {Promise<{ok: boolean}>}
+ */
+export async function runCurateCommand(ctx) {
+  const { runtime, gitClient } = ctx.deps;
+  const logger = createLogger("wiki", runtime);
+  const { findings } = auditWiki(ctx);
+
+  if (!findings.some((f) => f.level === "fail")) {
+    runtime.proc.stdout.write("wiki audit clean — no curation issue routed\n");
+    return { ok: true };
+  }
+
+  const body = buildBody(emitFindingsJson(findings));
+
+  if (ctx.options["dry-run"]) {
+    runtime.proc.stdout.write(
+      `[dry-run] would route findings to issue "${TITLE}":\n\n${body}`,
+    );
+    return { ok: true };
+  }
+
+  const cwd = resolveProjectRoot(runtime);
+  const repo =
+    ctx.options.repo || (await deriveRepo(gitClient, cwd, runtime.proc.env));
+  const token = await resolveToken();
+  const env = token
+    ? { ...runtime.proc.env, GH_TOKEN: token }
+    : runtime.proc.env;
+  const repoArgs = repo ? ["--repo", repo] : [];
+
+  // Ensure the label exists; a re-create on an existing label exits non-zero,
+  // which is expected and ignored.
+  await runtime.subprocess.run(
+    "gh",
+    [
+      "label",
+      "create",
+      LABEL.name,
+      "--color",
+      LABEL.color,
+      "--description",
+      LABEL.description,
+      ...repoArgs,
+    ],
+    { cwd, env },
+  );
+
+  const list = await runtime.subprocess.run(
+    "gh",
+    [
+      "issue",
+      "list",
+      "--search",
+      `${TITLE} in:title`,
+      "--state",
+      "open",
+      "--json",
+      "number",
+      ...repoArgs,
+    ],
+    { cwd, env },
+  );
+  let number = null;
+  try {
+    number = JSON.parse(list.stdout || "[]")[0]?.number ?? null;
+  } catch {
+    number = null;
+  }
+
+  // Pass the body through a temp file, not argv — robust to length and immune
+  // to finding text being read as a flag.
+  const tmp = runtime.proc.env.RUNNER_TEMP || runtime.proc.env.TMPDIR || "/tmp";
+  const bodyFile = path.join(tmp, "wiki-curation-body.md");
+  runtime.fsSync.writeFileSync(bodyFile, body);
+
+  const result = number
+    ? await runtime.subprocess.run(
+        "gh",
+        [
+          "issue",
+          "comment",
+          String(number),
+          "--body-file",
+          bodyFile,
+          ...repoArgs,
+        ],
+        { cwd, env },
+      )
+    : await runtime.subprocess.run(
+        "gh",
+        [
+          "issue",
+          "create",
+          "--title",
+          TITLE,
+          "--body-file",
+          bodyFile,
+          "--label",
+          LABEL.name,
+          ...repoArgs,
+        ],
+        { cwd, env },
+      );
+
+  if (result.exitCode !== 0) {
+    logger.warn("curate", `gh issue ${number ? "comment" : "create"} failed`);
+    return { ok: false };
+  }
+  runtime.proc.stdout.write(
+    number
+      ? `Commented curation findings on issue #${number}\n`
+      : "Opened a new wiki-curation issue\n",
+  );
+  return { ok: true };
+}

--- a/libraries/libwiki/test/curate-cli.test.js
+++ b/libraries/libwiki/test/curate-cli.test.js
@@ -1,0 +1,134 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { createMockFs, createMockSubprocess } from "@forwardimpact/libmock";
+
+import { runCurateCommand } from "../src/commands/curate.js";
+import { makeRuntime, ctxFor } from "./helpers.js";
+
+const PROJECT_ROOT = "/project";
+const WIKI_ROOT = `${PROJECT_ROOT}/wiki`;
+const FINDER = { findProjectRoot: () => PROJECT_ROOT };
+const STORYBOARD_AGENTS = [
+  "product-manager",
+  "release-engineer",
+  "security-engineer",
+  "staff-engineer",
+  "technical-writer",
+];
+
+// A clean wiki seed; `extra` overlays files that introduce audit failures.
+function cleanWiki(extra = {}) {
+  return createMockFs({
+    [`${WIKI_ROOT}/MEMORY.md`]: [
+      "## Cross-Cutting Priorities",
+      "",
+      "| Item | Agents | Owner | Status | Added |",
+      "| --- | --- | --- | --- | --- |",
+      "| *None* | — | — | — | — |",
+      "",
+    ].join("\n"),
+    [`${WIKI_ROOT}/storyboard-2026-M05.md`]: [
+      "# Storyboard — 2026-05",
+      "",
+      ...STORYBOARD_AGENTS.map((a) => `### ${a}`),
+      "",
+    ].join("\n"),
+    ...extra,
+  });
+}
+
+// An over-budget summary makes the audit dirty (a `fail`-level finding).
+const OVER_BUDGET = {
+  [`${WIKI_ROOT}/staff-engineer.md`]: `# Staff Engineer — Summary\n\n**Last run**: nothing.\n\n## Message Inbox\n\n<!-- memo:inbox -->\n\n${Array(600).fill("x").join("\n")}\n`,
+};
+
+function curate(fsSync, { options = {}, responses = {} } = {}) {
+  const subprocess = createMockSubprocess({ responses });
+  const harness = makeRuntime({ fsSync, finder: FINDER, subprocess });
+  return {
+    harness,
+    subprocess,
+    run: runCurateCommand(
+      ctxFor({
+        runtime: harness.runtime,
+        gitClient: { remoteGetUrl: async () => "" },
+        options: { today: "2026-05-24", repo: "owner/repo", ...options },
+      }),
+    ),
+  };
+}
+
+describe("fit-wiki curate", () => {
+  test("a clean wiki routes nothing and makes no gh call", async () => {
+    const { harness, subprocess, run } = curate(cleanWiki());
+    const result = await run;
+    assert.equal(result.ok, true);
+    // The audit shells out to `git ls-files`; what must not happen is any gh
+    // routing call.
+    assert.ok(!subprocess.calls.some((c) => c.cmd === "gh"));
+    assert.match(harness.stdout, /clean/);
+  });
+
+  test("a dirty wiki with no open issue creates one", async () => {
+    const { subprocess, run } = curate(cleanWiki(OVER_BUDGET), {
+      responses: { gh: { stdout: "[]" } },
+    });
+    const result = await run;
+    assert.equal(result.ok, true);
+
+    const create = subprocess.calls.find(
+      (c) => c.cmd === "gh" && c.args[0] === "issue" && c.args[1] === "create",
+    );
+    assert.ok(create, "expected a gh issue create call");
+    assert.ok(create.args.includes("--title"));
+    assert.equal(
+      create.args[create.args.indexOf("--title") + 1],
+      "Wiki curation: shared-state audit findings",
+    );
+    assert.ok(create.args.includes("--label"));
+    assert.equal(
+      create.args[create.args.indexOf("--label") + 1],
+      "wiki-curation",
+    );
+    // Body rides a temp file, never argv.
+    assert.ok(create.args.includes("--body-file"));
+    assert.ok(!create.args.some((a) => a === "--body"));
+    // No comment call when there is no existing issue.
+    assert.ok(
+      !subprocess.calls.some(
+        (c) => c.args[0] === "issue" && c.args[1] === "comment",
+      ),
+    );
+  });
+
+  test("a dirty wiki with an open issue comments on it", async () => {
+    const { subprocess, run } = curate(cleanWiki(OVER_BUDGET), {
+      responses: { gh: { stdout: '[{"number":42}]' } },
+    });
+    const result = await run;
+    assert.equal(result.ok, true);
+
+    const comment = subprocess.calls.find(
+      (c) => c.cmd === "gh" && c.args[0] === "issue" && c.args[1] === "comment",
+    );
+    assert.ok(comment, "expected a gh issue comment call");
+    assert.equal(comment.args[2], "42");
+    assert.ok(comment.args.includes("--body-file"));
+    assert.ok(
+      !subprocess.calls.some(
+        (c) => c.args[0] === "issue" && c.args[1] === "create",
+      ),
+    );
+  });
+
+  test("--dry-run prints the body and makes no gh call", async () => {
+    const { harness, subprocess, run } = curate(cleanWiki(OVER_BUDGET), {
+      options: { "dry-run": true },
+    });
+    const result = await run;
+    assert.equal(result.ok, true);
+    assert.ok(!subprocess.calls.some((c) => c.cmd === "gh"));
+    assert.match(harness.stdout, /\[dry-run\]/);
+    assert.match(harness.stdout, /```json/);
+  });
+});

--- a/libraries/libwiki/test/golden/fit-wiki/cases.json
+++ b/libraries/libwiki/test/golden/fit-wiki/cases.json
@@ -90,6 +90,15 @@
     "transform": []
   },
   {
+    "name": "curate help",
+    "args": ["curate", "--help"],
+    "env": {},
+    "exitCode": 0,
+    "stdoutFile": "curate-help.stdout.txt",
+    "stderrFile": "curate-help.stderr.txt",
+    "transform": []
+  },
+  {
     "name": "fix help",
     "args": ["fix", "--help"],
     "env": {},

--- a/libraries/libwiki/test/golden/fit-wiki/curate-help.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/curate-help.stdout.txt
@@ -1,0 +1,13 @@
+fit-wiki curate — Audit the shared wiki and route any findings to the single wiki-curation issue (create or comment), addressed to the technical-writer
+
+Usage: fit-wiki curate [options]
+
+Options:
+  --wiki-root=<string>  Override wiki root directory (default: wiki)
+  --today=<string>      Override today's ISO date (testing)
+  --repo=<string>       owner/repo slug (default: origin remote)
+  --dry-run             Print the issue body and intended action without calling gh
+
+Global options:
+  --help, -h  Show this help
+  --json      Render --help output as JSON

--- a/libraries/libwiki/test/golden/fit-wiki/help-flag.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/help-flag.stdout.txt
@@ -10,6 +10,7 @@ Commands:
   inbox [subcommand]                Triage the agent's Message Inbox (list/ack/promote/drop)
   rotate                            Rotate the current weekly log to a sealed part
   audit                             Audit the wiki against the declarative rule catalogue (line and word budgets, headings, decision blocks, storyboards, claims)
+  curate                            Audit the shared wiki and route any findings to the single wiki-curation issue (create or comment), addressed to the technical-writer
   fix                               Auto-fix wiki audit findings: rotate weekly logs, fix the rest with an AI agent (technical-writer, Haiku), flag the unresolvable
   memo                              Send a cross-team memo into a teammate's Message Inbox
   refresh [storyboard-path]         Regenerate storyboard XmR/marker blocks and clear expired MEMORY.md claims
@@ -32,6 +33,7 @@ Examples:
   fit-wiki inbox list --agent staff-engineer
   fit-wiki rotate --agent staff-engineer
   fit-wiki audit
+  fit-wiki curate
   fit-wiki fix
   fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"
   fit-wiki refresh

--- a/libraries/libwiki/test/golden/fit-wiki/help.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/help.stdout.txt
@@ -10,6 +10,7 @@ Commands:
   inbox [subcommand]                Triage the agent's Message Inbox (list/ack/promote/drop)
   rotate                            Rotate the current weekly log to a sealed part
   audit                             Audit the wiki against the declarative rule catalogue (line and word budgets, headings, decision blocks, storyboards, claims)
+  curate                            Audit the shared wiki and route any findings to the single wiki-curation issue (create or comment), addressed to the technical-writer
   fix                               Auto-fix wiki audit findings: rotate weekly logs, fix the rest with an AI agent (technical-writer, Haiku), flag the unresolvable
   memo                              Send a cross-team memo into a teammate's Message Inbox
   refresh [storyboard-path]         Regenerate storyboard XmR/marker blocks and clear expired MEMORY.md claims
@@ -32,6 +33,7 @@ Examples:
   fit-wiki inbox list --agent staff-engineer
   fit-wiki rotate --agent staff-engineer
   fit-wiki audit
+  fit-wiki curate
   fit-wiki fix
   fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"
   fit-wiki refresh

--- a/products/kata/actions/kata-agent/action.yml
+++ b/products/kata/actions/kata-agent/action.yml
@@ -95,6 +95,14 @@ inputs:
     description: Enable wiki checkout and sync
     required: false
     default: "true"
+  killswitch:
+    description: >
+      Operator killswitch. When set to a truthy value (anything other than
+      empty/0/false/no/off) the run fails fast before any token minting,
+      checkout, or agent work. Pass `${{ vars.KATA_KILLSWITCH }}` so one
+      repository variable halts every kata-* workflow at once.
+    required: false
+    default: ""
 
 outputs:
   trace-file:
@@ -122,6 +130,18 @@ outputs:
 runs:
   using: composite
   steps:
+    # Killswitch first: fail before any token minting, checkout, or agent work
+    # so one repository variable halts every kata-* workflow at once.
+    - name: Kata killswitch
+      shell: bash
+      env:
+        KATA_KILLSWITCH: ${{ inputs.killswitch }}
+      run: |
+        case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+          ""|0|false|no|off) ;;
+          *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH})." >&2; exit 1 ;;
+        esac
+
     - name: Generate installation token
       id: ci-app
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
@@ -217,3 +237,13 @@ runs:
         command: push
         app-id: ${{ inputs.app-id }}
         app-private-key: ${{ inputs.app-private-key }}
+
+    # Sum spend across every participant. fit-trace cost tolerates a missing
+    # trace (the run may have failed before producing one), so this needs no
+    # file guard.
+    - name: Report run cost
+      if: always()
+      shell: bash
+      env:
+        TRACE_FILE: ${{ steps.assess.outputs.trace-file }}
+      run: fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"

--- a/products/kata/actions/kata-agent/post-run/action.yml
+++ b/products/kata/actions/kata-agent/post-run/action.yml
@@ -1,9 +1,0 @@
-name: Post Run
-description: Run a command during job cleanup
-inputs:
-  command:
-    required: true
-runs:
-  using: node20
-  main: index.mjs
-  post: post.mjs

--- a/products/kata/actions/kata-agent/post-run/index.mjs
+++ b/products/kata/actions/kata-agent/post-run/index.mjs
@@ -1,5 +1,0 @@
-import { appendFileSync } from "fs";
-appendFileSync(
-  process.env.GITHUB_STATE,
-  `command=${process.env.INPUT_COMMAND}\n`,
-);

--- a/products/kata/actions/kata-agent/post-run/post.mjs
+++ b/products/kata/actions/kata-agent/post-run/post.mjs
@@ -1,2 +1,0 @@
-import { execSync } from "child_process";
-execSync(process.env.STATE_command, { stdio: "inherit" });


### PR DESCRIPTION
## What

Simplifies the GitHub Actions surface (workflows + composite actions) and moves the removed logic into the `fit-*` CLIs. Net ~368 fewer lines, core behavior unchanged.

## Changes

**Libraries**
- `libharness`: `run/supervise/facilitate/discuss` treat empty-string flags as "use default"; `fit-trace split` accepts `discuss`; `fit-trace cost` tolerates a missing/empty trace file (exit 0).
- `libwiki`: new `fit-wiki curate` (audit + route findings to the single `wiki-curation` issue via `gh --body-file`).

**Composite actions**
- `harness`: drop `command -v` guards, deprecated `artifact-suffix` input, task-source re-validation, per-flag `if` blocks (flat flag lists). Requires the new `fit-harness` binary.
- `benchmark`, `wiki`: drop `command -v` guards.
- `kata-agent`: new `killswitch` input + an `always()` "Report run cost" step.
- Delete dead `kata-agent/post-run/` sub-action.

**Workflows**
- 4 website workflows → 1 reusable `website.yml` + thin callers (no external dependency).
- `curate-wiki`: single `fit-wiki curate` call.
- `kata-dispatch/interview`: trimmed killswitch + one-line `fit-trace cost`.
- `kata-shift/coaching/storyboard`: drop inline killswitch + cost; pass `killswitch` to `kata-agent`.

## Release coupling

Workflow changes depend on a new gear binary release + sibling republish before the affected scheduled jobs (`curate-wiki`, kata cost steps, `harness` repin) work end to end. Release sequence handled post-merge: cut `gear@v0.1.11`, bump the gear pin, republish siblings + move `v1` tags, repin monorepo workflows.

## Test

`bun test` (libharness + libwiki unit + golden suites) passes. `biome` format/lint and `coaligned invariants` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)