### PR TITLE
chore(release): cut gear@v0.1.11, libharness@v1.2.0, libwiki@v0.2.32

### DIFF
--- a/libraries/libharness/package.json
+++ b/libraries/libharness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libharness",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Autonomous agent team harness — coordinate a lead and participant agents in one async session, with eval, benchmark, and trace tooling to prove the changes worked.",
   "keywords": [
     "orchestration",

--- a/libraries/libwiki/package.json
+++ b/libraries/libwiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libwiki",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "description": "Wiki lifecycle for agent teams — persistent memory, declarative integrity audits, and a collision ledger so coordination survives across sessions and parallel work.",
   "keywords": [
     "wiki",

--- a/products/gear/package.json
+++ b/products/gear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/gear",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Shared libraries and services for platform builders and agents — CLIs, retrieval, evaluation, and infrastructure published to npm.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Release cut for the CI-simplification work merged in #1855.

- `gear` 0.1.10 → 0.1.11 — rebuild fit-* binaries from new source
- `libharness` 1.1.0 → 1.2.0 — `fit-trace split` accepts `discuss`; empty-flag and missing-trace tolerance
- `libwiki` 0.2.31 → 0.2.32 — new `fit-wiki curate` command

Tags pushed after merge trigger `publish-binaries` (gear) and `publish-npm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)