### PR TITLE
chore(ci): bump gear pin to gear@v0.1.11

### DIFF
--- a/.github/actions/bootstrap/fit-install.sh
+++ b/.github/actions/bootstrap/fit-install.sh
@@ -38,7 +38,7 @@ DEFAULT_TOOLS=(apm just gh rg gitleaks coaligned)
 # publish step stamps the live tag into the released copy of this script; any
 # caller may override via the environment to pin a different release.
 FIT_RELEASE_REPO="${FIT_RELEASE_REPO:-forwardimpact/monorepo}"
-FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.10}"
+FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.11}"
 
 # Bun compile target for this platform. Binaries are built only for linux-x64
 # and darwin-arm64; any other platform is unsupported and fails hard — this is

--- a/scripts/fit-install.sh
+++ b/scripts/fit-install.sh
@@ -38,7 +38,7 @@ DEFAULT_TOOLS=(apm just gh rg gitleaks coaligned)
 # publish step stamps the live tag into the released copy of this script; any
 # caller may override via the environment to pin a different release.
 FIT_RELEASE_REPO="${FIT_RELEASE_REPO:-forwardimpact/monorepo}"
-FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.10}"
+FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.11}"
 
 # Bun compile target for this platform. Binaries are built only for linux-x64
 # and darwin-arm64; any other platform is unsupported and fails hard — this is


### PR DESCRIPTION
Point bootstrap at `gear@v0.1.11` (released, assets verified) in both `scripts/fit-install.sh` and `.github/actions/bootstrap/fit-install.sh`.

This is what makes CI install the new `fit-*` binaries: empty-flag tolerance, tolerant `fit-trace cost`/`split`, and `fit-wiki curate`. Fixes the `curate-wiki` daily job (06:00 UTC).

Triggers `publish-actions` (bootstrap leg) to republish bootstrap with the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)