### PR TITLE
chore(ci): repin kata-agent to v1.0.4 (killswitch + tolerant cost)

### DIFF
--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # kata-agent runs the killswitch first and reports run cost last.
-      - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
+      - uses: forwardimpact/kata-agent@53a90b6bb037894080f18577a437bb70de1c745d # v1.0.4
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}

--- a/.github/workflows/kata-shift.yml
+++ b/.github/workflows/kata-shift.yml
@@ -37,7 +37,7 @@ jobs:
           - { name: improvement-coach }
     steps:
       # kata-agent runs the killswitch first and reports run cost last.
-      - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
+      - uses: forwardimpact/kata-agent@53a90b6bb037894080f18577a437bb70de1c745d # v1.0.4
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # kata-agent runs the killswitch first and reports run cost last.
-      - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
+      - uses: forwardimpact/kata-agent@53a90b6bb037894080f18577a437bb70de1c745d # v1.0.4
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Repins `kata-coaching`, `kata-shift`, and `kata-storyboard` to `kata-agent@v1.0.4` (`53a90b6`), which:

- honors the new `killswitch` input (restores `KATA_KILLSWITCH` protection these three lost when #1855 removed their inline killswitch)
- reports run cost via the tolerant `fit-trace` (internal bootstrap@v1.0.8 / harness@v1.0.3, gear@v0.1.11)

After merge I re-enable the three workflows (disabled during the release window to preserve the killswitch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)