### PR TITLE
fix(kata-agent): drop vars expression from killswitch input description

### DIFF
--- a/products/kata/actions/kata-agent/action.yml
+++ b/products/kata/actions/kata-agent/action.yml
@@ -99,8 +99,8 @@ inputs:
     description: >
       Operator killswitch. When set to a truthy value (anything other than
       empty/0/false/no/off) the run fails fast before any token minting,
-      checkout, or agent work. Pass `${{ vars.KATA_KILLSWITCH }}` so one
-      repository variable halts every kata-* workflow at once.
+      checkout, or agent work. Pass the `KATA_KILLSWITCH` repository variable
+      so one variable halts every kata-* workflow at once.
     required: false
     default: ""
 


### PR DESCRIPTION
## Problem

Every `kata-shift`/`coaching`/`storyboard` job failed at **Set up job** on kata-agent@v1.0.4:

```
Unrecognized named-value: 'vars'. Located at position 1 within expression: vars.KATA_KILLSWITCH
```

GitHub's template parser validates `${{ }}` expressions **even inside an input description**, and a composite action cannot resolve the `vars` context. The killswitch input description contained a literal `${{ vars.KATA_KILLSWITCH }}` as usage guidance, which broke the whole action.

## Fix

Reword the description to plain prose (no `${{ }}`). The killswitch *step* already reads the value correctly via `inputs.killswitch`; the workflow still passes `killswitch: ${{ vars.KATA_KILLSWITCH }}` (valid at workflow level).

After merge: republish kata-agent, tag v1.0.5, repin the three kata workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)