### PR TITLE
chore(ci): repin kata-agent to v1.0.5 (killswitch template fix)

### DIFF
--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # kata-agent runs the killswitch first and reports run cost last.
-      - uses: forwardimpact/kata-agent@53a90b6bb037894080f18577a437bb70de1c745d # v1.0.4
+      - uses: forwardimpact/kata-agent@8dfb94075556824692e557593a559db5e58b9c3a # v1.0.5
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}

--- a/.github/workflows/kata-shift.yml
+++ b/.github/workflows/kata-shift.yml
@@ -37,7 +37,7 @@ jobs:
           - { name: improvement-coach }
     steps:
       # kata-agent runs the killswitch first and reports run cost last.
-      - uses: forwardimpact/kata-agent@53a90b6bb037894080f18577a437bb70de1c745d # v1.0.4
+      - uses: forwardimpact/kata-agent@8dfb94075556824692e557593a559db5e58b9c3a # v1.0.5
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # kata-agent runs the killswitch first and reports run cost last.
-      - uses: forwardimpact/kata-agent@53a90b6bb037894080f18577a437bb70de1c745d # v1.0.4
+      - uses: forwardimpact/kata-agent@8dfb94075556824692e557593a559db5e58b9c3a # v1.0.5
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Repins kata-coaching/shift/storyboard to `kata-agent@v1.0.5` (`8dfb940`), which fixes the template-validation error (`Unrecognized named-value: 'vars'`) that failed every kata job at Set up job. The killswitch input is now honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)