### PR TITLE
chore(skills): point setup skills at public sites; refresh kata-setup CI templates

### DIFF
--- a/.claude/skills/coaligned-setup/SKILL.md
+++ b/.claude/skills/coaligned-setup/SKILL.md
@@ -3,14 +3,14 @@ name: coaligned-setup
 description: >
   Bootstrap the Co-Aligned instruction architecture in a repository. Use
   when a repo has no layered agent instructions yet, when adopting the
-  COALIGNED.md standard, or when wiring `npx coaligned` into the checks so
+  Co-Aligned standard, or when wiring `npx coaligned` into the checks so
   instruction layers, jobs, and invariants stay enforced.
 ---
 
 # coaligned-setup
 
 Stand up the
-[Co-Aligned](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
+[Co-Aligned](https://www.coaligned.team/)
 instruction architecture in a repository: the root identity and jobs files, the
 invariant directory, and the `npx coaligned` checks that keep them honest.
 
@@ -102,7 +102,7 @@ validate. Fix any finding before committing — route by subcommand the same way
 
 ## Documentation
 
-- [Co-Aligned Instruction Architecture Standard](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
+- [Co-Aligned Instruction Architecture Standard](https://www.coaligned.team/)
   — the eight layers, their caps, and the rules that separate them.
 - [libcoaligned README](https://github.com/forwardimpact/monorepo/blob/main/libraries/libcoaligned/README.md)
   — what each `coaligned` subcommand checks.

--- a/.claude/skills/kata-setup/SKILL.md
+++ b/.claude/skills/kata-setup/SKILL.md
@@ -10,7 +10,7 @@ description: >
 # Set Up the Kata Agent Team
 
 Interactive skill that configures the
-[Kata Agent Team](https://www.forwardimpact.team/docs/internals/kata/) in your
+[Kata Agent Team](https://www.kata.team/) in your
 repository. Generates GitHub Actions workflow files for scheduled agents,
 facilitated sessions, and event-driven responses.
 
@@ -57,8 +57,9 @@ facilitated sessions, and event-driven responses.
 - [ ] The dispatch workflow does no prompt assembly — it passes
       `task-event: ${{ github.event_path }}` and lets the action compose the
       task (including the recursion guard).
-- [ ] Every generated workflow's first step is the `Kata killswitch` gate
-      (before any token mint or checkout).
+- [ ] Every generated workflow gates on the killswitch: `kata-agent` workflows
+      pass `killswitch: ${{ vars.KATA_KILLSWITCH }}`; the harness-based dispatch
+      workflow keeps the inline `Kata killswitch` first step.
 
 </do_confirm_checklist>
 
@@ -144,11 +145,14 @@ The matrix in `agent-shift.yml` carries one line per selected agent, in
 producer → reviewer → shipper order (see `references/schedules.md`). Storyboard
 and coaching workflows are generated only when `improvement-coach` is selected.
 
-Every template's first step is a `Kata killswitch` gate that reads the
-`KATA_KILLSWITCH` repository (or org) Actions variable and fails the run when it
-holds a truthy value (anything other than empty, `0`, `false`, `no`, or `off`).
-Keep it first so an engaged switch halts the run before any token mint,
-checkout, or agent work. It is unset by default, so it has no effect until an
+Every template gates on the `KATA_KILLSWITCH` repository (or org) Actions
+variable, failing the run when it holds a truthy value (anything other than
+empty, `0`, `false`, `no`, or `off`). The `kata-agent` workflows (shift,
+storyboard, coaching) pass `killswitch: ${{ vars.KATA_KILLSWITCH }}` to the
+action, which runs the gate as its first internal step — before any token mint,
+checkout, or agent work. The harness-based dispatch workflow mints its own token
+in the workflow, so it keeps an inline `Kata killswitch` first step that halts
+before that mint. The switch is unset by default, so it has no effect until an
 operator sets it.
 
 ### Step 3: Generate agent-dispatch
@@ -185,5 +189,5 @@ Summarize what was created and suggest next steps:
 - To halt all kata workflows at once (an emergency stop), set the
   `KATA_KILLSWITCH` repository variable to a truthy value (e.g. `1`); clear or
   unset it to resume
-- Read the [Kata internals](https://www.forwardimpact.team/docs/internals/kata/)
-  for architecture details
+- Read the [Kata Agent Team](https://www.kata.team/) site for how the team
+  works and its PDSA rhythm

--- a/.claude/skills/kata-setup/references/workflow-dispatch.md
+++ b/.claude/skills/kata-setup/references/workflow-dispatch.md
@@ -67,7 +67,7 @@ jobs:
       || github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     steps:
-      # First step: copy the `Kata killswitch` step verbatim from workflow-shift.md.
+      # First step: the `Kata killswitch` step from workflow-shift.md § Inline steps.
       - name: Generate token
         id: ci-app
         uses: actions/create-github-app-token@v3
@@ -94,8 +94,8 @@ jobs:
           agent-model: "{{MODEL}}"
           lead-model: "{{MODEL}}"
           discussion-id: ${{ inputs.discussion_id }}
-      # Copy the `Report run cost` step from workflow-shift.md (read trace-file
-      # from `steps.assess`).
+      # Then the `Report run cost` step per workflow-shift.md § Inline steps
+      # (TRACE_FILE from `steps.assess.outputs.trace-file`).
       # harness does not push wiki itself, so push memory with a fresh token.
       # Drop this step when wiki is disabled.
       - name: Push wiki changes

--- a/.claude/skills/kata-setup/references/workflow-facilitate.md
+++ b/.claude/skills/kata-setup/references/workflow-facilitate.md
@@ -47,13 +47,14 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
-      # First step: copy `Kata killswitch` verbatim from workflow-shift.md.
+      # kata-agent runs the killswitch first and reports run cost last.
       - uses: forwardimpact/kata-agent@{{KATA_AGENT_REF}}
         id: agent
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          killswitch: ${{ vars.KATA_KILLSWITCH }}
           mode: "discuss"
           lead-profile: "improvement-coach"
           agent-profiles: "{{AGENT_LIST}}"
@@ -63,7 +64,6 @@ jobs:
           task-text: >-
             Facilitate a team Kata storyboard session.
           task-amend: ${{ inputs.task-amend }}
-      # Last step: copy `Report run cost` verbatim from workflow-shift.md.
 ```
 
 ## Coaching Template
@@ -82,8 +82,8 @@ changes:
 
 Both are `kata-agent` workflows, so the hosted delta is identical to
 [`workflow-shift.md` § Template (hosted)](workflow-shift.md): add
-`id-token: write` to `permissions`, insert the OIDC mint step after the
-`Kata killswitch` step, and replace `app-id` / `app-private-key` with
+`id-token: write` to `permissions`, insert the OIDC mint step as the first step,
+and replace `app-id` / `app-private-key` with
 `installation-token: ${{ steps.mint.outputs.token }}`.
 
 ## Notes

--- a/.claude/skills/kata-setup/references/workflow-shift.md
+++ b/.claude/skills/kata-setup/references/workflow-shift.md
@@ -15,10 +15,11 @@ serializes them.
 | `{{KATA_AGENT_REF}}` | `b4a5b262f3d7acaee2da63f8b2a09bcf4730d804 # v1.0.0` |
 
 List `{{AGENT_MATRIX}}` in producer → reviewer → shipper order;
-`{{SHIFT_CRONS}}` are shift-start times. Set `wiki: "false"` to skip wiki sync,
-omit `agent-model:` for the default. The `Kata killswitch` and `Report run cost`
-steps are the canonical copies other files reference. Emit the self-hosted block
-(default) or the hosted block per `--hosted` (`SKILL.md`).
+`{{SHIFT_CRONS}}` are shift-start times. Set `wiki: "false"` to skip sync, omit
+`agent-model:` for the default. `kata-agent` runs the killswitch gate first and
+reports cost last. These workflows pass
+`killswitch: ${{ vars.KATA_KILLSWITCH }}` and add no inline steps. Emit the
+self-hosted (default) or hosted block per `--hosted` (`SKILL.md`).
 
 ## Template (Self-Hosted)
 
@@ -49,21 +50,14 @@ jobs:
         agent:
           {{AGENT_MATRIX}}
     steps:
-      - name: Kata killswitch
-        shell: bash
-        env:
-          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
-        run: |
-          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off) echo "Killswitch not engaged; proceeding." ;;
-            *) echo "::error::KATA_KILLSWITCH engaged. Failing fast." >&2; exit 1 ;;
-          esac
+      # kata-agent runs the killswitch first and reports run cost last.
       - uses: forwardimpact/kata-agent@{{KATA_AGENT_REF}}
         id: agent
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          killswitch: ${{ vars.KATA_KILLSWITCH }}
           agent-profile: ${{ matrix.agent.name }}
           agent-model: "{{MODEL}}"
           wiki: "{{WIKI}}"
@@ -72,17 +66,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           task-amend: ${{ inputs.task-amend }}
-      - name: Report run cost
-        if: always()
-        shell: bash
-        env:
-          TRACE_FILE: ${{ steps.agent.outputs.trace-file }}
-        run: |
-          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
-            fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No trace file produced — cost not reported."
-          fi
 ```
 
 ## Template (Hosted)
@@ -90,7 +73,7 @@ jobs:
 The self-hosted template with three changes (the **canonical** hosted recipe):
 
 1. Add `id-token: write` to `permissions`, keeping `contents: write`.
-2. Insert this OIDC mint step directly **after** the `Kata killswitch` step:
+2. Insert this OIDC mint step as the **first** step, before `kata-agent`:
 
    ```yaml
          - name: Mint installation token via Forward Impact OIDC
@@ -110,12 +93,31 @@ The self-hosted template with three changes (the **canonical** hosted recipe):
              printf 'token=%s\n' "$INSTALL_TOKEN" >> "$GITHUB_OUTPUT"
    ```
 
-3. In the `kata-agent` step, drop `app-id`/`app-private-key` and add
-   `installation-token: ${{ steps.mint.outputs.token }}`.
+3. In the `kata-agent` step, drop `app-id`/`app-private-key`, add
+   `installation-token: ${{ steps.mint.outputs.token }}`; keep `killswitch:`.
 
-`FIT_OIDC_URL` is the `services/oidc` URL as a repository **variable**;
-`::add-mask::` keeps the token out of logs. Hosted needs a `kata-agent` SHA
-accepting `installation-token`.
+`FIT_OIDC_URL` is the `services/oidc` URL as a repository **variable**, masked
+in logs. Hosted needs a `kata-agent` SHA accepting `installation-token`.
+
+## Inline steps
+
+For the harness-based dispatch workflow (`workflow-dispatch.md`), which does not
+delegate to `kata-agent`: copy the killswitch below as its first step, and add a
+final `if: always()` step running `fit-trace cost "$TRACE_FILE" --markdown >>
+"$GITHUB_STEP_SUMMARY"` (`TRACE_FILE` from the trace step's `trace-file`; a
+missing trace is tolerated, no guard).
+
+```yaml
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off) ;;
+            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH})." >&2; exit 1 ;;
+          esac
+```
 
 ## Resolving Action Refs
 

--- a/.claude/skills/monorepo-setup/SKILL.md
+++ b/.claude/skills/monorepo-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: monorepo-setup
 description: >
-  Stand up a new MONOREPO.md-compliant repository end to end — bootstrap the
+  Stand up a new Monorepo-standard repository end to end — bootstrap the
   skeleton, install the skill packs, run coaligned-setup then kata-setup, and
   fill the seams neither owns (root package.json, directory tree, agent
   profiles, CI, remote creation). Use when creating a Forward Impact-style repo
@@ -11,7 +11,7 @@ description: >
 # monorepo-setup
 
 Orchestrate a full repository bootstrap to the three standards: structure
-([MONOREPO.md](https://github.com/forwardimpact/monorepo/blob/main/MONOREPO.md)),
+([Monorepo](https://www.monorepo.team/)),
 instruction architecture (via the `coaligned-setup` skill), and the agent team
 (via the `kata-setup` skill).
 
@@ -34,9 +34,9 @@ once per repository.
 
 `git init`, default branch `main`, then the seam files from
 [references/repo-skeleton.md](references/repo-skeleton.md): `.gitignore` and the
-MONOREPO.md top-level directories, each with a `README.md` naming its jobs.
-See [MONOREPO.md] for what each directory is for — do not invent structure.
-Commit.
+[Monorepo standard][monorepo] top-level directories, each with a `README.md`
+naming its jobs. See [the Monorepo standard][monorepo] for what each directory
+is for — do not invent structure. Commit.
 
 ### Step 2 — Add the root package.json
 
@@ -97,7 +97,7 @@ that the wiki clones with its three ledgers via `fit-wiki pull`.
 
 <do_confirm_checklist goal="Verify the repo stands before handing off">
 
-- [ ] Git, the root `package.json`, and the MONOREPO.md directory tree exist.
+- [ ] Git, the root `package.json`, and the Monorepo directory tree exist.
 - [ ] Both skill packs and the kata agent profiles are under `.claude/`.
 - [ ] `coaligned-setup` and `kata-setup` both completed.
 - [ ] The check workflows exist (`check-quality`, `check-test`, `check-context`)
@@ -111,12 +111,12 @@ that the wiki clones with its three ledgers via `fit-wiki pull`.
 
 ## Documentation
 
-- [MONOREPO.md] — repository structure and the JTBD convention.
-- [COALIGNED.md](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
+- [Monorepo][monorepo] — repository structure and the JTBD convention.
+- [Co-Aligned](https://www.coaligned.team/)
   — the layered instruction architecture (owned by `coaligned-setup`).
-- [KATA.md](https://github.com/forwardimpact/monorepo/blob/main/KATA.md) — the
+- [Kata Agent Team](https://www.kata.team/) — the
   agent team and its PDSA loop (owned by `kata-setup`).
 - [APM](https://microsoft.github.io/apm/) — the package manager that installs
   the skill packs.
 
-[MONOREPO.md]: https://github.com/forwardimpact/monorepo/blob/main/MONOREPO.md
+[monorepo]: https://www.monorepo.team/

--- a/.claude/skills/monorepo-setup/references/repo-skeleton.md
+++ b/.claude/skills/monorepo-setup/references/repo-skeleton.md
@@ -8,8 +8,8 @@ commit the lockfile until the pinned `@forwardimpact/*` versions are published.
 
 ## Directory layout
 
-Per MONOREPO.md. Create only what the repo will use; each shippable directory
-carries a `README.md` naming its jobs.
+Per the [Monorepo standard](https://www.monorepo.team/). Create only what the
+repo will use; each shippable directory carries a `README.md` naming its jobs.
 
 - `products/` `services/` `libraries/` — shippable code (README each).
 - `websites/` — docs hub. `infrastructure/` — deployment assets.


### PR DESCRIPTION
## Summary

- Repoint the `kata-setup`, `coaligned-setup`, and `monorepo-setup` skills away from the internal note docs (`KATA.md`, `COALIGNED.md`, `MONOREPO.md`) to the public product sites: `www.kata.team`, `www.coaligned.team`, `www.monorepo.team`.
- Bring `kata-setup`'s generated-workflow templates up to date with the CI simplification (#1855): `kata-agent` now runs the killswitch gate first and reports run cost last, so the shift/storyboard/coaching templates pass `killswitch: ${{ vars.KATA_KILLSWITCH }}` and drop their inline kill/cost steps.
- The harness-based dispatch template keeps an inline killswitch first step and the no-guard one-line `fit-trace cost`; hosted recipe simplified to rely on the action's killswitch input.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`