### PR TITLE
feat(websites): build out Co-Aligned and Monorepo sites

### DIFF
--- a/websites/CLAUDE.md
+++ b/websites/CLAUDE.md
@@ -2,14 +2,14 @@
 
 Four sites built by `fit-doc`
 ([internals](fit/docs/internals/fit-doc/index.md)). Two are live; two are
-placeholders pending content and a publish workflow.
+built and pending a publish workflow.
 
-| Site                       | Source                | Domain                   | Status      |
-| -------------------------- | --------------------- | ------------------------ | ----------- |
-| Forward Impact Engineering | `websites/fit/`       | `www.forwardimpact.team` | Live        |
-| Kata Agent Team            | `websites/kata/`      | `www.kata.team`          | Live        |
-| Co-Aligned                 | `websites/coaligned/` | `www.coaligned.team`     | Placeholder |
-| Monorepo Structure         | `websites/monorepo/`  | `www.monorepo.team`      | Placeholder |
+| Site                       | Source                | Domain                   | Status |
+| -------------------------- | --------------------- | ------------------------ | ------ |
+| Forward Impact Engineering | `websites/fit/`       | `www.forwardimpact.team` | Live   |
+| Kata Agent Team            | `websites/kata/`      | `www.kata.team`          | Live   |
+| Co-Aligned                 | `websites/coaligned/` | `www.coaligned.team`     | Built  |
+| Monorepo Structure         | `websites/monorepo/`  | `www.monorepo.team`      | Built  |
 
 Preview locally:
 
@@ -115,7 +115,7 @@ Live sites share the same deployment pattern. Workflows in
 | `website-fit.yaml`  | `fit-pages`  | `forwardimpact/fit-pages`  |
 | `website-kata.yaml` | `kata-pages` | `forwardimpact/kata-pages` |
 
-The Co-Aligned and Monorepo placeholder sites do not yet have publish
+The Co-Aligned and Monorepo sites are built but do not yet have publish
 workflows; they will be added when the sites are ready to ship.
 
 Push to `main` (path-filtered) triggers: build with `fit-doc`, upload artifact,

--- a/websites/coaligned/assets/main.css
+++ b/websites/coaligned/assets/main.css
@@ -1,57 +1,65 @@
 /* ══════════════════════════════════════════════════════════════════
-   Co-Aligned — Brand Layer (placeholder)
+   Co-Aligned — Brand Layer
+   Tokens, fonts, brand-specific surfaces, and scroll-section styles.
+   Loaded after the shared base/layout/components stylesheets.
 
-   This site is wired up to the layered design language but the brand
-   is not yet implemented in code. Until then, neutral monochrome
-   fallback tokens keep the page rendering cleanly.
-
-   To brand this site, add a design/coaligned/ folder mirroring
-   design/fit/ and replace this :root block with the brand's tokens
-   per design/usage.md § 2 CSS Architecture.
+   Metaphor: instruction layers — a stepped stack, most general at the
+   base, most specific at the top. Cool indigo signal (blueprint ink).
    ══════════════════════════════════════════════════════════════════ */
 
-:root {
-  /* Surfaces */
-  --bg-page: #ffffff;
-  --bg-warm: #f5f5f5;
-  --bg-elevated: #f0f0f0;
-  --bg-hover: #eaeaea;
-  --bg-inverted: #1a1a1a;
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap");
 
-  /* Warm signal — neutral until the brand chooses a hue */
-  --accent-warm-50: #f5f5f5;
-  --accent-warm-100: #eaeaea;
-  --accent-warm-200: #d0d0d0;
-  --accent-warm-400: #a0a0a0;
-  --accent-warm-600: #707070;
+/* ── Design Tokens ─────────────────────────────────────────────── */
+
+:root {
+  /* Surfaces — cool paper */
+  --bg-page: #ffffff;
+  --bg-warm: #f4f5fb;
+  --bg-elevated: #eef0f8;
+  --bg-hover: #e2e5f3;
+  --bg-inverted: #13141b;
+
+  /* Indigo (cool signal — blueprint ink) */
+  --ink-50: #eef1fc;
+  --ink-100: #dde3f8;
+  --ink-200: #b6c2ef;
+  --ink-400: #5161d6;
+  --ink-600: #343ca0;
+
+  /* Family alias — shared layout.css reads --accent-warm-* */
+  --accent-warm-50: var(--ink-50);
+  --accent-warm-100: var(--ink-100);
+  --accent-warm-200: var(--ink-200);
+  --accent-warm-400: var(--ink-400);
+  --accent-warm-600: var(--ink-600);
 
   /* Text */
-  --text-primary: #000000;
-  --text-heading: #1a1a1a;
-  --text-body: #404040;
-  --text-secondary: #666666;
-  --text-tertiary: #999999;
-  --text-on-dark: #e0e0e0;
+  --text-primary: #06070c;
+  --text-heading: #13141b;
+  --text-body: #585a66;
+  --text-secondary: #6e7080;
+  --text-tertiary: #a6a8b8;
+  --text-on-dark: #e7e8ef;
 
-  /* Grays */
-  --gray-50: #f5f5f5;
-  --gray-100: #eaeaea;
-  --gray-200: #d0d0d0;
-  --gray-300: #b0b0b0;
-  --gray-400: #888888;
-  --gray-500: #666666;
-  --gray-700: #3a3a3a;
-  --gray-900: #1a1a1a;
-  --black: #000000;
+  /* Grays — cool-leaning */
+  --gray-50: #f1f2f8;
+  --gray-100: #e2e5f0;
+  --gray-200: #cbcedd;
+  --gray-300: #a6a8b8;
+  --gray-400: #6e7080;
+  --gray-500: #585a66;
+  --gray-700: #33343f;
+  --gray-900: #13141b;
+  --black: #06070c;
 
   /* Borders */
-  --border-default: #eaeaea;
-  --border-strong: #d0d0d0;
+  --border-default: #e2e5f0;
+  --border-strong: #cbcedd;
 
-  /* Radii */
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
+  /* Radii — crisp, architectural */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
   --radius-pill: 999px;
 
   /* Spacing */
@@ -68,14 +76,17 @@
   --space-24: 96px;
   --space-32: 128px;
 
-  /* Typography — system fonts until the brand chooses families */
-  --font-display: Georgia, "Times New Roman", serif;
+  /* Typography */
+  --font-display:
+    "Space Grotesk", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
   --font-sans:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-mono: "SF Mono", Consolas, "Liberation Mono", monospace;
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono:
+    "IBM Plex Mono", "SF Mono", Consolas, "Liberation Mono", monospace;
 
-  --text-hero-size: 4rem;
-  --text-hero-weight: 400;
+  --text-hero-size: 4.5rem;
+  --text-hero-weight: 700;
   --text-display-size: 2.75rem;
   --text-h1-size: 2rem;
   --text-h2-size: 1.5rem;
@@ -89,4 +100,550 @@
   --duration-fast: 150ms;
   --duration-normal: 200ms;
   --duration-slow: 400ms;
+}
+
+/* ── Layout: Home ──────────────────────────────────────────────── */
+
+.layout-home .page-content {
+  max-width: none;
+  padding: 0;
+}
+
+.layout-home .page-title {
+  display: none;
+}
+
+.layout-home .page-content > .coaligned-section {
+  padding: var(--space-24) var(--space-6);
+}
+
+/* ── Header ────────────────────────────────────────────────────── */
+
+.site-header {
+  background: transparent;
+  border-bottom: none;
+  transition:
+    background var(--duration-normal) var(--ease-default),
+    border-color var(--duration-normal) var(--ease-default);
+}
+
+.site-header.scrolled {
+  background: rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.brand-text {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.125rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.nav-github {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  opacity: 0.5;
+  transition: opacity var(--duration-fast) var(--ease-default);
+}
+
+.nav-github:hover {
+  opacity: 1;
+}
+
+.nav-spacer {
+  flex: 1;
+}
+
+/* ── Hero ──────────────────────────────────────────────────────── */
+
+.coaligned-hero {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding-top: 56px !important;
+  padding-bottom: var(--space-16) !important;
+  position: relative;
+}
+
+.coaligned-hero .layer-stack-hero {
+  width: 72px;
+  height: 72px;
+  margin-bottom: var(--space-8);
+  animation: fadeUp 600ms var(--ease-default) 100ms backwards;
+}
+
+.coaligned-hero .hero-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: var(--text-hero-size);
+  line-height: 1.05;
+  color: var(--black);
+  letter-spacing: -0.02em;
+  max-width: 880px;
+  margin: 0 auto var(--space-6);
+  animation: fadeUp 600ms var(--ease-default) 200ms backwards;
+}
+
+.coaligned-hero .hero-subtitle {
+  font-family: var(--font-sans);
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.6;
+  color: var(--gray-400);
+  max-width: 560px;
+  margin: 0 auto;
+  animation: fadeUp 600ms var(--ease-default) 300ms backwards;
+}
+
+.scroll-hint {
+  position: absolute;
+  bottom: var(--space-8);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  animation: fadeUp 600ms var(--ease-default) 500ms backwards;
+}
+
+.scroll-hint span {
+  font-family: var(--font-mono);
+  font-size: var(--text-badge-size);
+  color: var(--gray-300);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.scroll-line {
+  width: 1px;
+  height: 32px;
+  background: var(--gray-200);
+  animation: scrollPulse 2s var(--ease-default) infinite;
+}
+
+@keyframes scrollPulse {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scaleY(0.6);
+    transform-origin: top;
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Sections ──────────────────────────────────────────────────── */
+
+.coaligned-section-cool {
+  background: var(--bg-warm);
+}
+
+.section-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.section-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-small-size);
+  font-weight: 500;
+  color: var(--ink-400);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-4);
+}
+
+.section-headline {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: var(--text-display-size);
+  line-height: 1.1;
+  color: var(--gray-900);
+  letter-spacing: -0.02em;
+  max-width: 660px;
+  margin-bottom: var(--space-6);
+}
+
+.section-body {
+  font-size: 1.125rem;
+  line-height: 1.65;
+  color: var(--gray-400);
+  max-width: 580px;
+  margin-bottom: var(--space-12);
+}
+
+/* ── Stats ─────────────────────────────────────────────────────── */
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+}
+
+.stat-card {
+  background: var(--bg-page);
+  border: 1.5px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  text-align: center;
+}
+
+.stat-number {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 3.5rem;
+  line-height: 1;
+  color: var(--gray-900);
+  margin-bottom: var(--space-2);
+}
+
+.stat-label {
+  font-family: var(--font-sans);
+  font-size: var(--text-small-size);
+  font-weight: 500;
+  color: var(--gray-400);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.stat-detail {
+  font-family: var(--font-sans);
+  font-size: var(--text-small-size);
+  color: var(--gray-300);
+  margin-top: var(--space-2);
+}
+
+/* ── The Layers ────────────────────────────────────────────────── */
+
+.layers-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-6);
+}
+
+.layer-card {
+  padding: var(--space-6);
+  border-top: 3px solid var(--gray-200);
+  transition: border-color var(--duration-normal) var(--ease-default);
+}
+
+.layer-card:hover {
+  border-top-color: var(--ink-400);
+}
+
+.layer-card .layer-tag {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: var(--text-small-size);
+  color: var(--ink-400);
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-2);
+}
+
+.layer-card .layer-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-body-size);
+  color: var(--gray-900);
+  margin-bottom: var(--space-3);
+}
+
+.layer-card .layer-desc {
+  font-size: var(--text-small-size);
+  color: var(--gray-400);
+  line-height: 1.55;
+}
+
+/* ── Duo cards (foundations, gates) ────────────────────────────── */
+
+.duo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-6);
+}
+
+.foundation-card,
+.gate-card {
+  background: var(--bg-page);
+  border: 1.5px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  transition:
+    border-color var(--duration-normal) var(--ease-default),
+    transform var(--duration-normal) var(--ease-default);
+}
+
+.foundation-card:hover,
+.gate-card:hover {
+  border-color: var(--ink-200);
+  transform: translateY(-2px);
+}
+
+.foundation-source,
+.gate-kind {
+  font-family: var(--font-mono);
+  font-size: var(--text-badge-size);
+  color: var(--ink-400);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-2);
+}
+
+.foundation-name,
+.gate-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-h3-size);
+  color: var(--gray-900);
+  margin-bottom: var(--space-3);
+}
+
+.foundation-desc,
+.gate-desc {
+  font-size: var(--text-body-size);
+  color: var(--gray-400);
+  line-height: 1.6;
+}
+
+/* ── Getting Started ───────────────────────────────────────────── */
+
+.getting-started-label {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: var(--text-display-size);
+  line-height: 1.1;
+  color: var(--gray-900);
+  letter-spacing: -0.02em;
+  text-align: center;
+  margin-bottom: var(--space-2);
+}
+
+.getting-started-sub {
+  font-size: 1.125rem;
+  color: var(--gray-400);
+  text-align: center;
+  margin-bottom: var(--space-12);
+}
+
+.terminal {
+  background: var(--bg-inverted);
+  border-radius: var(--radius-lg);
+  padding: 0;
+  max-width: 680px;
+  margin: 0 auto;
+  overflow: hidden;
+  box-shadow:
+    0 24px 80px rgba(6, 7, 12, 0.15),
+    0 8px 24px rgba(6, 7, 12, 0.1);
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.terminal-title {
+  flex: 1;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: var(--text-badge-size);
+  color: var(--gray-400);
+}
+
+.terminal-lines {
+  padding: var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-small-size);
+  line-height: 2;
+}
+
+.terminal-line {
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity 300ms var(--ease-default),
+    transform 300ms var(--ease-default);
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
+.terminal-lines.typing .terminal-line:nth-child(1) {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 0ms;
+}
+
+.terminal-lines.typing .terminal-line:nth-child(2) {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 400ms;
+}
+
+.terminal-lines.typing .terminal-line:nth-child(3) {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 800ms;
+}
+
+.terminal-prompt {
+  color: var(--ink-400);
+  user-select: none;
+}
+
+.terminal-cmd {
+  color: var(--text-on-dark);
+}
+
+.terminal-string {
+  color: var(--ink-200);
+}
+
+.closing-note {
+  text-align: center;
+  font-size: var(--text-small-size);
+  color: var(--gray-400);
+  max-width: 540px;
+  margin: var(--space-12) auto 0;
+}
+
+.closing-note code {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--ink-600);
+  background: var(--ink-50);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+}
+
+/* ── Stagger Reveal ────────────────────────────────────────────── */
+
+.stagger-item {
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 400ms var(--ease-default),
+    transform 400ms var(--ease-default);
+}
+
+.stagger-item.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ── Layer-stack SVG ───────────────────────────────────────────── */
+
+.layer-stack-hero .layer-bar,
+.layer-divider .layer-bar {
+  stroke: var(--gray-300);
+  stroke-width: 1.5;
+  fill: none;
+}
+
+.layer-stack-hero .layer-bar-top,
+.layer-divider .layer-bar-top {
+  stroke: var(--ink-400);
+  fill: var(--ink-50);
+}
+
+/* ── Footer Brand ──────────────────────────────────────────────── */
+
+.footer-brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--text-on-dark);
+}
+
+.footer-tagline {
+  font-family: var(--font-sans);
+  font-size: var(--text-small-size);
+  color: var(--gray-400);
+}
+
+.site-footer {
+  margin-top: 0;
+}
+
+/* ── Divider ───────────────────────────────────────────────────── */
+
+.layer-divider {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-16) 0;
+}
+
+.layer-divider svg {
+  width: 20px;
+  height: 20px;
+}
+
+/* ── Responsive ────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  :root {
+    --text-hero-size: 2.75rem;
+    --text-display-size: 2rem;
+    --text-h1-size: 1.75rem;
+    --text-h2-size: 1.375rem;
+    --space-24: 64px;
+    --space-16: 48px;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .layers-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .duo-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stat-number {
+    font-size: 2.5rem;
+  }
+
+  .terminal {
+    margin: 0 calc(-1 * var(--space-4));
+    border-radius: var(--radius-md);
+  }
+}
+
+@media (max-width: 480px) {
+  .layers-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/websites/coaligned/index.md
+++ b/websites/coaligned/index.md
@@ -1,23 +1,195 @@
 ---
-title: Co-Aligned Engineers & Coding Agents
-description: An instruction architecture standard for creating aligned coding agents — grounded in Jobs To Be Done and The Checklist Manifesto.
+title: Co-Aligned Instruction Architecture
+description: An instruction architecture for humans and coding agents — eight layers, each with one job, each independently auditable. Grounded in Jobs To Be Done and The Checklist Manifesto.
 toc: false
+layout: home
 ---
 
-> "The volume and complexity of what we know has exceeded our individual
-> ability to deliver its benefits correctly, safely, or reliably."
->
-> — Atul Gawande, _The Checklist Manifesto_
+<div class="coaligned-section coaligned-hero">
+  <svg class="layer-stack-hero" viewBox="0 0 64 64" aria-hidden="true">
+    <rect class="layer-bar" x="10" y="54" width="44" height="4" rx="1.5" />
+    <rect class="layer-bar" x="12" y="47" width="40" height="4" rx="1.5" />
+    <rect class="layer-bar" x="14" y="40" width="36" height="4" rx="1.5" />
+    <rect class="layer-bar" x="16" y="33" width="32" height="4" rx="1.5" />
+    <rect class="layer-bar" x="18" y="26" width="28" height="4" rx="1.5" />
+    <rect class="layer-bar" x="20" y="19" width="24" height="4" rx="1.5" />
+    <rect class="layer-bar" x="22" y="12" width="20" height="4" rx="1.5" />
+    <rect class="layer-bar layer-bar-top" x="24" y="5" width="16" height="4" rx="1.5" />
+  </svg>
+  <h1 class="hero-title">Coding agents that stay aligned under load</h1>
+  <p class="hero-subtitle">One instruction architecture for humans and agents. Eight layers, each with a single job, each one you can audit on its own.</p>
+  <div class="scroll-hint">
+    <span>Scroll</span>
+    <div class="scroll-line"></div>
+  </div>
+</div>
 
-An instruction architecture standard for creating aligned coding agents —
-grounded in Jobs To Be Done and The Checklist Manifesto — that
-keeps humans and agents aligned to the progress each persona seeks, and keeps
-that alignment under load.
+<div class="coaligned-section coaligned-section-cool">
+  <div class="section-inner">
+    <div class="reveal">
+      <div class="section-label">The Problem</div>
+      <h2 class="section-headline">Instructions sprawl, and alignment breaks under load.</h2>
+      <p class="section-body">Prompts pile up. Instruction chains grow unauditable. The more expert the contributor, the more readily they skip the procedure — because they think they don't need it. Co-Aligned takes the opposite path: one layered architecture where every layer owns a single job, and a defect always traces to exactly one of them.</p>
+    </div>
+    <div class="stats-grid stagger">
+      <div class="stat-card stagger-item">
+        <div class="stat-number">8</div>
+        <div class="stat-label">Layers</div>
+        <div class="stat-detail">Most general to most specific</div>
+      </div>
+      <div class="stat-card stagger-item">
+        <div class="stat-number">1</div>
+        <div class="stat-label">Job per layer</div>
+        <div class="stat-detail">No layer restates another</div>
+      </div>
+      <div class="stat-card stagger-item">
+        <div class="stat-number">0</div>
+        <div class="stat-label">Guesswork</div>
+        <div class="stat-detail">Every defect localizes to one layer</div>
+      </div>
+    </div>
+  </div>
+</div>
 
-Co-Aligned builds on the [Monorepo](https://www.monorepo.team/) repository
-structure and is the upstream architecture that the
-[Kata Agent Team](https://www.kata.team/) implements.
+<div class="layer-divider">
+  <svg viewBox="0 0 16 16" aria-hidden="true">
+    <rect class="layer-bar" x="2" y="11" width="12" height="2" rx="1" />
+    <rect class="layer-bar" x="3" y="7" width="10" height="2" rx="1" />
+    <rect class="layer-bar layer-bar-top" x="4" y="3" width="8" height="2" rx="1" />
+  </svg>
+</div>
 
-## Learn more
+<div class="coaligned-section">
+  <div class="section-inner">
+    <div class="reveal">
+      <div class="section-label">The Architecture</div>
+      <h2 class="section-headline">Eight layers. Most general to most specific.</h2>
+      <p class="section-body">Each layer loads at the right moment and owns one concern. Auto-loaded layers stay budgeted so context never bloats; on-demand layers disclose only when the work calls for them.</p>
+    </div>
+    <div class="layers-grid stagger">
+      <div class="layer-card stagger-item">
+        <div class="layer-tag">L0</div>
+        <div class="layer-name">System Prompt</div>
+        <p class="layer-desc">Harness mechanics: turns, tool calls, the completion signal. Nothing about your project.</p>
+      </div>
+      <div class="layer-card stagger-item">
+        <div class="layer-tag">L1</div>
+        <div class="layer-name">CLAUDE.md</div>
+        <p class="layer-desc">Project identity. What it is, who it serves, and where to find things.</p>
+      </div>
+      <div class="layer-card stagger-item">
+        <div class="layer-tag">L2</div>
+        <div class="layer-name">CONTRIBUTING.md &amp; JTBD.md</div>
+        <p class="layer-desc">Contribution standards and the jobs each persona hires the work to do.</p>
+      </div>
+      <div class="layer-card stagger-item">
+        <div class="layer-tag">L3</div>
+        <div class="layer-name">Agent Profile</div>
+        <p class="layer-desc">One persona — voice, skill routing, and scope constraints. Boundaries, not steps.</p>
+      </div>
+      <div class="layer-card stagger-item">
+        <div class="layer-tag">L4</div>
+        <div class="layer-name">Agent References</div>
+        <p class="layer-desc">Cross-cutting protocols shared across agents: memory, coordination, approval.</p>
+      </div>
+      <div class="layer-card stagger-item">
+        <div class="layer-tag">L5</div>
+        <div class="layer-name">Skill Procedure</div>
+        <p class="layer-desc">The complete, imperative steps for one domain of work — no tribal knowledge required.</p>
+      </div>
+      <div class="layer-card stagger-item">
+        <div class="layer-tag">L6</div>
+        <div class="layer-name">Skill References</div>
+        <p class="layer-desc">The data a procedure consults: templates, worked examples, lookup tables.</p>
+      </div>
+      <div class="layer-card stagger-item">
+        <div class="layer-tag">L7</div>
+        <div class="layer-name">Checklists</div>
+        <p class="layer-desc">Binary verification at a pause point. No explanation — just confirmation.</p>
+      </div>
+    </div>
+  </div>
+</div>
 
-- [COALIGNED.md on GitHub](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
+<div class="layer-divider">
+  <svg viewBox="0 0 16 16" aria-hidden="true">
+    <rect class="layer-bar" x="2" y="11" width="12" height="2" rx="1" />
+    <rect class="layer-bar" x="3" y="7" width="10" height="2" rx="1" />
+    <rect class="layer-bar layer-bar-top" x="4" y="3" width="8" height="2" rx="1" />
+  </svg>
+</div>
+
+<div class="coaligned-section coaligned-section-cool">
+  <div class="section-inner">
+    <div class="reveal">
+      <div class="section-label">The Foundations</div>
+      <h2 class="section-headline">What agents align to, and how alignment holds.</h2>
+      <p class="section-body">Two well-publicized ideas answer the two halves of the problem — and together they explain why the layers are shaped the way they are.</p>
+    </div>
+    <div class="duo-grid stagger">
+      <div class="foundation-card stagger-item">
+        <div class="foundation-source">Christensen &amp; Moesta</div>
+        <div class="foundation-name">Jobs To Be Done</div>
+        <p class="foundation-desc">What agents align to. Every layer traces to the progress a persona seeks in a specific circumstance — not to a feature list.</p>
+      </div>
+      <div class="foundation-card stagger-item">
+        <div class="foundation-source">Atul Gawande</div>
+        <div class="foundation-name">The Checklist Manifesto</div>
+        <p class="foundation-desc">How alignment holds under load. Structured instructions keep existing knowledge consistently applied — by humans and agents alike.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="layer-divider">
+  <svg viewBox="0 0 16 16" aria-hidden="true">
+    <rect class="layer-bar" x="2" y="11" width="12" height="2" rx="1" />
+    <rect class="layer-bar" x="3" y="7" width="10" height="2" rx="1" />
+    <rect class="layer-bar layer-bar-top" x="4" y="3" width="8" height="2" rx="1" />
+  </svg>
+</div>
+
+<div class="coaligned-section">
+  <div class="section-inner">
+    <div class="reveal">
+      <div class="section-label">Verification</div>
+      <h2 class="section-headline">Two gates. One at entry, one at exit.</h2>
+      <p class="section-body">Checklists never teach — they confirm. If an item needs explaining, the procedure above it is incomplete. Pick the right type for the moment, and the pause point stays natural instead of getting skipped.</p>
+    </div>
+    <div class="duo-grid stagger">
+      <div class="gate-card stagger-item">
+        <div class="gate-kind">Entry gate</div>
+        <div class="gate-name">READ-DO</div>
+        <p class="gate-desc">Read each item, then do it. Loads constraints into memory before the first line of work, when missing one sends everything in the wrong direction.</p>
+      </div>
+      <div class="gate-card stagger-item">
+        <div class="gate-kind">Exit gate</div>
+        <div class="gate-name">DO-CONFIRM</div>
+        <p class="gate-desc">Do from memory, then pause and confirm. Verifies nothing was missed before a commit, merge, or release — independent checks, no interruption mid-flow.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="coaligned-section coaligned-section-cool">
+  <div class="section-inner">
+    <div class="reveal">
+      <h2 class="getting-started-label">Adopt it in three lines.</h2>
+      <p class="getting-started-sub">Install the skill pack. Tell Claude to set it up.</p>
+    </div>
+    <div class="terminal reveal">
+      <div class="terminal-bar">
+        <div class="terminal-dot"></div>
+        <div class="terminal-dot"></div>
+        <div class="terminal-dot"></div>
+        <div class="terminal-title">Terminal</div>
+      </div>
+      <div class="terminal-lines">
+        <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">cd my-repo/</span></div>
+        <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">apm install forwardimpact/coaligned-skills</span></div>
+        <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">echo </span><span class="terminal-string">"Set up Co-Aligned"</span><span class="terminal-cmd"> | claude</span></div>
+      </div>
+    </div>
+    <p class="closing-note reveal">Then wire <code>npx coaligned</code> into your checks, so every layer keeps its job. Read the full standard in <a href="https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md">COALIGNED.md</a>.</p>
+  </div>
+</div>

--- a/websites/coaligned/index.template.html
+++ b/websites/coaligned/index.template.html
@@ -20,34 +20,100 @@
     <header class="site-header">
       <div class="header-inner">
         <a class="brand" href="/">
-          <span class="brand-text">Co-Aligned Teams</span>
+          <span class="brand-text">Co-Aligned</span>
+        </a>
+        <div class="nav-spacer"></div>
+        <a href="https://github.com/forwardimpact/coaligned-skills" class="btn-ghost nav-github" target="_blank" aria-label="GitHub">
+          <img src="https://cdn.simpleicons.org/github/aeaba2" alt="" width="20" height="20" />
         </a>
       </div>
     </header>
-    <main>
+
+    <main{{#layout}} class="layout-{{layout}}"{{/layout}}>
       <div class="page-content">
+        {{^hasHero}}
         <h1 class="page-title">{{{title}}}</h1>
+        {{/hasHero}}
         {{{content}}}
       </div>
     </main>
+
     <footer class="site-footer">
       <div class="footer-inner">
         <div class="footer-column footer-column-left">
-          <span class="footer-heading">Co-Aligned Teams</span>
-          <a href="https://www.monorepo.team/">monorepo.team</a>
-          <a href="https://www.kata.team/">kata.team</a>
-          <a href="https://www.forwardimpact.team/">forwardimpact.team</a>
+          <span class="footer-brand">Co-Aligned</span>
+          <span class="footer-tagline">Eight layers. One job each.</span>
         </div>
         <div class="footer-social">
-          <a href="https://github.com/forwardimpact/monorepo" target="_blank" aria-label="GitHub">
+          <a href="https://github.com/forwardimpact/coaligned-skills" target="_blank" aria-label="GitHub">
             <img src="https://cdn.simpleicons.org/github/9ca3af" alt="" width="24" height="24" />
           </a>
         </div>
         <div class="footer-column footer-column-right">
           <span class="footer-heading">Copyright 2026</span>
-          <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a>
+          <a href="https://www.monorepo.team/">monorepo.team</a>
+          <a href="https://www.kata.team/">kata.team</a>
+          <a href="https://www.forwardimpact.team/">forwardimpact.team</a>
         </div>
       </div>
     </footer>
+
+    <script>
+      // Scroll reveal
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("visible");
+            }
+          });
+        },
+        { threshold: 0.15 }
+      );
+      document.querySelectorAll(".reveal").forEach((el) => observer.observe(el));
+
+      // Header scroll state
+      const header = document.querySelector(".site-header");
+      window.addEventListener("scroll", () => {
+        header.classList.toggle("scrolled", window.scrollY > 10);
+      }, { passive: true });
+
+      // Terminal typing effect
+      const terminal = document.querySelector(".terminal-lines");
+      if (terminal) {
+        const termObserver = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                terminal.classList.add("typing");
+                termObserver.unobserve(entry.target);
+              }
+            });
+          },
+          { threshold: 0.5 }
+        );
+        termObserver.observe(terminal);
+      }
+
+      // Stagger reveal children
+      document.querySelectorAll(".stagger").forEach((container) => {
+        const children = container.querySelectorAll(".stagger-item");
+        const staggerObserver = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                children.forEach((child, i) => {
+                  child.style.transitionDelay = `${i * 80}ms`;
+                  child.classList.add("visible");
+                });
+                staggerObserver.unobserve(entry.target);
+              }
+            });
+          },
+          { threshold: 0.15 }
+        );
+        staggerObserver.observe(container);
+      });
+    </script>
   </body>
 </html>

--- a/websites/coaligned/llms.txt
+++ b/websites/coaligned/llms.txt
@@ -1,0 +1,27 @@
+# Co-Aligned
+
+> An instruction architecture for humans and coding agents — eight layers,
+> each with one job, each independently auditable.
+
+Co-Aligned is an open-source standard for creating aligned coding agents.
+Instructions span eight layers, ascending from most general (the system
+prompt, every run) to most specific (a checklist at one pause point). Each
+layer owns a single job, and no layer restates another — so a defect always
+traces to exactly one of them.
+
+It draws on two well-publicized ideas. Jobs To Be Done (Christensen, Moesta)
+answers what agents align to: the progress each persona seeks, not a feature
+list. The Checklist Manifesto (Gawande) answers how alignment holds under
+load: structured instructions keep existing knowledge consistently applied.
+
+Co-Aligned builds on the Monorepo structure standard and is the upstream
+architecture the Kata Agent Team implements.
+
+Install via `apm install forwardimpact/coaligned-skills`, then ask Claude to
+set it up. Wire `npx coaligned` into your checks to keep every layer honest.
+
+## Optional
+
+- [The full standard (COALIGNED.md)](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
+- [Monorepo structure standard](https://www.monorepo.team/)
+- [Kata Agent Team](https://www.kata.team/)

--- a/websites/monorepo/assets/main.css
+++ b/websites/monorepo/assets/main.css
@@ -1,57 +1,65 @@
 /* ══════════════════════════════════════════════════════════════════
-   Monorepo — Brand Layer (placeholder)
+   Monorepo — Brand Layer
+   Tokens, fonts, brand-specific surfaces, and scroll-section styles.
+   Loaded after the shared base/layout/components stylesheets.
 
-   This site is wired up to the layered design language but the brand
-   is not yet implemented in code. Until then, neutral monochrome
-   fallback tokens keep the page rendering cleanly.
-
-   To brand this site, add a design/monorepo/ folder mirroring
-   design/fit/ and replace this :root block with the brand's tokens
-   per design/usage.md § 2 CSS Architecture.
+   Metaphor: a directory tree — every node traces back to one root, the
+   aim. Grounded pine-green signal (a living, ordered system).
    ══════════════════════════════════════════════════════════════════ */
 
-:root {
-  /* Surfaces */
-  --bg-page: #ffffff;
-  --bg-warm: #f5f5f5;
-  --bg-elevated: #f0f0f0;
-  --bg-hover: #eaeaea;
-  --bg-inverted: #1a1a1a;
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=IBM+Plex+Mono:wght@400;500&family=Inter:wght@400;500;600;700&display=swap");
 
-  /* Warm signal — neutral until the brand chooses a hue */
-  --accent-warm-50: #f5f5f5;
-  --accent-warm-100: #eaeaea;
-  --accent-warm-200: #d0d0d0;
-  --accent-warm-400: #a0a0a0;
-  --accent-warm-600: #707070;
+/* ── Design Tokens ─────────────────────────────────────────────── */
+
+:root {
+  /* Surfaces — warm-neutral paper */
+  --bg-page: #ffffff;
+  --bg-warm: #f3f6f3;
+  --bg-elevated: #ebf0ea;
+  --bg-hover: #dde6db;
+  --bg-inverted: #11160f;
+
+  /* Pine (grounded signal — living system) */
+  --ink-50: #e9f4ee;
+  --ink-100: #d2eadd;
+  --ink-200: #a3d4bd;
+  --ink-400: #2f9e78;
+  --ink-600: #1d6b52;
+
+  /* Family alias — shared layout.css reads --accent-warm-* */
+  --accent-warm-50: var(--ink-50);
+  --accent-warm-100: var(--ink-100);
+  --accent-warm-200: var(--ink-200);
+  --accent-warm-400: var(--ink-400);
+  --accent-warm-600: var(--ink-600);
 
   /* Text */
-  --text-primary: #000000;
-  --text-heading: #1a1a1a;
-  --text-body: #404040;
-  --text-secondary: #666666;
-  --text-tertiary: #999999;
-  --text-on-dark: #e0e0e0;
+  --text-primary: #050805;
+  --text-heading: #11160f;
+  --text-body: #565a54;
+  --text-secondary: #6c7068;
+  --text-tertiary: #a7aaa1;
+  --text-on-dark: #e6e9e3;
 
-  /* Grays */
-  --gray-50: #f5f5f5;
-  --gray-100: #eaeaea;
-  --gray-200: #d0d0d0;
-  --gray-300: #b0b0b0;
-  --gray-400: #888888;
-  --gray-500: #666666;
-  --gray-700: #3a3a3a;
-  --gray-900: #1a1a1a;
-  --black: #000000;
+  /* Grays — warm-leaning */
+  --gray-50: #f1f3ef;
+  --gray-100: #e3e7e0;
+  --gray-200: #cdd2c8;
+  --gray-300: #a7aaa1;
+  --gray-400: #6c7068;
+  --gray-500: #565a54;
+  --gray-700: #32362f;
+  --gray-900: #11160f;
+  --black: #050805;
 
   /* Borders */
-  --border-default: #eaeaea;
-  --border-strong: #d0d0d0;
+  --border-default: #e3e7e0;
+  --border-strong: #cdd2c8;
 
   /* Radii */
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
   --radius-pill: 999px;
 
   /* Spacing */
@@ -68,14 +76,15 @@
   --space-24: 96px;
   --space-32: 128px;
 
-  /* Typography — system fonts until the brand chooses families */
-  --font-display: Georgia, "Times New Roman", serif;
+  /* Typography */
+  --font-display: "Fraunces", Georgia, "Times New Roman", serif;
   --font-sans:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-mono: "SF Mono", Consolas, "Liberation Mono", monospace;
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono:
+    "IBM Plex Mono", "SF Mono", Consolas, "Liberation Mono", monospace;
 
-  --text-hero-size: 4rem;
-  --text-hero-weight: 400;
+  --text-hero-size: 4.5rem;
+  --text-hero-weight: 600;
   --text-display-size: 2.75rem;
   --text-h1-size: 2rem;
   --text-h2-size: 1.5rem;
@@ -89,4 +98,598 @@
   --duration-fast: 150ms;
   --duration-normal: 200ms;
   --duration-slow: 400ms;
+}
+
+/* ── Layout: Home ──────────────────────────────────────────────── */
+
+.layout-home .page-content {
+  max-width: none;
+  padding: 0;
+}
+
+.layout-home .page-title {
+  display: none;
+}
+
+.layout-home .page-content > .monorepo-section {
+  padding: var(--space-24) var(--space-6);
+}
+
+/* ── Header ────────────────────────────────────────────────────── */
+
+.site-header {
+  background: transparent;
+  border-bottom: none;
+  transition:
+    background var(--duration-normal) var(--ease-default),
+    border-color var(--duration-normal) var(--ease-default);
+}
+
+.site-header.scrolled {
+  background: rgba(255, 255, 255, 0.9);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.brand-text {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+}
+
+.nav-github {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  opacity: 0.5;
+  transition: opacity var(--duration-fast) var(--ease-default);
+}
+
+.nav-github:hover {
+  opacity: 1;
+}
+
+.nav-spacer {
+  flex: 1;
+}
+
+/* ── Hero ──────────────────────────────────────────────────────── */
+
+.monorepo-hero {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding-top: 56px !important;
+  padding-bottom: var(--space-16) !important;
+  position: relative;
+}
+
+.monorepo-hero .tree-hero {
+  width: 72px;
+  height: 72px;
+  margin-bottom: var(--space-8);
+  animation: fadeUp 600ms var(--ease-default) 100ms backwards;
+}
+
+.monorepo-hero .hero-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-hero-size);
+  line-height: 1.04;
+  color: var(--black);
+  letter-spacing: -0.02em;
+  max-width: 880px;
+  margin: 0 auto var(--space-6);
+  animation: fadeUp 600ms var(--ease-default) 200ms backwards;
+}
+
+.monorepo-hero .hero-subtitle {
+  font-family: var(--font-sans);
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.6;
+  color: var(--gray-400);
+  max-width: 580px;
+  margin: 0 auto;
+  animation: fadeUp 600ms var(--ease-default) 300ms backwards;
+}
+
+.scroll-hint {
+  position: absolute;
+  bottom: var(--space-8);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  animation: fadeUp 600ms var(--ease-default) 500ms backwards;
+}
+
+.scroll-hint span {
+  font-family: var(--font-mono);
+  font-size: var(--text-badge-size);
+  color: var(--gray-300);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.scroll-line {
+  width: 1px;
+  height: 32px;
+  background: var(--gray-200);
+  animation: scrollPulse 2s var(--ease-default) infinite;
+}
+
+@keyframes scrollPulse {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scaleY(0.6);
+    transform-origin: top;
+  }
+  50% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Sections ──────────────────────────────────────────────────── */
+
+.monorepo-section-soft {
+  background: var(--bg-warm);
+}
+
+.section-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.section-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-small-size);
+  font-weight: 500;
+  color: var(--ink-600);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-4);
+}
+
+.section-headline {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-display-size);
+  line-height: 1.1;
+  color: var(--gray-900);
+  letter-spacing: -0.02em;
+  max-width: 660px;
+  margin-bottom: var(--space-6);
+}
+
+.section-body {
+  font-size: 1.125rem;
+  line-height: 1.65;
+  color: var(--gray-400);
+  max-width: 600px;
+  margin-bottom: var(--space-12);
+}
+
+.section-body code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  color: var(--ink-600);
+  background: var(--ink-50);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+}
+
+/* ── Stats ─────────────────────────────────────────────────────── */
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+}
+
+.stat-card {
+  background: var(--bg-page);
+  border: 1.5px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  text-align: center;
+}
+
+.stat-number {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 3.5rem;
+  line-height: 1;
+  color: var(--gray-900);
+  margin-bottom: var(--space-2);
+}
+
+.stat-label {
+  font-family: var(--font-sans);
+  font-size: var(--text-small-size);
+  font-weight: 500;
+  color: var(--gray-400);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.stat-detail {
+  font-family: var(--font-sans);
+  font-size: var(--text-small-size);
+  color: var(--gray-300);
+  margin-top: var(--space-2);
+}
+
+/* ── The Structure ─────────────────────────────────────────────── */
+
+.dir-band {
+  font-family: var(--font-mono);
+  font-size: var(--text-badge-size);
+  font-weight: 500;
+  color: var(--ink-600);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.dir-band:not(:first-of-type) {
+  margin-top: var(--space-10);
+}
+
+.dir-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+}
+
+.dir-card {
+  background: var(--bg-page);
+  border: 1.5px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  border-left: 3px solid var(--ink-400);
+  padding: var(--space-6);
+  transition:
+    border-color var(--duration-normal) var(--ease-default),
+    transform var(--duration-normal) var(--ease-default);
+}
+
+.dir-card:hover {
+  transform: translateY(-2px);
+}
+
+.dir-card-soft {
+  border-left-color: var(--gray-300);
+}
+
+.dir-name {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: var(--text-body-size);
+  color: var(--gray-900);
+  margin-bottom: var(--space-3);
+}
+
+.dir-desc {
+  font-size: var(--text-small-size);
+  color: var(--gray-400);
+  line-height: 1.55;
+}
+
+/* ── Root files (trio) and Jobs (duo) ──────────────────────────── */
+
+.rootfile-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-6);
+}
+
+.duo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-6);
+}
+
+.rootfile-card,
+.job-card {
+  background: var(--bg-page);
+  border: 1.5px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  transition:
+    border-color var(--duration-normal) var(--ease-default),
+    transform var(--duration-normal) var(--ease-default);
+}
+
+.rootfile-card:hover,
+.job-card:hover {
+  border-color: var(--ink-200);
+  transform: translateY(-2px);
+}
+
+.rootfile-name {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: var(--text-body-size);
+  color: var(--gray-900);
+  margin-bottom: var(--space-1);
+}
+
+.rootfile-role {
+  font-family: var(--font-mono);
+  font-size: var(--text-badge-size);
+  color: var(--ink-600);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+
+.rootfile-desc {
+  font-size: var(--text-small-size);
+  color: var(--gray-400);
+  line-height: 1.55;
+}
+
+.job-kind {
+  font-family: var(--font-mono);
+  font-size: var(--text-badge-size);
+  color: var(--ink-600);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-2);
+}
+
+.job-name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-h3-size);
+  color: var(--gray-900);
+  margin-bottom: var(--space-3);
+}
+
+.job-desc {
+  font-size: var(--text-body-size);
+  color: var(--gray-400);
+  line-height: 1.6;
+}
+
+/* ── Getting Started ───────────────────────────────────────────── */
+
+.getting-started-label {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--text-display-size);
+  line-height: 1.1;
+  color: var(--gray-900);
+  letter-spacing: -0.02em;
+  text-align: center;
+  margin-bottom: var(--space-2);
+}
+
+.getting-started-sub {
+  font-size: 1.125rem;
+  color: var(--gray-400);
+  text-align: center;
+  margin-bottom: var(--space-12);
+}
+
+.terminal {
+  background: var(--bg-inverted);
+  border-radius: var(--radius-lg);
+  padding: 0;
+  max-width: 720px;
+  margin: 0 auto;
+  overflow: hidden;
+  box-shadow:
+    0 24px 80px rgba(5, 8, 5, 0.15),
+    0 8px 24px rgba(5, 8, 5, 0.1);
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.terminal-title {
+  flex: 1;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: var(--text-badge-size);
+  color: var(--gray-400);
+}
+
+.terminal-lines {
+  padding: var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-small-size);
+  line-height: 2;
+}
+
+.terminal-line {
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity 300ms var(--ease-default),
+    transform 300ms var(--ease-default);
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
+.terminal-lines.typing .terminal-line:nth-child(1) {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 0ms;
+}
+
+.terminal-lines.typing .terminal-line:nth-child(2) {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 400ms;
+}
+
+.terminal-lines.typing .terminal-line:nth-child(3) {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 800ms;
+}
+
+.terminal-prompt {
+  color: var(--ink-400);
+  user-select: none;
+}
+
+.terminal-cmd {
+  color: var(--text-on-dark);
+}
+
+.terminal-string {
+  color: var(--ink-200);
+}
+
+.closing-note {
+  text-align: center;
+  font-size: var(--text-small-size);
+  color: var(--gray-400);
+  max-width: 560px;
+  margin: var(--space-12) auto 0;
+}
+
+/* ── Stagger Reveal ────────────────────────────────────────────── */
+
+.stagger-item {
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 400ms var(--ease-default),
+    transform 400ms var(--ease-default);
+}
+
+.stagger-item.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ── Directory-tree SVG ────────────────────────────────────────── */
+
+.tree-hero .tree-node,
+.tree-hero .tree-leaf,
+.tree-divider .tree-node {
+  stroke: var(--gray-300);
+  stroke-width: 1.5;
+  fill: none;
+}
+
+.tree-hero .tree-root,
+.tree-divider .tree-root {
+  stroke: var(--ink-400);
+  fill: var(--ink-50);
+}
+
+.tree-hero .tree-branch,
+.tree-divider .tree-branch {
+  stroke: var(--gray-300);
+  stroke-width: 1.5;
+  fill: none;
+  stroke-linecap: round;
+}
+
+/* ── Footer Brand ──────────────────────────────────────────────── */
+
+.footer-brand {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.0625rem;
+  color: var(--text-on-dark);
+}
+
+.footer-tagline {
+  font-family: var(--font-sans);
+  font-size: var(--text-small-size);
+  color: var(--gray-400);
+}
+
+.site-footer {
+  margin-top: 0;
+}
+
+/* ── Divider ───────────────────────────────────────────────────── */
+
+.tree-divider {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-16) 0;
+}
+
+.tree-divider svg {
+  width: 20px;
+  height: 20px;
+}
+
+/* ── Responsive ────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  :root {
+    --text-hero-size: 2.75rem;
+    --text-display-size: 2rem;
+    --text-h1-size: 1.75rem;
+    --text-h2-size: 1.375rem;
+    --space-24: 64px;
+    --space-16: 48px;
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dir-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .rootfile-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .duo-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .stat-number {
+    font-size: 2.5rem;
+  }
+
+  .terminal {
+    margin: 0 calc(-1 * var(--space-4));
+    border-radius: var(--radius-md);
+  }
 }

--- a/websites/monorepo/index.md
+++ b/websites/monorepo/index.md
@@ -1,26 +1,191 @@
 ---
-title: Monorepo Team
-description: Structural conventions for repositories shared by humans and coding agents — top-level directories, root files, and a Jobs To Be Done catalogue.
+title: Monorepo Structure Standard
+description: The structure of a repository shared by humans and coding agents — six directories, three root files, and a Jobs To Be Done catalogue. Every directory and file traces back to a job.
 toc: false
+layout: home
 ---
 
-> "A system is a network of interdependent components that work together to try
-> to accomplish the aim of the system. A system must have an aim. Without an
-> aim, there is no system."
->
-> — W. Edwards Deming, _The New Economics_
+<div class="monorepo-section monorepo-hero">
+  <svg class="tree-hero" viewBox="0 0 64 64" aria-hidden="true">
+    <rect class="tree-node tree-root" x="25" y="5" width="14" height="9" rx="2" />
+    <path class="tree-branch" d="M32 14 V22 M14 22 H50 M14 22 V31 M32 22 V31 M50 22 V31" />
+    <rect class="tree-node" x="7" y="31" width="14" height="9" rx="2" />
+    <rect class="tree-node" x="25" y="31" width="14" height="9" rx="2" />
+    <rect class="tree-node" x="43" y="31" width="14" height="9" rx="2" />
+    <path class="tree-branch" d="M14 40 V48 M7 48 H21 M7 48 V55 M21 48 V55" />
+    <rect class="tree-leaf" x="3" y="55" width="8" height="6" rx="1.5" />
+    <rect class="tree-leaf" x="17" y="55" width="8" height="6" rx="1.5" />
+  </svg>
+  <h1 class="hero-title">Every file traces back to a job</h1>
+  <p class="hero-subtitle">The structure of a repository shared by humans and coding agents. Six directories, three root files, one aim — and nothing that means nothing.</p>
+  <div class="scroll-hint">
+    <span>Scroll</span>
+    <div class="scroll-line"></div>
+  </div>
+</div>
 
-Structural conventions for a repository shared by humans and coding agents.
-Top-level directories carry shippable code, root files orient every contributor,
-and a Jobs To Be Done catalogue grounds them in the progress each persona seeks.
-The jobs supply the aim — without them, the structure is arbitrary; without the
-structure, the jobs are invisible.
+<div class="monorepo-section monorepo-section-soft">
+  <div class="section-inner">
+    <div class="reveal">
+      <div class="section-label">The Problem</div>
+      <h2 class="section-headline">Structure without an aim is just folders.</h2>
+      <p class="section-body">Most repositories grow by accretion. Files land wherever, directories mean whatever, and nobody — human or agent — can say why a thing lives where it does. Monorepo starts from the aim: every directory and every file traces back to a job someone is trying to get done.</p>
+    </div>
+    <div class="stats-grid stagger">
+      <div class="stat-card stagger-item">
+        <div class="stat-number">6</div>
+        <div class="stat-label">Directories</div>
+        <div class="stat-detail">Each with a README naming its jobs</div>
+      </div>
+      <div class="stat-card stagger-item">
+        <div class="stat-number">3</div>
+        <div class="stat-label">Root files</div>
+        <div class="stat-detail">One job each, none restating another</div>
+      </div>
+      <div class="stat-card stagger-item">
+        <div class="stat-number">1</div>
+        <div class="stat-label">Aim</div>
+        <div class="stat-detail">Every structure decision traces to it</div>
+      </div>
+    </div>
+  </div>
+</div>
 
-This is the upstream structure that
-[Co-Aligned](https://www.coaligned.team/) layers an instruction architecture
-on top of, and that the [Kata Agent Team](https://www.kata.team/) implements
-as a running Plan-Do-Study-Act loop.
+<div class="tree-divider">
+  <svg viewBox="0 0 16 16" aria-hidden="true">
+    <rect class="tree-node tree-root" x="6" y="2" width="4" height="3" rx="1" />
+    <path class="tree-branch" d="M8 5 V8 M4 8 H12 M4 8 V11 M12 8 V11" />
+    <rect class="tree-node" x="2" y="11" width="4" height="3" rx="1" />
+    <rect class="tree-node" x="10" y="11" width="4" height="3" rx="1" />
+  </svg>
+</div>
 
-## Learn more
+<div class="monorepo-section">
+  <div class="section-inner">
+    <div class="reveal">
+      <div class="section-label">The Structure</div>
+      <h2 class="section-headline">Six directories. Three ship, three support.</h2>
+      <p class="section-body">Three directories carry shippable code; three support it without being shipped. Each carries a README that names the jobs it exists to serve.</p>
+    </div>
+    <div class="dir-band reveal">Carry shippable code</div>
+    <div class="dir-grid stagger">
+      <div class="dir-card stagger-item">
+        <div class="dir-name">products/</div>
+        <p class="dir-desc">User-facing products. Each names the personas it serves and the progress it helps them make.</p>
+      </div>
+      <div class="dir-card stagger-item">
+        <div class="dir-name">services/</div>
+        <p class="dir-desc">Long-running services consumed by products. Each captures the jobs it does for what depends on it.</p>
+      </div>
+      <div class="dir-card stagger-item">
+        <div class="dir-name">libraries/</div>
+        <p class="dir-desc">Shared code consumed by products and services, with the jobs it does for platform builders.</p>
+      </div>
+    </div>
+    <div class="dir-band reveal">Support the code</div>
+    <div class="dir-grid stagger">
+      <div class="dir-card dir-card-soft stagger-item">
+        <div class="dir-name">websites/</div>
+        <p class="dir-desc">Documentation hubs. Every guide maps to a Big Hire or Little Hire it serves.</p>
+      </div>
+      <div class="dir-card dir-card-soft stagger-item">
+        <div class="dir-name">wiki/</div>
+        <p class="dir-desc">Shared working memory. Where humans and agents record what they learn while working.</p>
+      </div>
+      <div class="dir-card dir-card-soft stagger-item">
+        <div class="dir-name">infrastructure/</div>
+        <p class="dir-desc">Deployment assets — Docker, gateway, database, load balancer — each with its own README.</p>
+      </div>
+    </div>
+  </div>
+</div>
 
-- [MONOREPO.md on GitHub](https://github.com/forwardimpact/monorepo/blob/main/MONOREPO.md)
+<div class="tree-divider">
+  <svg viewBox="0 0 16 16" aria-hidden="true">
+    <rect class="tree-node tree-root" x="6" y="2" width="4" height="3" rx="1" />
+    <path class="tree-branch" d="M8 5 V8 M4 8 H12 M4 8 V11 M12 8 V11" />
+    <rect class="tree-node" x="2" y="11" width="4" height="3" rx="1" />
+    <rect class="tree-node" x="10" y="11" width="4" height="3" rx="1" />
+  </svg>
+</div>
+
+<div class="monorepo-section monorepo-section-soft">
+  <div class="section-inner">
+    <div class="reveal">
+      <div class="section-label">The Root Files</div>
+      <h2 class="section-headline">Three files. One job each. None restates another.</h2>
+      <p class="section-body">Open the repository and three files orient you immediately — a link is cheaper than a duplicate, so each points at the others rather than repeating them.</p>
+    </div>
+    <div class="rootfile-grid stagger">
+      <div class="rootfile-card stagger-item">
+        <div class="rootfile-name">CLAUDE.md</div>
+        <div class="rootfile-role">Orients</div>
+        <p class="rootfile-desc">What the project is, who it serves, and where to find things. Auto-loaded on every run.</p>
+      </div>
+      <div class="rootfile-card stagger-item">
+        <div class="rootfile-name">CONTRIBUTING.md</div>
+        <div class="rootfile-role">Governs</div>
+        <p class="rootfile-desc">Invariants, technical rules, git workflow, security policy. Read on demand — every rule verifiable.</p>
+      </div>
+      <div class="rootfile-card stagger-item">
+        <div class="rootfile-name">JTBD.md</div>
+        <div class="rootfile-role">Catalogues</div>
+        <p class="rootfile-desc">The canonical Big Hires — one entry per persona-outcome pair, capturing the progress each persona seeks.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="tree-divider">
+  <svg viewBox="0 0 16 16" aria-hidden="true">
+    <rect class="tree-node tree-root" x="6" y="2" width="4" height="3" rx="1" />
+    <path class="tree-branch" d="M8 5 V8 M4 8 H12 M4 8 V11 M12 8 V11" />
+    <rect class="tree-node" x="2" y="11" width="4" height="3" rx="1" />
+    <rect class="tree-node" x="10" y="11" width="4" height="3" rx="1" />
+  </svg>
+</div>
+
+<div class="monorepo-section">
+  <div class="section-inner">
+    <div class="reveal">
+      <div class="section-label">Jobs To Be Done</div>
+      <h2 class="section-headline">The aim, made discoverable.</h2>
+      <p class="section-body">Jobs live near the code that serves them. Each is wrapped in a semantic <code>&lt;job&gt;</code> tag, so anyone — human or agent — finds every job in the repository with one <code>rg</code> search, no map required.</p>
+    </div>
+    <div class="duo-grid stagger">
+      <div class="job-card stagger-item">
+        <div class="job-kind">The adoption decision</div>
+        <div class="job-name">Big Hire</div>
+        <p class="job-desc">Why a persona hires this product over the alternatives — including hiring nothing at all. One per persona-outcome pair, in JTBD.md.</p>
+      </div>
+      <div class="job-card stagger-item">
+        <div class="job-kind">The repeated daily use</div>
+        <div class="job-name">Little Hire</div>
+        <p class="job-desc">What brings the persona back each time. Lives wherever it fits best — a product, service, or library README, a design doc, nearby code.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="monorepo-section monorepo-section-soft">
+  <div class="section-inner">
+    <div class="reveal">
+      <h2 class="getting-started-label">Stand one up in three lines.</h2>
+      <p class="getting-started-sub">Install the packs. Tell Claude to build the skeleton.</p>
+    </div>
+    <div class="terminal reveal">
+      <div class="terminal-bar">
+        <div class="terminal-dot"></div>
+        <div class="terminal-dot"></div>
+        <div class="terminal-dot"></div>
+        <div class="terminal-title">Terminal</div>
+      </div>
+      <div class="terminal-lines">
+        <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">cd my-new-repo/</span></div>
+        <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">apm install forwardimpact/coaligned-skills forwardimpact/kata-skills</span></div>
+        <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">echo </span><span class="terminal-string">"Set up a Monorepo-standard repo"</span><span class="terminal-cmd"> | claude</span></div>
+      </div>
+    </div>
+    <p class="closing-note reveal">The structure layers an <a href="https://www.coaligned.team/">instruction architecture</a> on top, and the <a href="https://www.kata.team/">Kata Agent Team</a> runs it as a daily loop. Read the full standard in <a href="https://github.com/forwardimpact/monorepo/blob/main/MONOREPO.md">MONOREPO.md</a>.</p>
+  </div>
+</div>

--- a/websites/monorepo/index.template.html
+++ b/websites/monorepo/index.template.html
@@ -20,23 +20,29 @@
     <header class="site-header">
       <div class="header-inner">
         <a class="brand" href="/">
-          <span class="brand-text">Monorepo Team</span>
+          <span class="brand-text">Monorepo</span>
+        </a>
+        <div class="nav-spacer"></div>
+        <a href="https://github.com/forwardimpact/monorepo" class="btn-ghost nav-github" target="_blank" aria-label="GitHub">
+          <img src="https://cdn.simpleicons.org/github/aeaba2" alt="" width="20" height="20" />
         </a>
       </div>
     </header>
-    <main>
+
+    <main{{#layout}} class="layout-{{layout}}"{{/layout}}>
       <div class="page-content">
+        {{^hasHero}}
         <h1 class="page-title">{{{title}}}</h1>
+        {{/hasHero}}
         {{{content}}}
       </div>
     </main>
+
     <footer class="site-footer">
       <div class="footer-inner">
         <div class="footer-column footer-column-left">
-          <span class="footer-heading">Monorepo Team</span>
-          <a href="https://www.coaligned.team/">coaligned.team</a>
-          <a href="https://www.kata.team/">kata.team</a>
-          <a href="https://www.forwardimpact.team/">forwardimpact.team</a>
+          <span class="footer-brand">Monorepo</span>
+          <span class="footer-tagline">Every file traces to a job.</span>
         </div>
         <div class="footer-social">
           <a href="https://github.com/forwardimpact/monorepo" target="_blank" aria-label="GitHub">
@@ -45,9 +51,69 @@
         </div>
         <div class="footer-column footer-column-right">
           <span class="footer-heading">Copyright 2026</span>
-          <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a>
+          <a href="https://www.coaligned.team/">coaligned.team</a>
+          <a href="https://www.kata.team/">kata.team</a>
+          <a href="https://www.forwardimpact.team/">forwardimpact.team</a>
         </div>
       </div>
     </footer>
+
+    <script>
+      // Scroll reveal
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("visible");
+            }
+          });
+        },
+        { threshold: 0.15 }
+      );
+      document.querySelectorAll(".reveal").forEach((el) => observer.observe(el));
+
+      // Header scroll state
+      const header = document.querySelector(".site-header");
+      window.addEventListener("scroll", () => {
+        header.classList.toggle("scrolled", window.scrollY > 10);
+      }, { passive: true });
+
+      // Terminal typing effect
+      const terminal = document.querySelector(".terminal-lines");
+      if (terminal) {
+        const termObserver = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                terminal.classList.add("typing");
+                termObserver.unobserve(entry.target);
+              }
+            });
+          },
+          { threshold: 0.5 }
+        );
+        termObserver.observe(terminal);
+      }
+
+      // Stagger reveal children
+      document.querySelectorAll(".stagger").forEach((container) => {
+        const children = container.querySelectorAll(".stagger-item");
+        const staggerObserver = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                children.forEach((child, i) => {
+                  child.style.transitionDelay = `${i * 80}ms`;
+                  child.classList.add("visible");
+                });
+                staggerObserver.unobserve(entry.target);
+              }
+            });
+          },
+          { threshold: 0.15 }
+        );
+        staggerObserver.observe(container);
+      });
+    </script>
   </body>
 </html>

--- a/websites/monorepo/llms.txt
+++ b/websites/monorepo/llms.txt
@@ -1,0 +1,31 @@
+# Monorepo
+
+> The structure of a repository shared by humans and coding agents —
+> six directories, three root files, and a Jobs To Be Done catalogue.
+
+Monorepo is an open-source standard for the shape of a repository that humans
+and coding agents share. Every directory and every file traces back to a job
+someone is trying to get done — structure without an aim is arbitrary, and an
+aim without structure is invisible.
+
+Six top-level directories carry the work. Three ship code — products,
+services, libraries — each with a README naming the jobs it serves. Three
+support the code without being shipped — websites, wiki, infrastructure.
+
+Three root files orient every contributor, each with one job and none
+restating another: CLAUDE.md orients (what, who, where), CONTRIBUTING.md
+governs (invariants, rules, policy), and JTBD.md catalogues the Big Hires.
+Jobs are wrapped in a semantic `<job>` tag so any of them is discoverable
+from anywhere with one `rg` search.
+
+Monorepo is the structure that Co-Aligned layers an instruction architecture
+on top of, and that the Kata Agent Team implements as a daily loop.
+
+Stand up a new one with `apm install forwardimpact/coaligned-skills
+forwardimpact/kata-skills`, then ask Claude to set up the repository.
+
+## Optional
+
+- [The full standard (MONOREPO.md)](https://github.com/forwardimpact/monorepo/blob/main/MONOREPO.md)
+- [Co-Aligned instruction architecture](https://www.coaligned.team/)
+- [Kata Agent Team](https://www.kata.team/)


### PR DESCRIPTION
## Summary

- Replace the placeholder Co-Aligned (`websites/coaligned/`) and Monorepo (`websites/monorepo/`) pages with full scroll-arc marketing sites, each a projection of its standard (`COALIGNED.md` / `MONOREPO.md`) rather than a restyled copy.
- Both follow the live kata site model: shared `base/layout/components.css`, a brand `main.css` token + component layer, and a home `index.template.html` with scroll-reveal, stagger, and terminal-typing JS.
- **Co-Aligned** — indigo blueprint identity, an 8-bar layer-stack glyph, the L0–L7 layer grid as the centerpiece, JTBD + Checklist Manifesto foundations, and READ-DO / DO-CONFIRM gates. CTA installs `coaligned-skills`.
- **Monorepo** — pine-green identity, a directory-tree glyph, the six directories in ship/support bands, the three root files (Orients/Governs/Catalogues), and the Big Hire / Little Hire jobs section. CTA installs `coaligned-skills` + `kata-skills`.
- Add an `llms.txt` to each site; update `websites/CLAUDE.md` status table (Placeholder → Built) and the publish-pipeline note. No publish workflow yet — that lands when the sites ship.

Verified both sites build with `fit-doc`, walked them top-to-bottom in the browser, and confirmed `coaligned instructions` + `rumdl` pass.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`