### PR TITLE
feat(websites): surface checklist-tag discovery on Co-Aligned site

### DIFF
--- a/websites/coaligned/assets/main.css
+++ b/websites/coaligned/assets/main.css
@@ -292,6 +292,15 @@
   margin-bottom: var(--space-12);
 }
 
+.section-body code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  color: var(--ink-600);
+  background: var(--ink-50);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+}
+
 /* ── Stats ─────────────────────────────────────────────────────── */
 
 .stats-grid {
@@ -423,6 +432,18 @@
   font-size: var(--text-body-size);
   color: var(--gray-400);
   line-height: 1.6;
+}
+
+.gate-find {
+  display: inline-block;
+  margin-top: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--ink-600);
+  background: var(--ink-50);
+  border: 1px solid var(--ink-100);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
 }
 
 /* ── Getting Started ───────────────────────────────────────────── */

--- a/websites/coaligned/index.md
+++ b/websites/coaligned/index.md
@@ -154,18 +154,20 @@ layout: home
     <div class="reveal">
       <div class="section-label">Verification</div>
       <h2 class="section-headline">Two gates. One at entry, one at exit.</h2>
-      <p class="section-body">Checklists never teach — they confirm. If an item needs explaining, the procedure above it is incomplete. Pick the right type for the moment, and the pause point stays natural instead of getting skipped.</p>
+      <p class="section-body">Checklists never teach — they confirm; if an item needs explaining, the procedure above it is incomplete. Each gate is wrapped in a semantic <code>&lt;read_do_checklist&gt;</code> or <code>&lt;do_confirm_checklist&gt;</code> tag, so every pause point in the repository is one <code>rg</code> search away — no map required.</p>
     </div>
     <div class="duo-grid stagger">
       <div class="gate-card stagger-item">
         <div class="gate-kind">Entry gate</div>
         <div class="gate-name">READ-DO</div>
         <p class="gate-desc">Read each item, then do it. Loads constraints into memory before the first line of work, when missing one sends everything in the wrong direction.</p>
+        <code class="gate-find">rg '&lt;read_do_checklist'</code>
       </div>
       <div class="gate-card stagger-item">
         <div class="gate-kind">Exit gate</div>
         <div class="gate-name">DO-CONFIRM</div>
         <p class="gate-desc">Do from memory, then pause and confirm. Verifies nothing was missed before a commit, merge, or release — independent checks, no interruption mid-flow.</p>
+        <code class="gate-find">rg '&lt;do_confirm_checklist'</code>
       </div>
     </div>
   </div>

--- a/websites/coaligned/llms.txt
+++ b/websites/coaligned/llms.txt
@@ -14,6 +14,11 @@ answers what agents align to: the progress each persona seeks, not a feature
 list. The Checklist Manifesto (Gawande) answers how alignment holds under
 load: structured instructions keep existing knowledge consistently applied.
 
+The lowest layer, verification, uses two checklist gates. Each is wrapped in
+a semantic tag — `<read_do_checklist>` for entry gates, `<do_confirm_checklist>`
+for exit gates — so every pause point in a repository is discoverable from
+anywhere with one `rg` search.
+
 Co-Aligned builds on the Monorepo structure standard and is the upstream
 architecture the Kata Agent Team implements.
 


### PR DESCRIPTION
## Summary

- Mirror the Monorepo site's `<job>` / `rg` discovery pattern on the Co-Aligned site, as an evergreen part of the brand layer rather than a one-off.
- The Verification section body now carries inline `<read_do_checklist>`, `<do_confirm_checklist>`, and `rg` chips, and each gate card carries its literal `rg '<…'` discovery command — so a reader sees exactly how to find every pause point in a repository.
- Structurally: `.section-body code` becomes a first-class chip in the Co-Aligned brand layer (matching Monorepo), and a new `.gate-find` rule ties each gate to its exact discovery command. `llms.txt` gains the same discovery note.

Verified the site builds with `fit-doc`, confirmed the chips render in the browser, and `coaligned instructions` + `rumdl` pass.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`