### PR TITLE
feat(libterrain,libsyntheticrender): external execution + clinical prose SQL tables

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "libraries/libcoaligned": {
       "name": "@forwardimpact/libcoaligned",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "bin": {
         "coaligned": "./bin/coaligned.js",
       },
@@ -153,7 +153,7 @@
     },
     "libraries/libharness": {
       "name": "@forwardimpact/libharness",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "bin": {
         "fit-harness": "./bin/fit-harness.js",
         "fit-trace": "./bin/fit-trace.js",
@@ -503,6 +503,7 @@
         "@forwardimpact/libtelemetry": "^0.1.23",
         "@forwardimpact/libtemplate": "^0.2.0",
         "@forwardimpact/libutil": "^0.1.0",
+        "@forwardimpact/map": "^0.15.61",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -579,7 +580,7 @@
     },
     "libraries/libwiki": {
       "name": "@forwardimpact/libwiki",
-      "version": "0.2.31",
+      "version": "0.2.33",
       "bin": {
         "fit-wiki": "./bin/fit-wiki.js",
       },
@@ -613,7 +614,7 @@
     },
     "products/gear": {
       "name": "@forwardimpact/gear",
-      "version": "0.1.6",
+      "version": "0.1.12",
       "dependencies": {
         "@forwardimpact/libcodegen": "^0.1.49",
         "@forwardimpact/libdoc": "^0.2.24",

--- a/libraries/libsyntheticrender/src/render/render-sql.js
+++ b/libraries/libsyntheticrender/src/render/render-sql.js
@@ -86,17 +86,89 @@ const JUNCTIONS = [
   },
 ];
 
+// Patient-facing prose tables. Each is one text column keyed off a base entity
+// plus its foreign key, except `patient_stories` which fans out to several
+// rows per condition. `rows(clinical, cache)` resolves the prose text from the
+// cache under the exact logical keys the generator emits (see
+// libsyntheticgen clinicalProseKeys), so ids line up with cache entries.
+const PROSE_TABLE_SPEC = [
+  {
+    key: "condition_explainers",
+    table: "condition_explainers",
+    pk: "condition_id",
+    foreignKeys: [{ column: "condition_id", references: "conditions(id)" }],
+    rows: (c, cache) =>
+      (c.conditions ?? []).map((x) => ({
+        condition_id: x.id,
+        explainer: cache.get(`clinical_condition_explainer_${x.id}`) ?? null,
+      })),
+  },
+  {
+    key: "trial_faqs",
+    table: "trial_faqs",
+    pk: "trial_id",
+    foreignKeys: [{ column: "trial_id", references: "trials(id)" }],
+    rows: (c, cache) =>
+      (c.trials ?? []).map((x) => ({
+        trial_id: x.id,
+        faq: cache.get(`clinical_trial_faq_${x.id}`) ?? null,
+      })),
+  },
+  {
+    key: "consent_summaries",
+    table: "consent_summaries",
+    pk: "trial_id",
+    foreignKeys: [{ column: "trial_id", references: "trials(id)" }],
+    rows: (c, cache) =>
+      (c.trials ?? []).map((x) => ({
+        trial_id: x.id,
+        summary: cache.get(`clinical_consent_summary_${x.id}`) ?? null,
+      })),
+  },
+  {
+    key: "site_descriptions",
+    table: "site_descriptions",
+    pk: "site_id",
+    foreignKeys: [{ column: "site_id", references: "sites(id)" }],
+    rows: (c, cache) =>
+      (c.sites ?? []).map((x) => ({
+        site_id: x.id,
+        description: cache.get(`clinical_site_description_${x.id}`) ?? null,
+      })),
+  },
+  {
+    key: "patient_stories",
+    table: "patient_stories",
+    pk: "id",
+    foreignKeys: [{ column: "condition_id", references: "conditions(id)" }],
+    rows: (c, cache) => patientStoryRows(c, cache),
+  },
+  {
+    key: "therapy_descriptions",
+    table: "therapy_descriptions",
+    pk: "topic",
+    rows: (c, cache) =>
+      (c.content?.therapy_topics ?? []).map((topic) => ({
+        topic,
+        description: cache.get(`clinical_therapy_description_${topic}`) ?? null,
+      })),
+  },
+];
+
 /**
  * Render coordinated Supabase migration files for a clinical entity graph.
  *
  * @param {object} clinicalEntities - `entities.clinical` from the generator
  * @param {object} outputConfig - `{ path, prefix, entities, include_embeddings }`.
  *   `path`, when present, prefixes every emitted filename (directory layout).
+ * @param {Map<string, string>|object} [prose] - resolved prose cache keyed by
+ *   logical key; supplies the text columns of the patient-facing prose tables.
  * @returns {Map<string, string>} path → file content
  */
-export function renderSql(clinicalEntities, outputConfig) {
+export function renderSql(clinicalEntities, outputConfig, prose) {
   const prefix = outputConfig.prefix ?? "clinical";
   const dir = normalizeDir(outputConfig.path);
+  const cache = toCache(prose);
   const requested = new Set(
     (outputConfig.entities ?? []).map((e) => stripDomain(e)),
   );
@@ -105,6 +177,9 @@ export function renderSql(clinicalEntities, outputConfig) {
   const includedKeys = new Set(includedSpecs.map((s) => s.key));
   const includedJunctions = JUNCTIONS.filter(
     (j) => includedKeys.has(j.sourceKey) && includedKeys.has(j.arrayField),
+  );
+  const includedProseSpecs = PROSE_TABLE_SPEC.filter((s) =>
+    requested.has(s.key),
   );
 
   const files = new Map();
@@ -128,9 +203,19 @@ export function renderSql(clinicalEntities, outputConfig) {
     );
   }
 
+  // Prose tables reference conditions/trials/sites, so they render after the
+  // base tables — the numbered filenames preserve that FK-apply order.
+  for (const spec of includedProseSpecs) {
+    files.set(
+      filePath(`${prefix}_${next()}_${spec.table}.sql`),
+      renderEntityTable(spec, spec.rows(clinicalEntities, cache)),
+    );
+  }
+
   const allTables = [
     ...includedSpecs.map((s) => s.table),
     ...includedJunctions.map((j) => j.table),
+    ...includedProseSpecs.map((s) => s.table),
   ];
   files.set(filePath(`${prefix}_${next()}_rls.sql`), renderRls(allTables));
 
@@ -144,6 +229,9 @@ export function renderSql(clinicalEntities, outputConfig) {
   return files;
 }
 
+// Prose specs declare no skip set — their row objects carry only real columns.
+const EMPTY_SKIP = new Set();
+
 function normalizeDir(path) {
   if (!path) return "";
   return path.endsWith("/") ? path : `${path}/`;
@@ -152,6 +240,40 @@ function normalizeDir(path) {
 function stripDomain(entityRef) {
   const dot = entityRef.indexOf(".");
   return dot === -1 ? entityRef : entityRef.slice(dot + 1);
+}
+
+function toCache(cache) {
+  if (cache instanceof Map) return cache;
+  return new Map(Object.entries(cache ?? {}));
+}
+
+/**
+ * Reproduce the generator's patient-story distribution so each row's id matches
+ * a prose cache key. For every condition listed in
+ * `content.patient_story_conditions`, emit `perCondition` rows
+ * (`ceil(patient_stories / conditions)`); conditions absent from the graph are
+ * skipped exactly as `clinicalProseKeys` skips them, keeping ids and FKs valid.
+ */
+function patientStoryRows(clinical, cache) {
+  const content = clinical.content;
+  if (!content) return [];
+  const storyConditions = content.patient_story_conditions ?? [];
+  const total = content.patient_stories ?? 0;
+  const perCondition = Math.ceil(total / Math.max(storyConditions.length, 1));
+  const rows = [];
+  for (const condId of storyConditions) {
+    const cond = (clinical.conditions ?? []).find((c) => c.id === condId);
+    if (!cond) continue;
+    for (let i = 0; i < perCondition; i++) {
+      rows.push({
+        id: `${condId}_${i}`,
+        condition_id: condId,
+        story_index: i,
+        story: cache.get(`clinical_patient_story_${condId}_${i}`) ?? null,
+      });
+    }
+  }
+  return rows;
 }
 
 function renderEntityTable(spec, records) {
@@ -184,10 +306,11 @@ function renderEntityTable(spec, records) {
 function inferColumns(spec, records) {
   const direct = [];
   const seen = new Set();
+  const skip = spec.skip ?? EMPTY_SKIP;
   for (const rec of records) {
     for (const key of Object.keys(rec)) {
       if (seen.has(key)) continue;
-      if (spec.skip.has(key)) continue;
+      if (skip.has(key)) continue;
       seen.add(key);
       direct.push({
         name: key,

--- a/libraries/libsyntheticrender/test/render-sql-prose.test.js
+++ b/libraries/libsyntheticrender/test/render-sql-prose.test.js
@@ -1,0 +1,217 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { renderSql } from "../src/render/render-sql.js";
+
+// Minimal clinical graph plus the `content` block the prose tables iterate.
+// perCondition for patient stories = ceil(patient_stories / conditions) =
+// ceil(4 / 2) = 2, so two stories per listed condition.
+function makeClinical() {
+  return {
+    conditions: [
+      { id: "c1", name: "Condition One" },
+      { id: "c2", name: "Condition Two" },
+    ],
+    sites: [{ id: "s1", name: "Site One" }],
+    researchers: [],
+    trials: [{ id: "t1", name: "Trial One" }],
+    criteria: [],
+    content: {
+      patient_story_conditions: ["c1", "c2"],
+      patient_stories: 4,
+      therapy_topics: ["immunotherapy", "chemo"],
+    },
+  };
+}
+
+function makeProse() {
+  return new Map([
+    ["clinical_condition_explainer_c1", "Explainer for c1."],
+    ["clinical_condition_explainer_c2", "Explainer for c2."],
+    ["clinical_trial_faq_t1", "FAQ for t1."],
+    ["clinical_consent_summary_t1", "Consent summary for t1."],
+    ["clinical_site_description_s1", "Description for s1."],
+    ["clinical_patient_story_c1_0", "Story c1 0."],
+    ["clinical_patient_story_c1_1", "Story c1 1."],
+    ["clinical_patient_story_c2_0", "Story c2 0."],
+    ["clinical_patient_story_c2_1", "Story c2 1."],
+    ["clinical_therapy_description_immunotherapy", "Immunotherapy overview."],
+    ["clinical_therapy_description_chemo", "Chemo overview."],
+  ]);
+}
+
+const PROSE_ENTITIES = [
+  "clinical.condition_explainers",
+  "clinical.trial_faqs",
+  "clinical.consent_summaries",
+  "clinical.site_descriptions",
+  "clinical.patient_stories",
+  "clinical.therapy_descriptions",
+];
+
+const ALL_ENTITIES = [
+  "clinical.conditions",
+  "clinical.sites",
+  "clinical.researchers",
+  "clinical.trials",
+  "clinical.criteria",
+  ...PROSE_ENTITIES,
+];
+
+describe("renderSql prose tables", () => {
+  test("emits a file per requested prose entity with resolved text", () => {
+    const out = renderSql(
+      makeClinical(),
+      { prefix: "bn", entities: ALL_ENTITIES },
+      makeProse(),
+    );
+
+    const explainers = out.get("bn_008_condition_explainers.sql");
+    assert.ok(
+      explainers.includes('CREATE TABLE IF NOT EXISTS "condition_explainers"'),
+    );
+    assert.ok(explainers.includes('"condition_id" text PRIMARY KEY'));
+    assert.ok(explainers.includes('"explainer" text'));
+    assert.ok(
+      explainers.includes(
+        'FOREIGN KEY ("condition_id") REFERENCES conditions(id)',
+      ),
+    );
+    assert.ok(explainers.includes("$$Explainer for c1.$$"));
+
+    assert.ok(out.get("bn_009_trial_faqs.sql").includes("$$FAQ for t1.$$"));
+    assert.ok(
+      out
+        .get("bn_010_consent_summaries.sql")
+        .includes("$$Consent summary for t1.$$"),
+    );
+    assert.ok(
+      out
+        .get("bn_011_site_descriptions.sql")
+        .includes("$$Description for s1.$$"),
+    );
+    const therapy = out.get("bn_013_therapy_descriptions.sql");
+    assert.ok(therapy.includes('"topic" text PRIMARY KEY'));
+    assert.ok(therapy.includes("$$Immunotherapy overview.$$"));
+    assert.ok(therapy.includes("$$Chemo overview.$$"));
+  });
+
+  test("patient_stories fans out perCondition rows with matching ids", () => {
+    const out = renderSql(
+      makeClinical(),
+      { prefix: "bn", entities: ALL_ENTITIES },
+      makeProse(),
+    );
+    const stories = out.get("bn_012_patient_stories.sql");
+    assert.ok(stories.includes('"id" text PRIMARY KEY'));
+    assert.ok(stories.includes('"condition_id" text'));
+    assert.ok(stories.includes('"story_index" integer'));
+    assert.ok(
+      stories.includes(
+        'FOREIGN KEY ("condition_id") REFERENCES conditions(id)',
+      ),
+    );
+    for (const id of ["c1_0", "c1_1", "c2_0", "c2_1"]) {
+      assert.ok(stories.includes(`$$${id}$$`), `missing story id ${id}`);
+    }
+    // Four story rows: count the dollar-quoted ids in the VALUES list.
+    const idMatches = stories.match(/\$\$c\d_\d\$\$/g) ?? [];
+    assert.strictEqual(idMatches.length, 4);
+  });
+
+  test("prose tables get public_read RLS alongside base tables", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+    });
+    const rls = out.get("bn_014_rls.sql");
+    for (const t of [
+      "condition_explainers",
+      "trial_faqs",
+      "consent_summaries",
+      "site_descriptions",
+      "patient_stories",
+      "therapy_descriptions",
+    ]) {
+      assert.ok(
+        rls.includes(`ALTER TABLE "${t}" ENABLE ROW LEVEL SECURITY`),
+        `RLS missing ALTER for ${t}`,
+      );
+      assert.ok(
+        rls.includes(`CREATE POLICY "public_read" ON "${t}"`),
+        `RLS missing policy for ${t}`,
+      );
+    }
+  });
+
+  test("prose tables render after base tables (FK-apply order)", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+    });
+    const paths = [...out.keys()];
+    assert.deepStrictEqual(paths, [
+      "bn_001_conditions.sql",
+      "bn_002_sites.sql",
+      "bn_003_researchers.sql",
+      "bn_004_trials.sql",
+      "bn_005_criteria.sql",
+      "bn_006_trial_sites.sql",
+      "bn_007_trial_conditions.sql",
+      "bn_008_condition_explainers.sql",
+      "bn_009_trial_faqs.sql",
+      "bn_010_consent_summaries.sql",
+      "bn_011_site_descriptions.sql",
+      "bn_012_patient_stories.sql",
+      "bn_013_therapy_descriptions.sql",
+      "bn_014_rls.sql",
+    ]);
+  });
+
+  test("omitting prose refs keeps the base 5-table output unchanged", () => {
+    const baseEntities = [
+      "clinical.conditions",
+      "clinical.sites",
+      "clinical.researchers",
+      "clinical.trials",
+      "clinical.criteria",
+    ];
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: baseEntities,
+    });
+    const paths = [...out.keys()];
+    assert.ok(!paths.some((p) => p.includes("condition_explainers")));
+    assert.ok(!paths.some((p) => p.includes("patient_stories")));
+    // conditions..criteria + trial_sites + trial_conditions + rls = 8
+    assert.strictEqual(out.size, 8);
+  });
+
+  test("missing prose resolves to NULL, not a thrown error", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ["clinical.condition_explainers"],
+    }); // no prose cache passed at all
+    const explainers = out.get("bn_001_condition_explainers.sql");
+    assert.ok(explainers.includes("NULL"));
+  });
+
+  test("render is byte-identical across repeated runs (determinism)", () => {
+    const a = renderSql(
+      makeClinical(),
+      {
+        prefix: "bn",
+        entities: ALL_ENTITIES,
+      },
+      makeProse(),
+    );
+    const b = renderSql(
+      makeClinical(),
+      {
+        prefix: "bn",
+        entities: ALL_ENTITIES,
+      },
+      makeProse(),
+    );
+    assert.deepStrictEqual([...a.entries()], [...b.entries()]);
+  });
+});

--- a/libraries/libterrain/bin/fit-terrain.js
+++ b/libraries/libterrain/bin/fit-terrain.js
@@ -4,7 +4,8 @@
 
 import "@forwardimpact/libpreflight/node22";
 
-import { join } from "path";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import { format } from "prettier";
 import {
   createCli,
@@ -55,6 +56,16 @@ const definition = {
   globalOptions: {
     story: { type: "string", description: "Path to a custom story DSL file" },
     cache: { type: "string", description: "Path to prose cache file" },
+    "output-root": {
+      type: "string",
+      description:
+        "Directory to write generated output into (default: project root)",
+    },
+    "schema-dir": {
+      type: "string",
+      description:
+        "Directory of map JSON schemas for pathway rendering (default: resolved from @forwardimpact/map)",
+    },
     help: { type: "boolean", short: "h", description: "Show this help" },
     version: { type: "boolean", description: "Show version" },
     json: { type: "boolean", description: "Output help as JSON" },
@@ -165,6 +176,27 @@ async function resolveLlmApi(config, modelOverride) {
 }
 
 /**
+ * Resolve the map JSON-schema directory from the installed `@forwardimpact/map`
+ * package. Pathway rendering reads nine `<name>.schema.json` files from here.
+ * Returns `null` when the package is not installed, so the pipeline cleanly
+ * skips pathway rendering rather than crashing — an external consumer that only
+ * renders clinical output (Polaris's case) need not depend on `map`.
+ *
+ * Called directly in this module so `this === import.meta`, which Bun requires
+ * for `import.meta.resolve`.
+ */
+function defaultSchemaDir() {
+  try {
+    const url = import.meta.resolve(
+      "@forwardimpact/map/schema/json/standard.schema.json",
+    );
+    return dirname(fileURLToPath(url));
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Run the pipeline for the given verb. Returns whether the verb succeeded;
  * the caller maps that to process.exitCode.
  *
@@ -175,6 +207,8 @@ async function resolveLlmApi(config, modelOverride) {
  * @param {string} [options.model]
  * @param {string} [options.story]
  * @param {string} [options.cache]
+ * @param {string} [options.outputRoot]
+ * @param {string} [options.schemaDir]
  * @returns {Promise<{ ok: boolean }>}
  */
 async function runVerb(options) {
@@ -197,7 +231,11 @@ async function runVerb(options) {
   // handles the compiled-vs-source split: cwd for a compiled binary, upward
   // package.json search otherwise — so this stays free of build-mode checks.
   const monorepoRoot = runtime.finder.findProjectRoot();
-  const schemaDir = join(monorepoRoot, "products/map/schema/json");
+  // Read root (story/cache/schema defaults) stays the resolved project root.
+  // Only the *write* target moves when `--output-root` is given, so an external
+  // consumer renders into a disposable directory it owns.
+  const outputRoot = options.outputRoot || monorepoRoot;
+  const schemaDir = options.schemaDir || defaultSchemaDir();
   const cachePath =
     options.cache ||
     join(monorepoRoot, "data", "synthetic", "prose-cache.json");
@@ -233,7 +271,7 @@ async function runVerb(options) {
   const sink = await selectOutputSink({
     verb,
     load: !!options.load,
-    monorepoRoot,
+    outputRoot,
     prettierFn: format,
     logger,
     config,
@@ -355,6 +393,8 @@ async function main() {
       model: values.model,
       story: values.story,
       cache: values.cache,
+      outputRoot: values["output-root"],
+      schemaDir: values["schema-dir"],
     }));
   } catch (err) {
     if (

--- a/libraries/libterrain/package.json
+++ b/libraries/libterrain/package.json
@@ -46,6 +46,7 @@
     "@forwardimpact/libcli": "^0.1.0",
     "@forwardimpact/libutil": "^0.1.0",
     "@forwardimpact/libconfig": "^0.1.59",
+    "@forwardimpact/map": "^0.15.61",
     "@forwardimpact/libpreflight": "^0.1.0",
     "@forwardimpact/libprompt": "^0.1.0",
     "@forwardimpact/libsyntheticgen": "^0.1.0",

--- a/libraries/libterrain/src/cli-helpers.js
+++ b/libraries/libterrain/src/cli-helpers.js
@@ -190,7 +190,7 @@ export function createPipeline(opts) {
 export async function selectOutputSink({
   verb,
   load,
-  monorepoRoot,
+  outputRoot,
   prettierFn,
   logger,
   config,
@@ -201,7 +201,7 @@ export async function selectOutputSink({
   if (verb !== "build" && verb !== "generate") return new NullSink();
 
   const writeSink = new WriteSink({
-    monorepoRoot,
+    outputRoot,
     prettierFn,
     logger,
     runtime,

--- a/libraries/libterrain/src/nodes.js
+++ b/libraries/libterrain/src/nodes.js
@@ -540,7 +540,7 @@ function unwrapFhirDatasets(datasetsMap, out, domain, crossRef) {
 
 function renderClinicalOutput(out, clinical, prose) {
   if (out.format === "supabase_migration") {
-    return renderSql(clinical, out.config);
+    return renderSql(clinical, out.config, prose);
   }
   return renderEmbeddings(clinical, prose, out.config);
 }

--- a/libraries/libterrain/src/sinks.js
+++ b/libraries/libterrain/src/sinks.js
@@ -10,7 +10,7 @@
  * @module libterrain/sinks
  */
 
-import { join, dirname } from "path";
+import { join, dirname, relative, isAbsolute } from "path";
 import {
   ContentFormatter,
   formatContent,
@@ -39,17 +39,20 @@ export class NullSink {
   }
 }
 
-/** Sink that formats pipeline output with Prettier and writes files to disk under the monorepo root. */
+/** Sink that formats pipeline output with Prettier and writes files to disk under the output root. */
 export class WriteSink {
   /**
-   * @param {{ monorepoRoot: string, prettierFn: Function, logger: object, runtime?: import('@forwardimpact/libutil/runtime').Runtime }} options
+   * @param {{ outputRoot: string, prettierFn: Function, logger: object, runtime?: import('@forwardimpact/libutil/runtime').Runtime }} options
+   *   `outputRoot` is the directory every generated file is written beneath; in
+   *   the monorepo it is the repo root, but an external consumer points it at a
+   *   disposable build directory via `fit-terrain --output-root`.
    */
-  constructor({ monorepoRoot, prettierFn, logger, runtime }) {
-    if (!monorepoRoot) throw new Error("monorepoRoot is required");
+  constructor({ outputRoot, prettierFn, logger, runtime }) {
+    if (!outputRoot) throw new Error("outputRoot is required");
     if (!prettierFn) throw new Error("prettierFn is required");
     if (!logger) throw new Error("logger is required");
     if (!runtime) throw new Error("runtime is required");
-    this.monorepoRoot = monorepoRoot;
+    this.outputRoot = outputRoot;
     this.formatter = new ContentFormatter(prettierFn, logger);
     this.logger = logger;
     this._fs = runtime.fs;
@@ -68,22 +71,20 @@ export class WriteSink {
 
     const filesWritten = await writeFiles(
       formattedFiles,
-      this.monorepoRoot,
+      this.outputRoot,
       this._fs,
+      this.logger,
     );
 
     let rawWritten = 0;
     if (formattedRaw.size > 0) {
-      await writeRawLocally(formattedRaw, this.monorepoRoot, this._fs);
+      await writeRawLocally(formattedRaw, this.outputRoot, this._fs);
       rawWritten = formattedRaw.size;
     }
 
     const evidence = result.entities?.activity?.evidence;
     if (evidence) {
-      const evidencePath = join(
-        this.monorepoRoot,
-        "data/activity/evidence.json",
-      );
+      const evidencePath = join(this.outputRoot, "data/activity/evidence.json");
       await this._fs.mkdir(dirname(evidencePath), { recursive: true });
       const formatted = await formatContent(
         evidencePath,
@@ -256,24 +257,55 @@ async function ensureDirs(paths, fs) {
 }
 
 /**
- * Write a Map of relative paths → content under the monorepo root. Cleans
- * each top-level subdirectory before writing so removed entities don't linger.
+ * True when `dir` is a strict descendant of `root` — not `root` itself and not
+ * a path that escapes it via `..`. Guards the destructive clean in
+ * `writeFiles` so a stray output path can never `rm -rf` the output root or
+ * anything outside it (the primary risk when `fit-terrain` runs in a
+ * consumer's repo via `--output-root`).
  */
-async function writeFiles(files, monorepoRoot, fs) {
+function isInside(root, dir) {
+  const rel = relative(root, dir);
+  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+}
+
+/**
+ * Write a Map of relative paths → content under the output root. Cleans each
+ * top-level subdirectory before writing so removed entities don't linger.
+ * Both the directories cleaned and the files written must be strict
+ * descendants of `outputRoot`; a path that would escape it is a fatal error
+ * raised before any `rm` runs, rather than a silent write outside the root.
+ */
+async function writeFiles(files, outputRoot, fs, logger) {
+  // Validate every write target before any destructive action. A clean dir can
+  // resolve inside the root while the full path still escapes (`a/b/../../..`),
+  // so both are checked: full paths here, the cleaned dirs below.
+  const entries = [...files].map(([relPath, content]) => {
+    const fullPath = join(outputRoot, relPath);
+    if (!isInside(outputRoot, fullPath)) {
+      throw new Error(
+        `refusing to write '${fullPath}': escapes output root '${outputRoot}'`,
+      );
+    }
+    return [fullPath, content];
+  });
+
   const generatedDirs = new Set();
   for (const relPath of files.keys()) {
     const parts = relPath.split("/");
     if (parts.length >= 2) {
-      generatedDirs.add(join(monorepoRoot, parts[0], parts[1]));
+      const dir = join(outputRoot, parts[0], parts[1]);
+      if (!isInside(outputRoot, dir)) {
+        throw new Error(
+          `refusing to clean '${dir}': escapes output root '${outputRoot}'`,
+        );
+      }
+      generatedDirs.add(dir);
     }
   }
   for (const dir of generatedDirs) {
+    logger?.info?.("write", `cleaning ${dir}`);
     await fs.rm(dir, { recursive: true, force: true });
   }
-  const entries = [...files].map(([relPath, content]) => [
-    join(monorepoRoot, relPath),
-    content,
-  ]);
   await ensureDirs(
     entries.map(([fullPath]) => fullPath),
     fs,
@@ -284,8 +316,8 @@ async function writeFiles(files, monorepoRoot, fs) {
   return files.size;
 }
 
-async function writeRawLocally(rawDocuments, monorepoRoot, fs) {
-  const rawRoot = join(monorepoRoot, "data/activity/raw");
+async function writeRawLocally(rawDocuments, outputRoot, fs) {
+  const rawRoot = join(outputRoot, "data/activity/raw");
   const entries = [...rawDocuments].map(([storagePath, content]) => [
     join(rawRoot, storagePath),
     content,

--- a/libraries/libterrain/test/sinks.test.js
+++ b/libraries/libterrain/test/sinks.test.js
@@ -83,7 +83,7 @@ describe("WriteSink", () => {
     });
 
     const sink = new WriteSink({
-      monorepoRoot: ROOT,
+      outputRoot: ROOT,
       prettierFn: format,
       runtime,
       logger: makeLogger(),
@@ -126,7 +126,7 @@ describe("WriteSink", () => {
     });
 
     const sink = new WriteSink({
-      monorepoRoot: ROOT,
+      outputRoot: ROOT,
       prettierFn: format,
       runtime,
       logger: makeLogger(),
@@ -146,7 +146,7 @@ describe("WriteSink", () => {
       files: new Map([["data/knowledge/x.html", "<p>hi</p>"]]),
     });
     const sink = new WriteSink({
-      monorepoRoot: ROOT,
+      outputRoot: ROOT,
       prettierFn: format,
       runtime,
       logger: makeLogger(),
@@ -156,6 +156,63 @@ describe("WriteSink", () => {
       fs.existsSync(join(ROOT, "data/activity/evidence.json")),
       false,
     );
+  });
+
+  test("writes under a caller-chosen outputRoot, not the project root", async () => {
+    const BUILD = "/build/.synthetic";
+    const { fs, runtime } = fsRuntime();
+    const result = makeResult({
+      files: new Map([["products/polaris/site/seed.sql", "select 1;\n"]]),
+    });
+    const sink = new WriteSink({
+      outputRoot: BUILD,
+      prettierFn: format,
+      runtime,
+      logger: makeLogger(),
+    });
+    await sink.accept(result);
+
+    assert.ok(
+      fs.existsSync(join(BUILD, "products/polaris/site/seed.sql")),
+      "file should land under the output root",
+    );
+    assert.strictEqual(
+      fs.existsSync(join(ROOT, "products/polaris/site/seed.sql")),
+      false,
+      "nothing should be written under the project root",
+    );
+  });
+
+  test("refuses to clean a directory that escapes the output root", async () => {
+    const { runtime } = fsRuntime();
+    // A relative path climbing out of the output root would otherwise resolve
+    // the clean target to a sibling of the root — the catastrophic rm the guard
+    // exists to prevent.
+    const result = makeResult({
+      files: new Map([["../../evil/x.txt", "boom"]]),
+    });
+    const sink = new WriteSink({
+      outputRoot: ROOT,
+      prettierFn: format,
+      runtime,
+      logger: makeLogger(),
+    });
+    await assert.rejects(() => sink.accept(result), /escapes output root/);
+  });
+
+  test("refuses a write whose full path escapes even when its top dir stays inside", async () => {
+    const { runtime } = fsRuntime();
+    // "a/b" stays inside so the clean guard passes, but the full path escapes.
+    const result = makeResult({
+      files: new Map([["a/b/../../../../etc/passwd", "boom"]]),
+    });
+    const sink = new WriteSink({
+      outputRoot: ROOT,
+      prettierFn: format,
+      runtime,
+      logger: makeLogger(),
+    });
+    await assert.rejects(() => sink.accept(result), /escapes output root/);
   });
 });
 
@@ -250,7 +307,7 @@ describe("CompositeSink", () => {
     });
 
     const writeSink = new WriteSink({
-      monorepoRoot: ROOT,
+      outputRoot: ROOT,
       prettierFn: format,
       runtime,
       logger: makeLogger(),


### PR DESCRIPTION
## Summary

Library prerequisites that unblock spec 1160 (BioNova Polaris), which vendors `story.dsl` and runs `fit-terrain build` itself to render its database seed. Both were blocking: today `fit-terrain` hardcodes monorepo paths (and would `rm -rf` a consumer's source tree), and the six clinical prose types never reach SQL.

**Prerequisite A — `fit-terrain` runs outside the monorepo** (`libterrain`)
- `--output-root` moves only the write target; story/cache/schema reads stay at the project root. Defaults to the root, so in-monorepo behavior is unchanged.
- `WriteSink`'s `monorepoRoot` becomes `outputRoot` end to end. The destructive pre-write clean now refuses any directory that is not a strict descendant of the output root — validating both the cleaned dirs and the full write paths before any `rm` — and logs each removal.
- `--schema-dir` defaults to the schema dir resolved from `@forwardimpact/map` (added as a dependency) and degrades to `null` (cleanly skipping pathway rendering) when the package is absent.

**Prerequisite B — clinical prose → SQL seed tables** (`libsyntheticrender` + `libterrain` node)
- The prose cache is threaded into `renderSql`; `PROSE_TABLE_SPEC` emits one table per prose type.
- `patientStoryRows` reproduces the generator's `perCondition = ceil(stories / conditions)` distribution and skip-unknown-condition exactly, so row ids match the cached logical keys.
- Prose tables render after the base tables (FK-apply order) and join the RLS file with `public_read`. Missing prose resolves to `NULL` deterministically.

Verified end to end: a build into a disposable `--output-root` from the real `story.dsl` + committed cache emits all six prose tables (cardinalities 6/6/6/5/12/6, RLS covering all of them), needs no `ANTHROPIC_API_KEY`, leaves the source tree untouched, and re-renders byte-identically.

Reviewed by a 3-agent panel (unanimous SHIP); quorum findings addressed: write-path guard hardened (now covers the full path, not just the rm target) and redundant `skip` boilerplate removed.

## Follow-up (not in scope here)

- `libsyntheticrender/src/render/render-embeddings.js` maps a trial's `prose-description` field to `clinical_consent_summary_${id}` — a latent mapping quirk unrelated to this PR's SQL path. Noting it so it isn't lost; left for a separate change.
- Release-train version bumps for `libterrain` / `libsyntheticrender` are handled at release-cut time, not in this feature diff.

## Test plan

- [ ] \`bun run check\`
- [ ] \`bun run test\`