### PR TITLE
fix(skills): verify setup on a clean run, not the author's machine

### DIFF
--- a/.claude/skills/coaligned-setup/SKILL.md
+++ b/.claude/skills/coaligned-setup/SKILL.md
@@ -3,8 +3,8 @@ name: coaligned-setup
 description: >
   Bootstrap the Co-Aligned instruction architecture in a repository. Use
   when a repo has no layered agent instructions yet, when adopting the
-  Co-Aligned standard, or when wiring `npx coaligned` into the checks so
-  instruction layers, jobs, and invariants stay enforced.
+  Co-Aligned standard, or when wiring the `coaligned` checks into the
+  repository so instruction layers, jobs, and invariants stay enforced.
 ---
 
 # coaligned-setup
@@ -12,7 +12,7 @@ description: >
 Stand up the
 [Co-Aligned](https://www.coaligned.team/)
 instruction architecture in a repository: the root identity and jobs files, the
-invariant directory, and the `npx coaligned` checks that keep them honest.
+invariant directory, and the `coaligned` checks that keep them honest.
 
 Run this once per repository. For ongoing work use the sibling skills:
 [coaligned-layer](../coaligned-layer/SKILL.md) for instruction layers,
@@ -41,7 +41,7 @@ preference.
   generation.
 - **Generated `.jobs` blocks** — the repo is genuinely many packages, each
   with its own `package.json`. Each package declares `jobs` in its manifest;
-  `npx coaligned jtbd --fix` generates the catalog and job blocks into the
+  `coaligned jtbd --fix` generates the catalog and job blocks into the
   README and root `JTBD.md`.
 
 When in doubt, choose the static file — fewer moving parts. See
@@ -65,28 +65,36 @@ Do not restate one file in another. CLAUDE.md orients; CONTRIBUTING.md governs.
 
 Create `.coaligned/invariants/`. Leave it empty for now, or add a first rule
 module with coaligned-invariant. The directory is where the repo's own
-declarative checks live; `npx coaligned invariants` discovers every
-`*.rules.mjs` under it.
+declarative checks live; `coaligned invariants` discovers every `*.rules.mjs`
+under it.
 
 ### Step 4 — Wire the checks into the repository
 
-Add `npx coaligned` to the repository's check command so every layer, job, and
-invariant is enforced before merge.
+Wire the check into the repository's check command and CI so every layer, job,
+and invariant is enforced before merge. The CLI exposes four entry points:
 
-```sh
-npx coaligned                # instructions + jtbd (and invariants if present)
-npx coaligned instructions   # layer length and checklist caps only
-npx coaligned jtbd --fix     # regenerate stale catalog and job blocks
-npx coaligned invariants     # the repo's own rule modules
+```text
+coaligned                # instructions + jtbd (and invariants if present)
+coaligned instructions   # layer length and checklist caps only
+coaligned jtbd --fix     # regenerate stale catalog and job blocks
+coaligned invariants     # the repo's own rule modules
 ```
 
-Run the bare `npx coaligned` in the repository's lint/check task and in CI.
+Invoke it through an entry point the run environment can resolve. A clean CI
+runner has nothing on `PATH` and no workspace to resolve a bare `coaligned`
+against, so wire the registry-resolvable form — the published CLI package run
+through the repository's package manager — and record that concrete command in
+CONTRIBUTING.md. Use the same command in the lint/check task and the CI job;
+never one that only resolves on a contributor's pre-provisioned machine.
 
 ### Step 5 — Verify the bootstrap
 
-Run `npx coaligned`. A clean run means the layers fit their caps and the jobs
-validate. Fix any finding before committing — route by subcommand the same way
-[coaligned-audit](../coaligned-audit/SKILL.md) does.
+Verify the wired check the way CI runs it, from a clean dependency resolution. A
+`coaligned` already on your `PATH` masks an invocation that cannot resolve on a
+fresh runner — so confirm the repository's check command passes on a clean
+checkout, not just in your shell. A clean run means the layers fit their caps and
+the jobs validate; fix any finding before committing, routing by subcommand the
+same way [coaligned-audit](../coaligned-audit/SKILL.md) does.
 
 ## Done When
 
@@ -95,8 +103,11 @@ validate. Fix any finding before committing — route by subcommand the same way
 - [ ] `CLAUDE.md`, `CONTRIBUTING.md`, and `JTBD.md` exist and stay within
       their caps.
 - [ ] `.coaligned/invariants/` exists.
-- [ ] `npx coaligned` is wired into the repository's check command and CI.
-- [ ] `npx coaligned` passes with no findings.
+- [ ] The check is wired into the repository's check command and CI through an
+      invocation a clean runner resolves, with the concrete command in
+      CONTRIBUTING.md.
+- [ ] The wired check passes from a clean checkout, not only from a binary
+      already installed on `PATH`.
 
 </do_confirm_checklist>
 

--- a/.claude/skills/coaligned-setup/SKILL.md
+++ b/.claude/skills/coaligned-setup/SKILL.md
@@ -92,9 +92,9 @@ never one that only resolves on a contributor's pre-provisioned machine.
 Verify the wired check the way CI runs it, from a clean dependency resolution. A
 `coaligned` already on your `PATH` masks an invocation that cannot resolve on a
 fresh runner — so confirm the repository's check command passes on a clean
-checkout, not just in your shell. A clean run means the layers fit their caps and
-the jobs validate; fix any finding before committing, routing by subcommand the
-same way [coaligned-audit](../coaligned-audit/SKILL.md) does.
+checkout, not just in your shell. A clean run means the layers fit their caps
+and the jobs validate; fix any finding before committing, routing by subcommand
+the same way [coaligned-audit](../coaligned-audit/SKILL.md) does.
 
 ## Done When
 

--- a/.claude/skills/coaligned-setup/references/structure-decision.md
+++ b/.claude/skills/coaligned-setup/references/structure-decision.md
@@ -17,7 +17,7 @@ generated blocks back into a static file — is rarely worth it.
 ## Single static JTBD.md
 
 Author Big Hire entries directly in `JTBD.md`. Nothing generates them; the file
-is the source of truth. `npx coaligned jtbd` validates entry structure but has
+is the source of truth. `coaligned jtbd` validates entry structure but has
 nothing to regenerate.
 
 Best for a repository that ships as one unit: a single library, one service,
@@ -42,7 +42,7 @@ Each package declares its jobs in `package.json`:
 }
 ```
 
-`npx coaligned jtbd --fix` reads every package's `jobs`, validates them against
+`coaligned jtbd --fix` reads every package's `jobs`, validates them against
 the JTBD schema, and regenerates the marker-delimited catalog and job blocks in
 the directory READMEs and the root `JTBD.md`. Run it whenever a manifest's
 `jobs` change; CI fails if a generated block is stale.

--- a/.claude/skills/kata-setup/SKILL.md
+++ b/.claude/skills/kata-setup/SKILL.md
@@ -174,20 +174,19 @@ for prerequisites, configuration, and the tunnel/webhook setup.
 
 ### Step 4: Verify
 
-Run verification:
+Setup is verified when the repository is green, not when files exist:
 
-- `gh secret list` — confirm secrets are configured
-- Confirm workflow files were written to `.github/workflows/`
-- Suggest a test run: `gh workflow run "Agent: Shift"`
+- Validate every generated workflow parses as YAML.
+- Run the repository's checks on a clean checkout; never leave or ignore red CI.
+- `gh secret list` — confirm secrets and the named agent profiles resolve at run
+  time (profiles committed or bootstrap-installed from the pinned packs).
+- Suggest a first run: `gh workflow run "Agent: Shift"`.
 
 ### Step 5: Report
 
-Summarize what was created and suggest next steps:
+Summarize what was created and the next steps:
 
 - Customize agent profiles if using defaults
 - Adjust schedules after observing initial runs
-- To halt all kata workflows at once (an emergency stop), set the
-  `KATA_KILLSWITCH` repository variable to a truthy value (e.g. `1`); clear or
-  unset it to resume
-- Read the [Kata Agent Team](https://www.kata.team/) site for how the team
-  works and its PDSA rhythm
+- Emergency stop: set `KATA_KILLSWITCH` to a truthy value; unset it to resume
+- Read the [Kata Agent Team](https://www.kata.team/) site for the PDSA rhythm

--- a/specs/1160-bionova-finder-app/spec.md
+++ b/specs/1160-bionova-finder-app/spec.md
@@ -41,13 +41,13 @@ synthetic data.
 ### Synthetic data foundation
 
 `bionova-apps` vendors `data/synthetic/story.dsl` **verbatim** from this
-monorepo, alongside the committed `prose-cache.json`. The DSL is the repository's
-domain source of truth — the apex of the provenance chain, not generated
-output. `bionova-apps` runs `fit-terrain` against its own copy of `story.dsl`
-to produce the SQL migrations and embeddings JSONL that seed PostgreSQL. The
-build is credential-free: `fit-terrain build` renders from the committed prose
-cache and makes no LLM calls. Regenerating from the vendored DSL reproduces the
-seed byte-for-byte.
+monorepo, alongside the committed `prose-cache.json`. The DSL is the
+repository's domain source of truth — the apex of the provenance chain, not
+generated output. `bionova-apps` runs `fit-terrain` against its own copy of
+`story.dsl` to produce the SQL migrations and embeddings JSONL that seed
+PostgreSQL. The build is credential-free: `fit-terrain build` renders from the
+committed prose cache and makes no LLM calls. Regenerating from the vendored DSL
+reproduces the seed byte-for-byte.
 
 This inverts the relationship from "vendor the rendered SQL" to "vendor the DSL
 and render locally." Auditing what the app contains means reading
@@ -89,11 +89,11 @@ ANSI or HTML depending on the surface.
 ### Technology stack
 
 Self-hosted Supabase stack via Docker Compose (PG On Rails pattern). PostgreSQL
-+ pgvector for data and semantic search. PostgREST for auto-generated REST API.
-GoTrue for auth. HuggingFace TEI for embeddings. Supabase Edge Functions for
-eligibility scoring and embedding generation. Next.js App Router + Tailwind +
-shadcn/ui for the frontend. Forward Impact shared libraries from npm.
-`@forwardimpact/libterrain` + `@forwardimpact/map` from npm provide the
+with pgvector for data and semantic search. PostgREST for auto-generated REST
+API. GoTrue for auth. HuggingFace TEI for embeddings. Supabase Edge Functions
+for eligibility scoring and embedding generation. Next.js App Router with
+Tailwind and shadcn/ui for the frontend. Forward Impact shared libraries from
+npm. `@forwardimpact/libterrain` and `@forwardimpact/map` from npm provide the
 synthetic-data build.
 
 ### Data seeding
@@ -183,10 +183,10 @@ implemented. Each needs its own spec, design, and plan.
 3. `/trials/:id/eligibility` presents a screener and returns a match score.
    Verify: completing the screener for a matching patient returns "eligible".
 
-4. `/trials/:id` shows the trial's FAQ and consent summary, and `/conditions/:id`
-   shows the condition explainer — all sourced from prose seed tables. Verify:
-   the rendered text matches the corresponding `clinical_*` keys in
-   `prose-cache.json`.
+4. `/trials/:id` shows the trial's FAQ and consent summary, and
+   `/conditions/:id` shows the condition explainer — all sourced from prose seed
+   tables. Verify: the rendered text matches the corresponding `clinical_*` keys
+   in `prose-cache.json`.
 
 5. `bionova-polaris search --condition=diabetes` returns the same trials as the
    web search. Verify: CLI output matches web response data.


### PR DESCRIPTION
## Why

Setting up Co-Aligned and the Kata team in a fresh repo (`forwardimpact/bionova-apps`) shipped two PRs whose CI was red, even though setup "passed" locally:

- `npx coaligned` 404s on a clean runner — there is **no bare `coaligned` package on npm**. It resolves only from a PATH-installed gear binary (locally) or a workspace `bunx coaligned` (this monorepo). The published entry point is `@forwardimpact/libcoaligned` (bin `coaligned`).
- A setup skill that verifies by *file existence* or a *local pass* never notices red CI — self-caused or pre-existing.

Both gaps share one root cause: **"verified" meant "worked on my machine," not "the checks pass on a clean run."**

## What changed

**`coaligned-setup`**
- Step 4 no longer hardcodes `npx coaligned`. It states the principle: wire a **registry-resolvable** invocation and record the concrete command in the consumer's `CONTRIBUTING.md`. It deliberately does **not** name a package — the genericity rule keeps `@forwardimpact/libcoaligned` out of the skill; the concrete command lives in the consuming repo.
- Step 5 + the Done-When checklist require verifying from a **clean dependency resolution** — a CLI already on `PATH` masks a check that can't resolve in CI.
- Swept the stray `npx coaligned` mentions in the intro, description, and `structure-decision.md` reference to the generic `coaligned <subcommand>` form.

**`kata-setup`**
- Step 4 "Verify" reframed from "files were written" to **"the repository is green"**: validate generated workflow YAML, run the repo's checks on a clean checkout (never leave or ignore red CI), confirm named agent profiles resolve at run time. Trimmed Step 5 to stay within the SKILL.md cap.

## Verification

- `coaligned instructions` flags neither skill; both within caps (coaligned-setup 119, kata-setup 192).
- No `npx coaligned` or `@forwardimpact/libcoaligned` scope left in either skill (genericity preserved).
- The concrete `npx @forwardimpact/libcoaligned` invocation and the Deno toolchain fix that these lessons came from are applied downstream in the bionova-apps PRs, which are now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)