### PR TITLE
design(2150): flatten agent references into .claude/agents/

### DIFF
--- a/specs/2150-flatten-agent-references/design-a.md
+++ b/specs/2150-flatten-agent-references/design-a.md
@@ -1,0 +1,174 @@
+# Design 2150-a: Flatten agent references into `.claude/agents/`
+
+Spec 2150 removes the `.claude/agents/references/` subdirectory so the monorepo
+matches what `apm install` already produces: agent references flat in
+`.claude/agents/`, as siblings of the profiles, each renamed with an `x-` prefix
+(`x-memory-protocol.md`). Agent references stay a distinct L4 entity from L6
+skill references; only their **location**, **name**, and **classifier** change.
+This design fixes which components carry the classifier, where the links
+repoint, and why a single frontmatter test replaces the directory.
+
+The whole change rests on one substitution: the directory `agents/references/`
+was a **classifier** — "a file here is a reference, not a profile." APM destroys
+that classifier by flattening. The replacement is the test Claude Code's agent
+loader already uses: a `.claude/agents/*.md` file is a **profile** if it has
+`name`/`description` frontmatter, a **reference** if it does not. Three consumers
+that read the directory must adopt the frontmatter test instead.
+
+## Components
+
+| Component | Role | Change |
+| --- | --- | --- |
+| Reference files | The nine shared L4 protocols | Relocate + rename `agents/references/<n>.md` → `agents/x-<n>.md`; delete the subdir. Their own cross-links repoint to the `x-` siblings |
+| Agent profiles (×6) | L3 instruction layer that cites references | Repoint reference links to the flat sibling path, anchors preserved |
+| Skill citations | kata-\* / fit-\* skills citing agent references by GitHub URL | Drop the `/references/` path segment from the URL |
+| `libpack` stager | Builds the `.apm/agents/` tree for the pack | Partition by frontmatter (below); retire the dedicated references step |
+| `libcoaligned` layer model | Assigns each instruction file its layer + length budget | Partition the flat dir by frontmatter; keep L3/L4 layers and budgets |
+| Genericity invariant | Enforces published pack content stays repo-portable | Replace the `agents/references/` selector with the relocated coverage |
+| `COALIGNED.md` § L4 | Documents the L4 layer | New location + frontmatter classifier; keep L4-vs-L6 distinction |
+
+## The frontmatter classifier (shared interface)
+
+A pure predicate, applied to a `.claude/agents/*.md` file's content:
+
+```
+isProfile(file)  := frontmatter has both `name` and `description`
+isReference(file) := not isProfile(file)
+```
+
+This is not new behavior — it is the rule the runtime loader already applies to
+decide what appears as an agent. Both `libpack` and `libcoaligned` move from a
+path test to this content test, so all three readers (loader, packer, linter)
+agree. References have no frontmatter (they open with a `#` heading), so the
+partition is unambiguous for the nine current files and self-correcting for any
+future one.
+
+The `x-` filename prefix is a **second, redundant** signal layered on the
+authoritative frontmatter test: it makes references obvious to a human reading
+the directory and sorts them below the six profiles (all of which begin a–t). It
+is not what the tooling classifies on — frontmatter is, because that is what the
+loader honors — but the genericity invariant asserts the two never disagree:
+every `x-*` file carries no agent frontmatter, and no profile is named `x-*`.
+That guard turns a naming slip into a CI failure rather than a mis-loaded agent.
+
+```mermaid
+graph TD
+  F[".claude/agents/*.md"] --> Q{name + description<br/>frontmatter?}
+  Q -->|yes| P["profile — L3, agent in pack, agents table<br/>(must NOT be named x-*)"]
+  Q -->|no| R["reference — L4, flat .md in pack, excluded from table<br/>(named x-*)"]
+```
+
+## Data flow — symmetry by construction
+
+The defect is an asymmetry between three representations. Flattening the source
+makes all three identical, so the round-trip is the identity:
+
+```mermaid
+graph LR
+  M[".claude/agents/ flat<br/>(monorepo, authored)"] --> L["libpack stage<br/>.apm/agents/ flat"]
+  L --> A["apm install<br/>.claude/agents/ flat (customer)"]
+  A -. "same basenames" .-> M
+```
+
+Today the monorepo node is nested and the install node is flat, so links
+authored against the monorepo dangle in the install. With all three flat, one
+link form resolves everywhere.
+
+## `libpack` — frontmatter partition
+
+`#stageAgents` currently globs `agents/*.md` and stamps every file
+`<stem>.agent.md`, recording each in the agents table. After flattening it would
+wrongly treat the nine references as agents. The design:
+
+- `#stageAgents` reads each `agents/*.md`, applies `isProfile`. Profiles stage as
+  `<stem>.agent.md` and feed the agents table. References stage as plain
+  `<stem>.md` and are excluded from the table.
+- `#stageAgentReferences` (the `cp` of `agents/references/`) is **deleted** — the
+  references now ride along through the single staging pass. No `references/`
+  subdir is created in the pack.
+
+The pack's `.apm/agents/` becomes flat (six `.agent.md` + nine `.md`), which APM
+then installs verbatim into a flat `.claude/agents/` — the flatten is now a
+no-op because the input is already flat.
+
+## `libcoaligned` — partition one directory, keep two layers
+
+The layer model has `findAgentProfiles` (globs `agents/*.md`) and
+`findAgentReferences` (globs `agents/references/`). Both now read the **same**
+flat `agents/*.md` and split it with `isProfile`:
+
+- Profiles → L3 layer + budget (unchanged).
+- References → L4 layer + budget (unchanged), with the `x-memory-protocol`
+  filename keeping its enlarged L4 sub-budget exactly as today.
+
+No layer is removed and no budget changes — the L4 entity persists, selected by
+content instead of path. `findAgentReferences`'s directory walk is replaced by a
+filter over the profile finder's directory listing, so the two finders share one
+`readdir`.
+
+## Link rewrite
+
+Two families collapse to one. Every target ends up as a flat, `x-`-prefixed
+sibling:
+
+| Citing surface | Before | After |
+| --- | --- | --- |
+| Agent profiles (root-relative) | `.claude/agents/references/<n>.md#a` | `.claude/agents/x-<n>.md#a` |
+| Agent profiles (relative) | `references/<n>.md#a` | `x-<n>.md#a` |
+| Skill citations (GitHub URL) | `…/.claude/agents/references/<n>.md#a` | `…/.claude/agents/x-<n>.md#a` |
+| Reference↔reference | `<n>.md` | `x-<n>.md` |
+
+Two completeness oracles, both outside `specs/**`: `rg --hidden
+'agents/references/'` returns nothing (the subdir path is gone) and no surviving
+link names a reference without the `x-` prefix.
+
+## Genericity invariant
+
+The rule selects published pack content by glob, currently including
+`.claude/agents/references/**`. That path disappears. Replace it with
+`.claude/agents/**`, which covers the relocated references and the profiles
+together — both are pack content that must hold in a repo that installed the
+pack, so widening the glob to the whole agents directory is the more faithful
+selector, not merely a patch. The same invariant gains the convention guard:
+`isProfile(f) ⟺ not named x-*` over `.claude/agents/*.md`, so the visible name
+and the loader's verdict can never drift apart.
+
+## Key Decisions
+
+| Decision | Choice | Rejected alternative |
+| --- | --- | --- |
+| Make the two structures agree | Flatten the monorepo to match APM's output | Patch APM to preserve nesting — no such flag; its integrator derives the target from the stem and discards the directory |
+| Reference-vs-profile classifier | Absence of `name`/`description` frontmatter | Keep a directory marker — APM flattens any subdir under agents, so no on-disk directory survives to mark it |
+| Make references visible + sort last | `x-` filename prefix as a redundant convention, with an invariant tying it to the frontmatter verdict | Prefix as the *primary* classifier — the loader keys on frontmatter regardless, so a prefixed file with stray frontmatter would still load as an agent; prefix must follow frontmatter, not replace it |
+| Keep agent references distinct | Preserve L4 layer + budget, selected by frontmatter | Fold references into a skill's L6 `references/` — would shrink their budget and erase the agent-vs-skill reference distinction the spec requires |
+| References in the pack | Flat `<stem>.md` via the one staging pass | Keep `#stageAgentReferences` copying a `references/` subdir — recreates the very nesting APM discards; dead code |
+| `libcoaligned` finders | One `readdir`, partitioned by `isProfile` | Two directory globs — the second (`agents/references/`) now matches nothing |
+| History | `specs/**` + CHANGELOG immutable | Rewrite old paths — large diff, no value |
+
+## Verification mapping
+
+| Criterion | Where satisfied |
+| --- | --- |
+| 1 no `references/` dir; files flat | Reference relocation |
+| 2 monorepo == install basenames | Data-flow symmetry; libpack flat staging |
+| 3 no dangling links | Link rewrite; `rg` oracle |
+| 4 libpack partition + clean table | `#stageAgents` frontmatter split; `#stageAgentReferences` deleted |
+| 5 libcoaligned budgets incl. memory-protocol | One-dir partition keeping L3/L4 |
+| 6 invariant covers references + convention guard | `.claude/agents/**` selector; `isProfile ⟺ not x-*` guard |
+| 7 L4 distinct from L6 | layers kept; `COALIGNED.md` § L4 updated |
+| 8 all references `x-`, no profile is | naming applied at relocation; convention guard enforces |
+| 9 full suite green | every component above |
+
+## Risks
+
+- **A future reference accidentally carries `name`/`description` frontmatter** and
+  is mis-classified as an agent (and would load as a subagent). Mitigation: the
+  `isProfile ⟺ not x-*` convention guard added to the genericity invariant fails
+  CI on exactly this — a prefixed file with frontmatter, or a profile named
+  `x-*`. This converts the design's only soft spot into an enforced rule.
+- **A citation outside the swept globs** (e.g. a non-`.md` surface) keeps the old
+  path. Mitigation: criterion 3's `rg --hidden` oracle spans all files, not only
+  the edited ones.
+- **`memory-protocol` budget regression** if the filename special-case is dropped
+  in the finder rewrite. Mitigation: criterion 5 asserts the enlarged budget
+  against the flat path.

--- a/specs/2150-flatten-agent-references/spec.md
+++ b/specs/2150-flatten-agent-references/spec.md
@@ -1,0 +1,134 @@
+# Spec 2150: Flatten agent references into `.claude/agents/`
+
+**Classification:** Internal. The change lands on the instruction architecture
+(`.claude/`), two shared libraries (`libpack`, `libcoaligned`), a Co-Aligned
+invariant, and the standard's own documentation (`COALIGNED.md`). It carries
+external blast radius because the published `kata-skills` / `fit-skills` packs
+ship these agents and references, but that radius **fixes** a defect rather than
+introducing one (see § What customers see today).
+
+## Problem
+
+The monorepo stores agent references one directory deep, at
+`.claude/agents/references/<name>.md`, and the agent profiles and skills link to
+them at that path. The APM packer ships them the same way. But `apm install`
+does **not** preserve that directory: its agent integrator collects every `.md`
+under a package's agents source recursively and deploys each one by filename
+stem into a flat `.claude/agents/`. Skill references survive (the skill
+integrator copies skill directories whole); agent references do not.
+
+The result is a structural asymmetry between the monorepo and every customer
+install:
+
+| | `.claude/agents/` layout | reference links resolve? |
+| --- | --- | --- |
+| Monorepo (authored) | profiles + nested `references/` subdir | yes |
+| Customer (apm install) | profiles + references **flattened as siblings** | **no — every reference link dangles** |
+
+In a fresh install the nine references land at `.claude/agents/<name>.md`, but
+the profiles still link to `.claude/agents/references/<name>.md`, which no longer
+exists. An agent that follows its own on-boot reading instructions to read the
+memory protocol hits a missing path. The same break hits the GitHub-URL links
+that skills use to cite agent references, since those URLs encode the
+`references/` segment too.
+
+The monorepo is the outlier. APM's flattening is fixed behavior with no flag to
+disable it (its agent integrator derives the target name from the filename stem
+and discards the directory). So the only way to make the two structures agree is
+to author the monorepo in the shape APM produces: agent references flat in
+`.claude/agents/`.
+
+## What customers see today
+
+Customers who already installed the pack **already have the flat layout** with
+broken links — the defect is live, not hypothetical. This change does not move
+their files; it makes the links resolve against the files they already have, and
+makes the monorepo match. No customer migration step is required.
+
+## The distinction being preserved
+
+Agent references and skill references stay **different entities**. This spec
+relocates agent references and changes how they are *identified*; it does not
+merge them with skill references.
+
+| | Agent reference | Skill reference |
+| --- | --- | --- |
+| Role | Cross-cutting protocols shared across agents (memory, coordination, approval) | Domain data a single skill's procedure consults |
+| Home | `.claude/agents/x-<name>.md` (was `.claude/agents/references/<name>.md`) | `.claude/skills/<skill>/references/<name>.md` (unchanged) |
+| Co-Aligned layer | L4, its own length budget | L6, smaller length budget |
+| Identified by | **Absence of agent frontmatter** (no `name`/`description`), plus an `x-` filename prefix as an enforced naming convention — was: living in the `references/` subdir | Living under a skill's `references/` (unchanged) |
+
+The classifier shift is the heart of the change. Today "is it in
+`agents/references/`?" answers "is this a reference, not a profile?" Flattening
+removes that directory, so the question must be answered the way Claude Code's
+own agent loader already answers it: a file in `.claude/agents/` is a **profile**
+if it has `name`/`description` frontmatter and a **reference** if it does not.
+The monorepo's own tooling adopts the same classifier the runtime already uses.
+
+References also take an `x-` filename prefix (`x-memory-protocol.md`). The prefix
+is a human-and-sort aid — it makes references visually obvious as not-agents and
+sorts them below all six profiles — and a guard: the two signals must agree, so a
+file named `x-*` must carry no agent frontmatter and a profile must not be named
+`x-*`. Frontmatter remains the authoritative classifier because it is what the
+loader keys on; the prefix is an enforced convention that keeps the visible name
+honest about what the loader will do.
+
+## Scope
+
+In scope — the full file inventory belongs in the design:
+
+| Surface | What changes |
+| --- | --- |
+| Reference files | The nine `.claude/agents/references/*.md` move up to `.claude/agents/x-*.md` (relocated and prefix-renamed); the `references/` subdir is removed. Their own cross-links repoint to the renamed siblings |
+| Agent profiles | The six profiles' links to references (`.claude/agents/references/<name>.md` and the relative `references/<name>.md`, with or without `#anchor`) repoint to the flattened, prefixed sibling path |
+| Skill citations | The GitHub-URL links across the kata-\* and fit-\* skills that cite agent references drop the `references/` path segment |
+| `libpack` | Agent staging classifies by frontmatter: profiles ship as agents, frontmatter-less files ship as flat references and are excluded from the agents table. The dedicated agent-references staging step is retired |
+| `libcoaligned` | The instruction-layer model partitions `.claude/agents/*.md` by frontmatter instead of by directory: profiles keep their layer and budget, references keep the L4 layer and budget (including the enlarged `x-memory-protocol` budget), selected from the flat directory |
+| Co-Aligned invariant | The genericity rule's `.claude/agents/references/` selector is replaced so it still covers the relocated references; a guard asserts the `x-*` naming convention agrees with the frontmatter classifier (every `x-*` file has no agent frontmatter; no profile is named `x-*`) |
+| `COALIGNED.md` | § L4 records the new location and the frontmatter-based identification; the L4-vs-L6 distinction is kept |
+| Root docs | `CLAUDE.md`, `CONTRIBUTING.md`, `KATA.md`, and the relevant published doc page drop the `agents/references/` path where they name it |
+
+Out of scope:
+
+- **The L4-vs-L6 distinction.** Agent references stay a separate layer with a
+  separate budget. This is a relocation and re-classification, not a merge.
+- **Reference content.** No reference is rewritten, split, or shortened. The L4
+  budgets are unchanged, so no file needs trimming.
+- **Skill references.** `.claude/skills/<skill>/references/` is untouched.
+- **Immutable history.** `specs/**` and `CHANGELOG.md` entries that name the old
+  path are left as written. New CHANGELOG entries describing this change are in
+  scope.
+- **APM itself.** No change to the packer/integrator behavior is requested; the
+  monorepo conforms to it.
+
+## Success Criteria
+
+| # | Criterion | Verified by |
+| --- | --- | --- |
+| 1 | No `.claude/agents/references/` directory exists; the nine references live at `.claude/agents/x-<name>.md` | `test ! -d .claude/agents/references`; each former reference resolves at the flat `x-` path |
+| 2 | The monorepo's `.claude/agents/` file set and a fresh `apm install` of the pack produce the **same** agent-directory filenames | install the packed bundle into a scratch dir; the sorted basename set of its `.claude/agents/*.md` equals the monorepo's |
+| 3 | No reference link dangles, in the monorepo and after install | a link check over `.claude/agents/*.md` (and the packed/installed copy) finds every reference target present; `rg --hidden 'agents/references/'` outside `specs/**` returns nothing |
+| 4 | `libpack` ships profiles as agents and frontmatter-less files as flat references, and the generated agents table lists only the real agents | libpack unit tests for the frontmatter partition; the packed bundle has no `references/` subdir and a clean agents table |
+| 5 | `libcoaligned` classifies profiles vs references by frontmatter and applies the correct L3/L4 budgets, including the enlarged `x-memory-protocol` budget | libcoaligned tests; `coaligned instructions` passes against the flat layout |
+| 6 | The Co-Aligned genericity invariant still covers the relocated references, and a guard enforces that the `x-*` naming convention agrees with the frontmatter classifier | `bun run invariants` passes; it fails if a reference is made repo-specific, if an `x-*` file carries agent frontmatter, or if a profile is named `x-*` |
+| 7 | Agent references remain a distinct L4 entity from L6 skill references | `COALIGNED.md` § L4 documents the new location, the `x-` convention, and the frontmatter classifier; the layer and budget separation is intact |
+| 8 | All nine references carry the `x-` prefix; no profile does | `ls .claude/agents/` shows the six profiles unprefixed and the nine references as `x-*`, sorting last |
+| 9 | Full quality suite passes | repository check, test, format, invariant, and `coaligned` commands all green |
+
+## Persona and Job
+
+Serves **Platform Builders** and **Teams Using Agents** (who install the
+`kata-skills` / `fit-skills` packs and need their agents' references to resolve)
+and **Internal contributors** (who navigate one consistent layout in the
+monorepo and in installs). The change removes a structural asymmetry that
+silently breaks agent self-instruction in every install.
+
+## Open decisions (resolved with the requester)
+
+| Decision | Resolution | Needs human signal |
+| --- | --- | --- |
+| Flatten the monorepo, or move references under a skill (Option B), or leave nested and rewrite links to GitHub URLs? | **Flatten the monorepo** so it matches APM's output | Recommendation — confirmed |
+| Keep agent references distinct from skill references? | **Yes** — preserve the L4-vs-L6 layer and budget separation; this is the stated reason for choosing flatten over a shared-skill home | Requirement — confirmed |
+| New classifier for "reference vs profile" once the directory is gone | **Absence of `name`/`description` frontmatter**, matching Claude Code's own agent loader | Recommendation — confirmed |
+| Make references visually distinct and sort them last | **`x-` filename prefix** (`x-memory-protocol.md`) as an enforced naming convention on top of the frontmatter classifier | Requirement — confirmed |
+| `specs/` + CHANGELOG history naming the old path | **Left as-is (immutable)** | Recommendation — confirmed |


### PR DESCRIPTION
## Summary

- Lockstep **spec + design** for spec 2150. Removes the `.claude/agents/references/` subdirectory so the monorepo follows the same structure `apm install` already produces.
- Agent references relocate to flat `.claude/agents/x-<name>.md` — relocated and `x-`-prefixed so they stand out as not-agents and sort below the six profiles.
- They stay a **distinct L4 entity** from L6 skill references; only their location, name, and classifier change.
- New classifier: **absence of `name`/`description` frontmatter** (what Claude Code's loader already keys on), with the `x-` prefix as an enforced naming convention. A genericity-invariant guard asserts `isProfile(f) ⟺ not named x-*` so the visible name and the loader's verdict can never drift.
- `libpack` partitions agent staging by frontmatter and retires the dedicated references copy; `libcoaligned` partitions one flat directory keeping the L3/L4 budgets (incl. the enlarged `x-memory-protocol` budget); the genericity invariant glob widens to `.claude/agents/**`.

Files: `specs/2150-flatten-agent-references/{spec.md,design-a.md}`. STATUS row `2150 design approved` (shipping implies approval; recorded in the wiki).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`