### PR TITLE
design(2160): provision declared packs in the bootstrap action

### DIFF
--- a/specs/2160-bootstrap-apm-install/design-a.md
+++ b/specs/2160-bootstrap-apm-install/design-a.md
@@ -1,0 +1,120 @@
+# Design 2160 — Provision declared packs in the bootstrap action
+
+Adds a self-contained, `apm.yml`-gated provisioning unit to the `bootstrap`
+composite action so a consuming repo's declared skill and agent packs are
+materialized before any later agent step. The unit is inert for repos that
+commit their trees (the monorepo) and for repos that declare no root `apm.yml`.
+
+## Restated problem
+
+`.github/actions/bootstrap/action.yml` installs the `apm` CLI but never runs
+`apm install`, so a repo that declares its profiles and skills as packs (and
+gitignores the materialized trees) has no instruction trees on disk at agent
+run time. The action must provision those packs — pinned by `apm.lock.yaml`,
+gated on a root `apm.yml`, completing before `scripts/bootstrap.sh` — and stay
+exactly as it is today for every other repo.
+
+## Architecture
+
+Provisioning is one cohesive unit added to the existing composite action: a
+**Restore apm cache** step and a **Provision packs** step, both gated on the
+presence of a root `apm.yml`. They sit after PATH setup and before the
+`Bootstrap` step. No new action inputs; the gate is the file, not a toggle.
+
+```mermaid
+flowchart TD
+  A[setup-bun] --> B[Configure git identity]
+  B --> C[Sync to origin/main]
+  C --> D[Checkout wiki]
+  D --> E[Resolve cache paths]
+  E --> F[Restore environment cache]
+  F --> G[Install CLI deps incl. apm]
+  G --> H[Add deps to PATH]
+  H --> I{root apm.yml?}
+  I -- no --> K[Bootstrap: scripts/bootstrap.sh]
+  I -- yes --> J1[apm cache restore+save key=apm.lock.yaml]
+  J1 --> J2[Provision: apm install]
+  J2 --> K
+```
+
+The consuming repo owns deployment shape. The action runs a plain `apm install`
+from the repo root; `apm` reads the repo's `apm.yml` and `apm.lock.yaml` and
+deploys profiles and skills to the paths it records under `deployed_files`
+(auto-detected, or from `apm.yml targets:`). For an `apm_package` dependency
+`apm` deploys the agent profiles itself — a consumer lockfile lists each
+`.claude/agents/<name>.md` under `deployed_files` (verified against the
+reference consumer's `apm.lock.yaml`). The action never post-processes the
+deployed tree.
+
+## Components
+
+| Component | Where | Responsibility |
+| --- | --- | --- |
+| Provisioning gate | `if: hashFiles('apm.yml') != ''` on both new steps | Declarative no-op for repos without a root `apm.yml`; never runs a bare `apm install` (SC2). |
+| Restore apm cache | new `actions/cache` step | Restores `apm`'s content-addressed download cache, keyed on `apm.lock.yaml`, so warm runs reuse checkouts (SC5). |
+| Provision packs | new composite `run` step | Runs `apm install` from the repo root; nonzero exit fails the run (SC4). Deploys profiles + skills (SC1). |
+| `apm` CLI | already installed by `fit-install.sh` | Resolves packs against `apm.lock.yaml` `resolved_commit` (SC3) and deploys profiles + skills (its `deployed_files`) per the repo's `apm.yml`. |
+
+## Interfaces
+
+- **Gate** — `hashFiles('apm.yml')` matches only the workspace-root file (no
+  `**`), so it returns `''` for any repo without a root `apm.yml` and the step
+  `if:` skips both new steps with no shell invoked. This is the only thing that
+  governs provisioning; there is no new input.
+- **apm cache location** — `apm` honors `XDG_CACHE_HOME` (verified: it sets the
+  cache root to `$XDG_CACHE_HOME/apm`), where it holds its git repository db and
+  checkouts content-addressed by commit. Each new step sets `XDG_CACHE_HOME` in
+  its own `env:` so the `actions/cache` `path:` names `$XDG_CACHE_HOME/apm`
+  deterministically on the Linux runner.
+- **Provision command** — `apm install`, run with the working directory at the
+  repo root. No `--target`; the repo's `apm.yml` (`targets:` or auto-detected)
+  decides deploy paths.
+- **Failure contract** — the composite `run` step fails the action on `apm`'s
+  nonzero exit (unresolvable declared or pinned pack), so the run never reaches
+  `scripts/bootstrap.sh` with a partial environment.
+
+## Key Decisions
+
+| Decision | Choice | Rejected alternative |
+| --- | --- | --- |
+| Where provisioning lives | In `bootstrap`, the action every workflow already calls and `kata-agent` delegates to. | A new step in `kata-agent`/`harness` — duplicates the gate across actions; spec scopes this to `bootstrap`. |
+| Provisioning gate | File presence via `hashFiles('apm.yml')` in step `if:`. | A boolean action input — spec excludes an opt-in toggle; an input can disagree with reality and the file is the real signal. |
+| Deploy mechanism | Plain `apm install`; let the repo's `apm.yml`/`apm.lock.yaml` drive paths and `apm` deploy profiles itself (its `deployed_files` for an `apm_package` dep include `.claude/agents/`). | Replicate the benchmark installer's manual `apm_modules/**/agents/` staging — that staging exists for a `skill_bundle` dep that deploys skills only; for `apm_package` deps it is redundant and couples `bootstrap` to `apm` internals. |
+| Cache isolation | A separate `apm.yml`-gated `actions/cache` for `$XDG_CACHE_HOME/apm`, keyed on `apm.lock.yaml`. | Fold `apm.lock.yaml` into the existing env-cache key — a pack bump would needlessly drop `node_modules`/`generated`; gating keeps the apm concern inert for non-apm repos. |
+| Re-download avoidance | Rely on `apm`'s content-addressed cache (git db + checkouts by commit); always run `apm install` on a warm cache (cheap local deploy). | Skip `apm install` on a cache hit — the deployed trees live in the (uncached) workspace, so they must be re-deployed every run. |
+
+## Data flow
+
+```mermaid
+sequenceDiagram
+  participant Action as bootstrap action
+  participant Cache as actions/cache
+  participant Apm as apm CLI
+  participant FS as workspace + XDG cache
+  Action->>Action: hashFiles('apm.yml') != '' ?
+  Action->>Cache: restore key=apm.lock.yaml hash
+  Cache-->>FS: warm apm download cache (if hit)
+  Action->>Apm: apm install (cwd=repo root)
+  Apm->>FS: resolve apm.lock.yaml, fetch missing commits
+  Apm->>FS: deploy profiles + skills to configured paths
+  Apm-->>Action: exit 0 (or nonzero -> action fails)
+  Action->>Action: Bootstrap (scripts/bootstrap.sh)
+```
+
+## Success criteria coverage
+
+| # | Met by |
+| --- | --- |
+| 1 | Provision step runs `apm install` before the `Bootstrap` step; profiles + skills land at their configured paths. |
+| 2 | `hashFiles('apm.yml') != ''` gate skips both steps; no bare `apm install`, so no `apm.yml` is auto-created. |
+| 3 | `apm install` resolves against `apm.lock.yaml`; deployed commits match each `resolved_commit`. |
+| 4 | Composite `run` step fails the action on `apm`'s nonzero exit. |
+| 5 | Separate cache keyed on `apm.lock.yaml` + `apm`'s content-addressed checkouts: unchanged lock reuses, changed lock re-provisions. |
+
+## Clean break and scope
+
+The action gains steps; it removes nothing and wraps nothing in a fallback. The
+monorepo (commits its trees, no root `apm.yml`) and any non-apm consumer take
+the gate's `no` branch and behave exactly as before — no shim, no compat path.
+MCP-server provisioning, the consumer's commit-vs-declare choice, and changes to
+`kata-agent`/`harness`/`wiki` stay out of scope per the spec.

--- a/specs/2160-bootstrap-apm-install/design-a.md
+++ b/specs/2160-bootstrap-apm-install/design-a.md
@@ -55,7 +55,7 @@ deployed tree.
 | Provisioning gate | `if: hashFiles('apm.yml') != ''` on the three new steps | Declarative no-op for repos without a root `apm.yml`; never runs a bare `apm install` (SC2). |
 | apm cache | new `actions/cache` step | Restores/saves `apm`'s content-addressed download cache (`~/.cache/apm`), keyed on `apm.lock.yaml`, so warm runs reuse checkouts (SC5). |
 | Provision packs | new composite `run` step | Runs `apm install` from the repo root; deploys profiles + skills (SC1). |
-| Verify provisioning | new composite `run` step | Reconciles each pack declared in `apm.yml` against the lockfile + disk: every declared pack must have a resolved lockfile entry whose `deployed_files` all exist; exits nonzero otherwise (SC4). |
+| Verify provisioning | new composite `run` step | Reconciles each pack declared in `apm.yml` (`dependencies.apm`) against the lockfile + disk: every declared pack must match a lockfile entry (by `repo_url`) with a non-empty `deployed_files`, all of which exist; exits nonzero otherwise (SC4). |
 | `apm` CLI | already installed by `fit-install.sh` | Resolves packs against `apm.lock.yaml` `resolved_commit` (SC3) and deploys profiles + skills (its `deployed_files`) per the repo's `apm.yml`. |
 
 ## Interfaces
@@ -72,12 +72,14 @@ deployed tree.
   marker such as `.claude/`/`CLAUDE.md`) decides deploy paths.
 - **Failure contract** — `apm install` exits `0` even when a pack fails to
   resolve (verified), so the exit code cannot gate the run. Verify instead
-  reconciles the packs **declared** in `apm.yml` against the post-install
-  `apm.lock.yaml` and disk: a declared pack with no resolved lockfile entry, or
-  any `deployed_files` path that is absent, fails the action. Anchoring on the
-  declared list (not on whatever `deployed_files` happen to be present) catches
-  a pack that never resolved — whose lockfile entry would otherwise be missing
-  entirely — so the run never reaches `scripts/bootstrap.sh` partial.
+  reconciles the packs **declared** under `apm.yml`'s `dependencies.apm` against
+  the post-install `apm.lock.yaml` (matched by `repo_url`) and disk: a declared
+  pack with no resolved lockfile entry, an entry with empty `deployed_files`, or
+  any listed path that is absent fails the action. Anchoring on the declared
+  list (not on whatever `deployed_files` happen to be present) catches a pack
+  that never resolved — whose lockfile entry would otherwise be missing
+  entirely. Verify is the failure point within the provisioning unit, so the run
+  never reaches `scripts/bootstrap.sh` partial.
 
 ## Key Decisions
 
@@ -88,7 +90,7 @@ deployed tree.
 | Deploy mechanism | Plain `apm install`; let the repo's `apm.yml`/`apm.lock.yaml` drive paths and `apm` deploy profiles itself (the reference consumer's lockfile records `.claude/agents/*.md` under `deployed_files`). | Replicate the benchmark installer's manual `apm_modules/**/agents/` staging — that workaround is specific to the benchmark's `apm install --target claude` harness isolation; the plain install bootstrap runs needs no such staging and it would couple `bootstrap` to `apm` internals. |
 | Cache isolation | A separate `apm.yml`-gated `actions/cache` for `~/.cache/apm`, keyed on `apm.lock.yaml`. | Fold `apm.lock.yaml` into the existing env-cache key — a pack bump would needlessly drop `node_modules`/`generated`; gating keeps the apm concern inert for non-apm repos. |
 | Re-download avoidance | Rely on `apm`'s content-addressed cache (git db + checkouts by commit); always run `apm install` on a warm cache (cheap local deploy). `actions/cache` saves on a successful run; a cold or lock-changed cache fetches from upstream — the intended re-provision. | Skip `apm install` on a cache hit — the deployed trees live in the (uncached) workspace, so they must be re-deployed every run. |
-| Failure detection | Reconcile `apm.yml` declared packs against resolved lockfile entries + on-disk `deployed_files`. | Trust `apm install`'s exit code (verified it exits `0` on an unresolvable pack), or check only `deployed_files` presence — a never-resolved pack omits its lockfile entry, so that check passes blind, violating SC4. |
+| Failure detection | Reconcile `apm.yml` declared packs against resolved lockfile entries (non-empty `deployed_files`) + on-disk paths. | Trust `apm install`'s exit code (verified it exits `0` on an unresolvable pack), or check only `deployed_files` presence — a never-resolved pack omits its lockfile entry, so that check passes blind, violating SC4. |
 
 ## Data flow
 

--- a/specs/2160-bootstrap-apm-install/design-a.md
+++ b/specs/2160-bootstrap-apm-install/design-a.md
@@ -55,7 +55,7 @@ deployed tree.
 | Provisioning gate | `if: hashFiles('apm.yml') != ''` on the three new steps | Declarative no-op for repos without a root `apm.yml`; never runs a bare `apm install` (SC2). |
 | apm cache | new `actions/cache` step | Restores/saves `apm`'s content-addressed download cache (`~/.cache/apm`), keyed on `apm.lock.yaml`, so warm runs reuse checkouts (SC5). |
 | Provision packs | new composite `run` step | Runs `apm install` from the repo root; deploys profiles + skills (SC1). |
-| Verify provisioning | new composite `run` step | Asserts every `deployed_files` path in `apm.lock.yaml` now exists; exits nonzero if any is missing (SC4). |
+| Verify provisioning | new composite `run` step | Reconciles each pack declared in `apm.yml` against the lockfile + disk: every declared pack must have a resolved lockfile entry whose `deployed_files` all exist; exits nonzero otherwise (SC4). |
 | `apm` CLI | already installed by `fit-install.sh` | Resolves packs against `apm.lock.yaml` `resolved_commit` (SC3) and deploys profiles + skills (its `deployed_files`) per the repo's `apm.yml`. |
 
 ## Interfaces
@@ -71,11 +71,13 @@ deployed tree.
   `--target`; the repo's `apm.yml` (`targets:`, or auto-detected from a harness
   marker such as `.claude/`/`CLAUDE.md`) decides deploy paths.
 - **Failure contract** — `apm install` exits `0` even when a pack fails to
-  resolve (verified), so the exit code cannot gate the run. The Verify step
-  reads `apm.lock.yaml`'s `deployed_files` and fails the action when any listed
-  path is absent — covering both an unresolved pack and a deploy that resolved
-  no target. The run never reaches `scripts/bootstrap.sh` with a partial
-  environment.
+  resolve (verified), so the exit code cannot gate the run. Verify instead
+  reconciles the packs **declared** in `apm.yml` against the post-install
+  `apm.lock.yaml` and disk: a declared pack with no resolved lockfile entry, or
+  any `deployed_files` path that is absent, fails the action. Anchoring on the
+  declared list (not on whatever `deployed_files` happen to be present) catches
+  a pack that never resolved — whose lockfile entry would otherwise be missing
+  entirely — so the run never reaches `scripts/bootstrap.sh` partial.
 
 ## Key Decisions
 
@@ -83,10 +85,10 @@ deployed tree.
 | --- | --- | --- |
 | Where provisioning lives | In `bootstrap`, the action every workflow already calls and `kata-agent` delegates to. | A new step in `kata-agent`/`harness` — duplicates the gate across actions; spec scopes this to `bootstrap`. |
 | Provisioning gate | File presence via `hashFiles('apm.yml')` in step `if:`. | A boolean action input — spec excludes an opt-in toggle; an input can disagree with reality and the file is the real signal. |
-| Deploy mechanism | Plain `apm install`; let the repo's `apm.yml`/`apm.lock.yaml` drive paths and `apm` deploy profiles itself (its `deployed_files` for an `apm_package` dep include `.claude/agents/`). | Replicate the benchmark installer's manual `apm_modules/**/agents/` staging — that staging exists for a `skill_bundle` dep that deploys skills only; for `apm_package` deps it is redundant and couples `bootstrap` to `apm` internals. |
+| Deploy mechanism | Plain `apm install`; let the repo's `apm.yml`/`apm.lock.yaml` drive paths and `apm` deploy profiles itself (the reference consumer's lockfile records `.claude/agents/*.md` under `deployed_files`). | Replicate the benchmark installer's manual `apm_modules/**/agents/` staging — that workaround is specific to the benchmark's `apm install --target claude` harness isolation; the plain install bootstrap runs needs no such staging and it would couple `bootstrap` to `apm` internals. |
 | Cache isolation | A separate `apm.yml`-gated `actions/cache` for `~/.cache/apm`, keyed on `apm.lock.yaml`. | Fold `apm.lock.yaml` into the existing env-cache key — a pack bump would needlessly drop `node_modules`/`generated`; gating keeps the apm concern inert for non-apm repos. |
-| Re-download avoidance | Rely on `apm`'s content-addressed cache (git db + checkouts by commit); always run `apm install` on a warm cache (cheap local deploy). | Skip `apm install` on a cache hit — the deployed trees live in the (uncached) workspace, so they must be re-deployed every run. |
-| Failure detection | Verify every `deployed_files` path exists after install. | Trust `apm install`'s exit code — verified it exits `0` on an unresolvable pack, so the run would continue with a partial environment, violating SC4. |
+| Re-download avoidance | Rely on `apm`'s content-addressed cache (git db + checkouts by commit); always run `apm install` on a warm cache (cheap local deploy). `actions/cache` saves on a successful run; a cold or lock-changed cache fetches from upstream — the intended re-provision. | Skip `apm install` on a cache hit — the deployed trees live in the (uncached) workspace, so they must be re-deployed every run. |
+| Failure detection | Reconcile `apm.yml` declared packs against resolved lockfile entries + on-disk `deployed_files`. | Trust `apm install`'s exit code (verified it exits `0` on an unresolvable pack), or check only `deployed_files` presence — a never-resolved pack omits its lockfile entry, so that check passes blind, violating SC4. |
 
 ## Data flow
 
@@ -102,8 +104,8 @@ sequenceDiagram
   Action->>Apm: apm install (cwd=repo root)
   Apm->>FS: resolve apm.lock.yaml, fetch missing commits
   Apm->>FS: deploy profiles + skills to configured paths
-  Action->>FS: verify every deployed_files path exists
-  FS-->>Action: missing path -> action fails (SC4)
+  Action->>FS: reconcile apm.yml packs vs lockfile + deployed_files
+  FS-->>Action: unresolved pack or missing path -> action fails (SC4)
   Action->>Action: Bootstrap (scripts/bootstrap.sh)
 ```
 
@@ -112,9 +114,9 @@ sequenceDiagram
 | # | Met by |
 | --- | --- |
 | 1 | Provision step runs `apm install` before the `Bootstrap` step; profiles + skills land at their configured paths. |
-| 2 | `hashFiles('apm.yml') != ''` gate skips both steps; no bare `apm install`, so no `apm.yml` is auto-created. |
+| 2 | `hashFiles('apm.yml') != ''` gate skips all three new steps; no bare `apm install`, so no `apm.yml` is auto-created. |
 | 3 | `apm install` resolves against `apm.lock.yaml`; deployed commits match each `resolved_commit`. |
-| 4 | Verify step fails the action when any `deployed_files` path is missing (`apm install` itself exits `0` on failure). |
+| 4 | Verify reconciles `apm.yml` declared packs against resolved lockfile entries + on-disk paths; a declared-but-unresolved pack fails the run (`apm install` itself exits `0`). |
 | 5 | Separate cache keyed on `apm.lock.yaml` + `apm`'s content-addressed checkouts: unchanged lock reuses, changed lock re-provisions. |
 
 ## Clean break and scope

--- a/specs/2160-bootstrap-apm-install/design-a.md
+++ b/specs/2160-bootstrap-apm-install/design-a.md
@@ -35,7 +35,7 @@ flowchart TD
   I -- no --> K[Bootstrap: scripts/bootstrap.sh]
   I -- yes --> J1[apm cache restore+save key=apm.lock.yaml]
   J1 --> J2[Provision: apm install]
-  J2 --> J3[Verify: every deployed_files path exists]
+  J2 --> J3[Verify: declared packs resolved + files exist]
   J3 --> K
 ```
 

--- a/specs/2160-bootstrap-apm-install/design-a.md
+++ b/specs/2160-bootstrap-apm-install/design-a.md
@@ -16,10 +16,11 @@ exactly as it is today for every other repo.
 
 ## Architecture
 
-Provisioning is one cohesive unit added to the existing composite action: a
-**Restore apm cache** step and a **Provision packs** step, both gated on the
-presence of a root `apm.yml`. They sit after PATH setup and before the
-`Bootstrap` step. No new action inputs; the gate is the file, not a toggle.
+Provisioning is one cohesive unit added to the existing composite action: an
+**apm cache** step, a **Provision packs** step, and a **Verify provisioning**
+step, all gated on the presence of a root `apm.yml`. They sit after PATH setup
+and before the `Bootstrap` step. No new action inputs; the gate is the file,
+not a toggle.
 
 ```mermaid
 flowchart TD
@@ -34,7 +35,8 @@ flowchart TD
   I -- no --> K[Bootstrap: scripts/bootstrap.sh]
   I -- yes --> J1[apm cache restore+save key=apm.lock.yaml]
   J1 --> J2[Provision: apm install]
-  J2 --> K
+  J2 --> J3[Verify: every deployed_files path exists]
+  J3 --> K
 ```
 
 The consuming repo owns deployment shape. The action runs a plain `apm install`
@@ -50,28 +52,30 @@ deployed tree.
 
 | Component | Where | Responsibility |
 | --- | --- | --- |
-| Provisioning gate | `if: hashFiles('apm.yml') != ''` on both new steps | Declarative no-op for repos without a root `apm.yml`; never runs a bare `apm install` (SC2). |
-| Restore apm cache | new `actions/cache` step | Restores `apm`'s content-addressed download cache, keyed on `apm.lock.yaml`, so warm runs reuse checkouts (SC5). |
-| Provision packs | new composite `run` step | Runs `apm install` from the repo root; nonzero exit fails the run (SC4). Deploys profiles + skills (SC1). |
+| Provisioning gate | `if: hashFiles('apm.yml') != ''` on the three new steps | Declarative no-op for repos without a root `apm.yml`; never runs a bare `apm install` (SC2). |
+| apm cache | new `actions/cache` step | Restores/saves `apm`'s content-addressed download cache (`~/.cache/apm`), keyed on `apm.lock.yaml`, so warm runs reuse checkouts (SC5). |
+| Provision packs | new composite `run` step | Runs `apm install` from the repo root; deploys profiles + skills (SC1). |
+| Verify provisioning | new composite `run` step | Asserts every `deployed_files` path in `apm.lock.yaml` now exists; exits nonzero if any is missing (SC4). |
 | `apm` CLI | already installed by `fit-install.sh` | Resolves packs against `apm.lock.yaml` `resolved_commit` (SC3) and deploys profiles + skills (its `deployed_files`) per the repo's `apm.yml`. |
 
 ## Interfaces
 
 - **Gate** — `hashFiles('apm.yml')` matches only the workspace-root file (no
-  `**`), so it returns `''` for any repo without a root `apm.yml` and the step
-  `if:` skips both new steps with no shell invoked. This is the only thing that
-  governs provisioning; there is no new input.
-- **apm cache location** — `apm` honors `XDG_CACHE_HOME` (verified: it sets the
-  cache root to `$XDG_CACHE_HOME/apm`), where it holds its git repository db and
-  checkouts content-addressed by commit. Each new step sets `XDG_CACHE_HOME` in
-  its own `env:` so the `actions/cache` `path:` names `$XDG_CACHE_HOME/apm`
-  deterministically on the Linux runner.
-- **Provision command** — `apm install`, run with the working directory at the
-  repo root. No `--target`; the repo's `apm.yml` (`targets:` or auto-detected)
-  decides deploy paths.
-- **Failure contract** — the composite `run` step fails the action on `apm`'s
-  nonzero exit (unresolvable declared or pinned pack), so the run never reaches
-  `scripts/bootstrap.sh` with a partial environment.
+  `**`), returning `''` for any repo without a root `apm.yml`, so the step `if:`
+  skips all three new steps with no shell invoked.
+- **apm cache location** — `actions/cache` names `~/.cache/apm`, `apm`'s default
+  cache root on the Linux runner (it holds the git repository db and checkouts,
+  content-addressed by commit). `actions/cache` expands the `~` itself, so no
+  env var is set and the path needs no shell expansion.
+- **Provision command** — `apm install`, working directory at the repo root. No
+  `--target`; the repo's `apm.yml` (`targets:`, or auto-detected from a harness
+  marker such as `.claude/`/`CLAUDE.md`) decides deploy paths.
+- **Failure contract** — `apm install` exits `0` even when a pack fails to
+  resolve (verified), so the exit code cannot gate the run. The Verify step
+  reads `apm.lock.yaml`'s `deployed_files` and fails the action when any listed
+  path is absent — covering both an unresolved pack and a deploy that resolved
+  no target. The run never reaches `scripts/bootstrap.sh` with a partial
+  environment.
 
 ## Key Decisions
 
@@ -80,8 +84,9 @@ deployed tree.
 | Where provisioning lives | In `bootstrap`, the action every workflow already calls and `kata-agent` delegates to. | A new step in `kata-agent`/`harness` — duplicates the gate across actions; spec scopes this to `bootstrap`. |
 | Provisioning gate | File presence via `hashFiles('apm.yml')` in step `if:`. | A boolean action input — spec excludes an opt-in toggle; an input can disagree with reality and the file is the real signal. |
 | Deploy mechanism | Plain `apm install`; let the repo's `apm.yml`/`apm.lock.yaml` drive paths and `apm` deploy profiles itself (its `deployed_files` for an `apm_package` dep include `.claude/agents/`). | Replicate the benchmark installer's manual `apm_modules/**/agents/` staging — that staging exists for a `skill_bundle` dep that deploys skills only; for `apm_package` deps it is redundant and couples `bootstrap` to `apm` internals. |
-| Cache isolation | A separate `apm.yml`-gated `actions/cache` for `$XDG_CACHE_HOME/apm`, keyed on `apm.lock.yaml`. | Fold `apm.lock.yaml` into the existing env-cache key — a pack bump would needlessly drop `node_modules`/`generated`; gating keeps the apm concern inert for non-apm repos. |
+| Cache isolation | A separate `apm.yml`-gated `actions/cache` for `~/.cache/apm`, keyed on `apm.lock.yaml`. | Fold `apm.lock.yaml` into the existing env-cache key — a pack bump would needlessly drop `node_modules`/`generated`; gating keeps the apm concern inert for non-apm repos. |
 | Re-download avoidance | Rely on `apm`'s content-addressed cache (git db + checkouts by commit); always run `apm install` on a warm cache (cheap local deploy). | Skip `apm install` on a cache hit — the deployed trees live in the (uncached) workspace, so they must be re-deployed every run. |
+| Failure detection | Verify every `deployed_files` path exists after install. | Trust `apm install`'s exit code — verified it exits `0` on an unresolvable pack, so the run would continue with a partial environment, violating SC4. |
 
 ## Data flow
 
@@ -90,14 +95,15 @@ sequenceDiagram
   participant Action as bootstrap action
   participant Cache as actions/cache
   participant Apm as apm CLI
-  participant FS as workspace + XDG cache
+  participant FS as workspace + ~/.cache/apm
   Action->>Action: hashFiles('apm.yml') != '' ?
   Action->>Cache: restore key=apm.lock.yaml hash
   Cache-->>FS: warm apm download cache (if hit)
   Action->>Apm: apm install (cwd=repo root)
   Apm->>FS: resolve apm.lock.yaml, fetch missing commits
   Apm->>FS: deploy profiles + skills to configured paths
-  Apm-->>Action: exit 0 (or nonzero -> action fails)
+  Action->>FS: verify every deployed_files path exists
+  FS-->>Action: missing path -> action fails (SC4)
   Action->>Action: Bootstrap (scripts/bootstrap.sh)
 ```
 
@@ -108,7 +114,7 @@ sequenceDiagram
 | 1 | Provision step runs `apm install` before the `Bootstrap` step; profiles + skills land at their configured paths. |
 | 2 | `hashFiles('apm.yml') != ''` gate skips both steps; no bare `apm install`, so no `apm.yml` is auto-created. |
 | 3 | `apm install` resolves against `apm.lock.yaml`; deployed commits match each `resolved_commit`. |
-| 4 | Composite `run` step fails the action on `apm`'s nonzero exit. |
+| 4 | Verify step fails the action when any `deployed_files` path is missing (`apm install` itself exits `0` on failure). |
 | 5 | Separate cache keyed on `apm.lock.yaml` + `apm`'s content-addressed checkouts: unchanged lock reuses, changed lock re-provisions. |
 
 ## Clean break and scope


### PR DESCRIPTION
Architectural design for spec 2160 (merged: `specs/2160-bootstrap-apm-install/spec.md`).

## What this design adds

A self-contained, `apm.yml`-gated provisioning unit in the `bootstrap` composite action — an **apm cache** step, a **Provision packs** step (`apm install`), and a **Verify provisioning** step — placed after PATH setup and before `scripts/bootstrap.sh`. The unit is inert for repos that commit their trees (the monorepo) and for any repo without a root `apm.yml`.

## Key decisions

- **Deploy mechanism** — plain `apm install`; for an `apm_package` dependency `apm` deploys the agent profiles itself (verified: the reference consumer's `apm.lock.yaml` records `.claude/agents/*.md` under `deployed_files`). Bootstrap does **not** replicate the benchmark installer's manual `agents/` staging (that workaround is specific to its `--target claude` harness isolation).
- **Gate** — `hashFiles('apm.yml') != ''` in the step `if:` (no toggle input); matches only the workspace-root file, so SC2 is a declarative no-op with no bare `apm install`.
- **Failure detection** — `apm install` exits `0` even on an unresolvable pack (verified against apm 0.12.4), so the exit code can't gate the run. Verify reconciles the packs declared under `apm.yml`'s `dependencies.apm` against the lockfile (by `repo_url`) + on-disk `deployed_files`, satisfying SC4.
- **Cache** — a separate `apm.yml`-gated `actions/cache` for `~/.cache/apm` keyed on `apm.lock.yaml`, isolated from the existing env cache (SC5).

## Verification notes

Claims grounded first-hand against apm 0.12.4: profile deployment via `deployed_files`, `apm install` exit-0-on-failure, `XDG_CACHE_HOME`/`~/.cache/apm` cache root, and `hashFiles()` gate semantics.

Reviewed by a clean 3-reviewer `kata-review` technical panel (multiple rounds; all blocker/high/medium findings addressed). Approval is human-only — not requesting it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)