### PR TITLE
fix(monorepo-setup): scaffold and document scripts/bootstrap.sh

### DIFF
--- a/.claude/skills/monorepo-setup/SKILL.md
+++ b/.claude/skills/monorepo-setup/SKILL.md
@@ -33,10 +33,12 @@ once per repository.
 ### Step 1 — Bootstrap the skeleton
 
 `git init`, default branch `main`, then the seam files from
-[references/repo-skeleton.md](references/repo-skeleton.md): `.gitignore` and the
-[Monorepo standard][monorepo] top-level directories, each with a `README.md`
-naming its jobs. See [the Monorepo standard][monorepo] for what each directory
-is for — do not invent structure. Commit.
+[references/repo-skeleton.md](references/repo-skeleton.md): `.gitignore`,
+`scripts/bootstrap.sh` (the `bootstrap` action runs it in every Kata workflow —
+without it they fail `exit 127`), and the [Monorepo standard][monorepo]
+top-level directories, each with a `README.md` naming its jobs. See [the
+Monorepo standard][monorepo] for what each directory is for — do not invent
+structure. Commit.
 
 ### Step 2 — Add the root package.json
 
@@ -99,6 +101,7 @@ that the wiki clones with its three ledgers via `fit-wiki pull`.
 <do_confirm_checklist goal="Verify the repo stands before handing off">
 
 - [ ] Git, the root `package.json`, and the Monorepo directory tree exist.
+- [ ] `scripts/bootstrap.sh` exists and is executable (the `bootstrap` action runs it).
 - [ ] Both skill packs and the kata agent profiles are under `.claude/`.
 - [ ] `coaligned-setup` and `kata-setup` both completed.
 - [ ] The check workflows exist (`check-quality`, `check-test`, `check-context`)

--- a/.claude/skills/monorepo-setup/SKILL.md
+++ b/.claude/skills/monorepo-setup/SKILL.md
@@ -101,7 +101,8 @@ that the wiki clones with its three ledgers via `fit-wiki pull`.
 <do_confirm_checklist goal="Verify the repo stands before handing off">
 
 - [ ] Git, the root `package.json`, and the Monorepo directory tree exist.
-- [ ] `scripts/bootstrap.sh` exists and is executable (the `bootstrap` action runs it).
+- [ ] `scripts/bootstrap.sh` exists and is executable (the `bootstrap` action
+      runs it).
 - [ ] Both skill packs and the kata agent profiles are under `.claude/`.
 - [ ] `coaligned-setup` and `kata-setup` both completed.
 - [ ] The check workflows exist (`check-quality`, `check-test`, `check-context`)

--- a/.claude/skills/monorepo-setup/references/repo-skeleton.md
+++ b/.claude/skills/monorepo-setup/references/repo-skeleton.md
@@ -50,6 +50,28 @@ apm_modules/      # APM writes this on first install
 Pin a version whose budgets exempt YAML frontmatter (0.1.15+); published skill
 packs carry publish-injected frontmatter that otherwise breaches the caps.
 
+## scripts/bootstrap.sh
+
+The `bootstrap` composite action (every Kata workflow runs it) checks out the
+repo, puts the `fit-*` CLIs on PATH, then runs `./scripts/bootstrap.sh`. The
+action requires this file with no guard — a repo missing it fails every
+workflow at that step with `exit 127`. Keep it to environment setup: install
+the workspace, then sync the wiki.
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install workspace dependencies with the repository's install command.
+<install-command>
+
+# Sync agent memory. Non-fatal so a missing or empty wiki never blocks CI.
+npx fit-wiki init || echo "bootstrap: wiki init skipped" >&2
+npx fit-wiki pull || echo "bootstrap: wiki pull skipped" >&2
+```
+
+Commit it executable (`chmod +x scripts/bootstrap.sh`).
+
 ## Check workflows
 
 Never a single `check.yml`. Generate one workflow per concern — at minimum

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -69,6 +69,19 @@ in the monorepo and needs no publish-time transform. Skill packs and npm
 packages are excluded: they transform at publish (the skill-pack stage rewrites
 layout) or already have a home under the directories above.
 
+## Environment Bootstrap
+
+A Monorepo-standard repository carries one environment-setup entrypoint at
+`scripts/bootstrap.sh`. CI resolves the shared tooling, then runs this script to
+make the workspace usable — install dependencies, run any codegen, and sync the
+`wiki/` working memory. The shared CI bootstrap action invokes it by path with
+no fallback, so the file is mandatory: a repo missing it fails every agent and
+check workflow at the bootstrap step with `exit 127`.
+
+Keep it to environment setup. Keeping the branch current with the default
+branch, provisioning services, and seeding data are separate concerns owned by
+whoever needs them, not folded into this entrypoint.
+
 ## Root Files
 
 Three root files orient every contributor. Each has one job; none restates


### PR DESCRIPTION
## Summary

- The shared `bootstrap` composite action runs `./scripts/bootstrap.sh` in the consuming repo (after putting the `fit-*` CLIs on PATH) with no existence guard. Repos stood up by `monorepo-setup` never received that file, so every Kata agent and check workflow failed at the bootstrap step with `exit 127` (observed in a downstream installation).
- Add `scripts/bootstrap.sh` to the `monorepo-setup` `repo-skeleton.md` seam artifacts (install workspace, sync wiki), reference it in Step 1, and add a Done-When check that the file exists and is executable.
- Document the entrypoint in the `MONOREPO.md` standard under a new "Environment Bootstrap" section: what it is, why it is mandatory, and its boundary — so the standard itself explains the requirement.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- [ ] `coaligned instructions` / `coaligned invariants` pass on the edited skill (skill-genericity: uses `npx fit-wiki` and an `<install-command>` placeholder — no `bun`/`bunx`/`just` or repo-specific package names).


---
_Generated by [Claude Code](https://claude.ai/code/session_016KgnQrzAb9ahBpB23ue6nc)_