### PR TITLE
docs(bootstrap): two-layer env-bootstrap model + standardized apm-pack reconstitution

### DIFF
--- a/.claude/skills/monorepo-setup/SKILL.md
+++ b/.claude/skills/monorepo-setup/SKILL.md
@@ -61,6 +61,11 @@ skills only — confirm the kata **agent profiles** also landed in
 (`agents/*.agent.md` → `.claude/agents/<name>.md`, with the flat
 `agents/x-*.md` reference files).
 
+The `apm.yml` this writes makes the packs reconstitutable:
+`scripts/bootstrap.sh` runs `apm install` on every fresh environment (Step 1),
+so you may commit `.claude/skills/` and `.claude/agents/` or gitignore them as
+build output — either satisfies the run-time requirement that they be present.
+
 ### Step 4 — Invoke coaligned-setup, then kata-setup
 
 These two upstream skills are the reason this orchestration exists. **Invoke

--- a/.claude/skills/monorepo-setup/references/repo-skeleton.md
+++ b/.claude/skills/monorepo-setup/references/repo-skeleton.md
@@ -52,13 +52,21 @@ packs carry publish-injected frontmatter that otherwise breaches the caps.
 
 ## scripts/bootstrap.sh
 
-The `bootstrap` composite action (every Kata workflow runs it) checks out the
-repo, puts the `fit-*` CLIs on PATH, then runs `./scripts/bootstrap.sh`. The
-action requires this file with no guard — a repo missing it fails every
-workflow at that step with `exit 127`. In a Claude session the same script runs
-from the `SessionStart` hook, after the installer curl (see
-[wiki-init.md](wiki-init.md)). Keep it to environment setup: install the
-workspace, then sync the wiki.
+This is the **workspace** half of the two-layer bootstrap (the installer that
+puts the toolchain on `PATH` is the other half — see
+[wiki-init.md](wiki-init.md)). Both entry points run installer-then-this-script
+in the same order: the `bootstrap` composite action in every Kata workflow, and
+the `SessionStart` hook in a Claude session. So every environment-setup step
+that must hold in both places lives here, not in the CI-only action. The action
+requires this file with no guard — a repo missing it fails every workflow at
+that step with `exit 127`.
+
+Keep it to environment setup: install the workspace, reconstitute the APM skill
+packs and agent profiles, then sync the wiki. The `apm install` step is what
+lets a repo treat `.claude/skills/` and `.claude/agents/` as reconstitutable
+build output rather than committed source — the kata agent workflows require
+those present, and this is the only step that rebuilds them on a fresh
+environment.
 
 ```sh
 #!/usr/bin/env bash
@@ -66,6 +74,11 @@ set -euo pipefail
 
 # Install workspace dependencies with the repository's install command.
 <install-command>
+
+# Reconstitute the APM skill packs + agent profiles when this repo uses APM.
+if [ -f apm.yml ] || [ -f apm.lock.yaml ]; then
+  apm install
+fi
 
 # Sync agent memory. Non-fatal so a missing or empty wiki never blocks CI.
 npx fit-wiki init || echo "bootstrap: wiki init skipped" >&2

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -71,16 +71,32 @@ layout) or already have a home under the directories above.
 
 ## Environment Bootstrap
 
-A Monorepo-standard repository carries one environment-setup entrypoint at
-`scripts/bootstrap.sh`. CI resolves the shared tooling, then runs this script to
-make the workspace usable — install dependencies, run any codegen, and sync the
-`wiki/` working memory. The shared CI bootstrap action invokes it by path with
-no fallback, so the file is mandatory: a repo missing it fails every agent and
-check workflow at the bootstrap step with `exit 127`.
+Every agent session sets up its environment in two layers, in order:
 
-Keep it to environment setup. Keeping the branch current with the default
-branch, provisioning services, and seeding data are separate concerns owned by
-whoever needs them, not folded into this entrypoint.
+1. **Toolchain — `fit-install.sh`.** Puts the pinned FIT toolchain on `PATH`
+   (`apm`, `just`, `gh`, `rg`, `gitleaks`, `coaligned`, and any requested
+   `fit-*` CLIs). It is a released, versioned, repo-agnostic artifact — the same
+   bytes for every repository, installing binaries only. It never mutates a
+   repository's working tree.
+2. **Workspace — `scripts/bootstrap.sh`.** Uses that toolchain to reconstitute
+   _this_ repository's tree: install dependencies with the repo's own package
+   manager; run `apm install` to rebuild the APM skill packs and agent profiles
+   when the repo carries an `apm.yml`; sync the `wiki/` working memory. It is
+   repo-owned, because these steps are repo-specific.
+
+Both entry points run **both layers, in the same order**. The CI bootstrap
+action runs `fit-install.sh` then `scripts/bootstrap.sh`; the native
+`.claude/settings.json` `SessionStart` hook does the same. That symmetry is the
+contract — an agent gets the same tools, dependencies, skills, and memory
+whether it runs in CI or a local session. **A step that must hold in both
+places belongs in one of these two scripts, never in the CI-only composite
+action**, which native sessions never invoke.
+
+`scripts/bootstrap.sh` is mandatory: the CI bootstrap action invokes it by path
+with no fallback, so a repo missing it fails every agent and check workflow at
+that step with `exit 127`. Keep it to environment setup. Keeping the branch
+current with the default branch, provisioning services, and seeding data are
+separate concerns owned by whoever needs them, not folded into this entrypoint.
 
 ## Root Files
 

--- a/references/bionova-apps/plan-a-01.md
+++ b/references/bionova-apps/plan-a-01.md
@@ -108,7 +108,16 @@ data/synthetic/seed_embeddings.jsonl
 products/polaris/site/supabase/migrations/20250101*_seed_*.sql
 # Per-service runtime data volumes:
 infrastructure/*/data/
+# APM skill packs + agent profiles — reconstituted by scripts/bootstrap.sh:
+.agents/
+.claude/agents/
+.claude/skills/
+.github/agents/
 ```
+
+Polaris treats the skill packs and agent profiles as reconstitutable build
+output: the skeleton's `scripts/bootstrap.sh` rebuilds them from `apm.yml` on
+every environment (CI and native), so they are gitignored rather than committed.
 
 Verify: `bun install` exits 0; `just --list` shows recipes; `bun run check`
 (coaligned + lint + tsc) passes.


### PR DESCRIPTION
## Summary

Agent sessions must set up identically in CI and native Claude Code sessions. The composite bootstrap action is CI-only, so consistency lives in the two surfaces both paths share: `fit-install.sh` (toolchain) and `scripts/bootstrap.sh` (workspace). A consuming repo (bionova-apps) gitignored its APM skill packs but nothing ran `apm install`, so agent workflows started with no profiles or skills.

Keeps the toolchain/workspace boundary — `bun install`/`apm install` stay **out** of the released, repo-agnostic `fit-install.sh` (package-manager choice and CI cache-skip logic are repo-specific) — and instead standardizes `scripts/bootstrap.sh`.

- **MONOREPO.md** § Environment Bootstrap: define the two layers, the two-path symmetry invariant (both run `fit-install.sh` then `scripts/bootstrap.sh`), and that a cross-path step never belongs in the CI-only action.
- **monorepo-setup skill**: `bootstrap.sh` template gains a guarded `apm install` (rebuilds `.claude/skills` + `.claude/agents` when `apm.yml` is present); Step 3 notes the packs are therefore reconstitutable — commit or gitignore, either satisfies the run-time requirement.
- **reference spec `plan-a-01`**: bionova gitignores the packs as build output, reconstituted by the skeleton's `bootstrap.sh` (pointer only, no restating the skill).

Companion live fix: forwardimpact/bionova-apps#10.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226nD6nHxXZQVovnzNMYMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01226nD6nHxXZQVovnzNMYMD)_