### PR TITLE
docs(references): document the workflow for keeping a reference current

### DIFF
--- a/references/CLAUDE.md
+++ b/references/CLAUDE.md
@@ -15,3 +15,23 @@ commit SHAs, dates, and version pins by nature, so the `temporal` and
 `model-defaults` invariants skip `references/**` the way they skip `specs/**`.
 
 One subdirectory per referenced deliverable, named for what it builds.
+
+## Keeping a reference current
+
+A reference has two artifacts to hold in agreement: the spec here, and its
+implementation repository elsewhere. Work flows both ways — a defect surfaced
+while building the repo flows back into the spec; an evolved library, skill, or
+standard flows forward into the repo. To run a pass on one:
+
+1. **Add the repository to this session.** Use the `add_repo` tool to bring the
+   reference's repo into this session's scope, then clone it — now you can read
+   its history and open pull requests against it from here.
+2. **Reconcile the spec against reality.** Read the repo's commits since the
+   last pass; the fixes made while building it are what the spec got wrong.
+   Confirm the spec still reproduces a working build.
+3. **Route each change to the layer that owns it.** A change that applies to
+   every repository of this kind belongs in the owning skill or standard, not
+   the spec; only reference-specific detail belongs in the spec. Never restate
+   in the spec what an authoritative layer owns — point to it.
+4. **Bring the repository up to the spec.** Apply the reconciled change in the
+   implementation repo so the built reference and its spec agree again.


### PR DESCRIPTION
## Summary

Adds a `## Keeping a reference current` section to `references/CLAUDE.md` capturing the maintenance loop between a reference's two artifacts — the spec here and its implementation repository elsewhere:

1. Add the repository to the session (`add_repo`) and clone it.
2. Reconcile the spec against reality — read the repo's commits since the last pass; the fixes made while building it are what the spec got wrong.
3. Route each change to the layer that owns it — shared behaviour → the owning skill or standard; reference-specific detail → the spec; never restate in the spec what an authoritative layer owns.
4. Bring the repository up to the reconciled spec.

Framed as a bidirectional loop (defects flow repo→spec; evolved capabilities flow spec/standard→repo) and fully generic — no repo named — so it holds for future references.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01226nD6nHxXZQVovnzNMYMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01226nD6nHxXZQVovnzNMYMD)_