### PR TITLE
chore(release): cut libharness@v1.2.1, gear@v0.1.14

### DIFF
--- a/libraries/libharness/package.json
+++ b/libraries/libharness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libharness",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Autonomous agent team harness — coordinate a lead and participant agents in one async session, with eval, benchmark, and trace tooling to prove the changes worked.",
   "keywords": [
     "orchestration",


### PR DESCRIPTION
Release commit for the harness native-CLI fix chain (root cause: compiled `fit-harness` cannot self-resolve the SDK's native `claude` binary; fixed in #1891).

## Tier 1 + 4 of the bottom-up release chain (CONTRIBUTING § Releasing)

- **libharness@v1.2.1** (patch) — `libraries/libharness` source changed in #1891 (`fix(harness)`): new `claude-code-executable.js` (`resolveClaudeCodeExecutable`) and `agent-runner.js` passing `pathToClaudeCodeExecutable` to the SDK for compiled binaries, plus an index export. Post-1.0 `fix` → patch.
- **gear@v0.1.14** — recompiles the gear bundle (`fit-harness`, `fit-benchmark`, `fit-trace`, …) from this commit so the compiled `fit-harness` carries the `pathToClaudeCodeExecutable` wiring. Tag applied to the merged commit after CI is green.

Both tags are applied to the squash-merge commit; `fit-install.sh`'s `FIT_GEAR_RELEASE` is re-pointed at `gear@v0.1.14` in a follow-up PR only after the gear binaries publish green (producer-before-consumer).

— Release Engineer 🚀

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdvRLPvv5tEKf41HZX7oWY)_