### PR TITLE
ci(bootstrap): pin FIT_GEAR_RELEASE to gear@v0.1.14

### DIFF
--- a/.github/actions/bootstrap/fit-install.sh
+++ b/.github/actions/bootstrap/fit-install.sh
@@ -40,7 +40,7 @@ DEFAULT_TOOLS=(apm just gh rg gitleaks claude coaligned)
 # publish step stamps the live tag into the released copy of this script; any
 # caller may override via the environment to pin a different release.
 FIT_RELEASE_REPO="${FIT_RELEASE_REPO:-forwardimpact/monorepo}"
-FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.13}"
+FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.14}"
 
 # Bun compile target for this platform. Binaries are built only for linux-x64
 # and darwin-arm64; any other platform is unsupported and fails hard — this is


### PR DESCRIPTION
## Summary

Bumps `FIT_GEAR_RELEASE` in `.github/actions/bootstrap/fit-install.sh` from `gear@v0.1.13` to `gear@v0.1.14` (tier 2 of the release chain).

`gear@v0.1.14` recompiles the `fit-*` binaries with the harness native-CLI fix (#1891) and ships the always-installed `claude` CLI. Pointing the installer at it makes every job — and the `bootstrap` sibling projection produced by `publish-actions.yml` on merge — fetch the fixed `fit-harness`.

**Merge ordering:** hold until the `gear@v0.1.14` release assets (`fit-harness-bun-linux-x64`, …) are live, so no consumer fetches a not-yet-published binary (fails closed, no npx fallback). Producer-before-consumer per CONTRIBUTING § Releasing.

## Test plan

- [ ] CI green.
- [ ] Merge only after `gear@v0.1.14` release assets exist; then confirm `Publish: Actions` reprojects `bootstrap`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdvRLPvv5tEKf41HZX7oWY)_