### PR TITLE
ci(release): tag any org repo + deterministic v1-move for actions

### DIFF
--- a/.github/actions/release-tagger/action.yml
+++ b/.github/actions/release-tagger/action.yml
@@ -1,0 +1,111 @@
+name: Release Tagger
+description: >
+  Create append-only release tags on a target repo and, for action releases
+  (`v<major>.<minor>.<patch>`), move the `v<major>` alias forward per the
+  monorepo's v1-move policy. Deterministic and idempotent: an existing release
+  tag is never moved, and the major alias only ever moves forward to a commit
+  that carries the release tag and is reachable from the default branch.
+
+inputs:
+  owner:
+    description: Repository owner (org).
+    required: true
+  repo:
+    description: Target repository name (no owner prefix).
+    required: true
+  tags:
+    description: Whitespace/comma-separated release tags to create.
+    required: true
+  sha:
+    description: Commit to tag; defaults to the target repo's default-branch tip.
+    required: false
+    default: ""
+  token:
+    description: >
+      Token with `contents: write` on the target repo (an App installation
+      token scoped to that repo). Minted by the caller — composite actions
+      cannot read secrets.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        OWNER: ${{ inputs.owner }}
+        REPO: ${{ inputs.repo }}
+        TAGS: ${{ inputs.tags }}
+        SHA_INPUT: ${{ inputs.sha }}
+        TAG_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+
+        # Work in a throwaway clone of the TARGET repo so this action can tag
+        # any org repo, not just the one it runs in. blob:none keeps the full
+        # commit graph + tags (needed for ancestry and alias checks) without
+        # fetching file contents.
+        work="$(mktemp -d)"
+        git clone --quiet --filter=blob:none \
+          "https://x-access-token:${TAG_TOKEN}@github.com/${OWNER}/${REPO}.git" "$work"
+        cd "$work"
+        git config user.name "kata-agent-team[bot]"
+        git config user.email "kata-agent-team[bot]@users.noreply.github.com"
+
+        default_ref="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)"
+
+        # Resolve and validate the target commit: a full SHA reachable from the
+        # default branch (a reviewed commit), never an arbitrary ref.
+        target="${SHA_INPUT:-$(git rev-parse "$default_ref")}"
+        if ! printf '%s' "$target" | grep -Eq '^[0-9a-f]{40}$'; then
+          echo "::error::sha must be a full 40-char commit (got '$target')"; exit 1
+        fi
+        if ! git merge-base --is-ancestor "$target" "$default_ref"; then
+          echo "::error::target $target is not reachable from ${default_ref#origin/}"; exit 1
+        fi
+
+        # Normalize separators, then validate every tag's shape up front so a
+        # bad entry fails before anything is pushed.
+        tags="$(printf '%s' "$TAGS" | tr ',\n\r\t' '    ')"
+        n=0
+        for t in $tags; do
+          case "$t" in
+            *@v[0-9]*) ;;                       # package release: <name>@v<version>
+            v[0-9]*.[0-9]*.[0-9]*) ;;           # action release: v<major>.<minor>.<patch>
+            *) echo "::error::tag '$t' is not release-shaped"; exit 1 ;;
+          esac
+          n=$((n + 1))
+        done
+        [ "$n" -gt 0 ] || { echo "::error::no tags supplied"; exit 1; }
+
+        for t in $tags; do
+          # Append-only: create the release tag if absent, never move it.
+          if git rev-parse -q --verify "refs/tags/$t^{commit}" >/dev/null 2>&1; then
+            echo "$t already exists — leaving in place"
+          else
+            git tag "$t" "$target"
+            git push --quiet origin "refs/tags/$t"
+            echo "created $t -> $target"
+          fi
+          tag_commit="$(git rev-parse "refs/tags/$t^{commit}")"
+
+          # v1-move: only for exact v<major>.<minor>.<patch> action releases.
+          # The major alias tracks the release tag's commit, moving forward only.
+          printf '%s' "$t" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' || continue
+          major="${t%%.*}"
+          if git rev-parse -q --verify "refs/tags/$major^{commit}" >/dev/null 2>&1; then
+            old="$(git rev-parse "refs/tags/$major^{commit}")"
+            if [ "$old" = "$tag_commit" ]; then
+              echo "$major already at $tag_commit"
+            elif git merge-base --is-ancestor "$old" "$tag_commit"; then
+              git tag -f "$major" "$tag_commit"
+              git push --force --quiet origin "refs/tags/$major"
+              echo "moved $major: $old -> $tag_commit"
+            else
+              echo "::error::refusing to move $major: current target $old is not an ancestor of $tag_commit (backward or off-line move)"; exit 1
+            fi
+          else
+            git tag "$major" "$tag_commit"
+            git push --quiet origin "refs/tags/$major"
+            echo "created alias $major -> $tag_commit"
+          fi
+        done

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,34 +1,31 @@
 name: "Release: Tag"
 
-# Create and push release tags on an already-reviewed commit, so the
-# tag-triggered publish pipelines (Publish: Binaries, Publish: Package) fire.
+# Create release tags on any repo in the org, in CI. Session types that cut
+# releases can push branches and merge PRs but cannot create tags (proxy denies
+# git tag push, git/refs write, and the releases API). This dispatch job tags
+# instead, using an App installation token scoped to the target repo — the kata
+# App is installed org-wide, so one workflow tags monorepo package releases and
+# sibling action releases alike.
 #
-# Dispatch-only. A release cut updates package.json on main via PR; the actual
-# `{prefix}@v{version}` tags are created here. Tags are pushed with the kata App
-# token, NOT the default GITHUB_TOKEN — a GITHUB_TOKEN push would not retrigger
-# the downstream `push: tags` workflows (GitHub suppresses that to avoid
-# recursion), so the release would never publish.
-#
-# A release sweep cuts every package from the same release commit, so one `sha`
-# targets a whole `tags` list. Each tag is validated and pushed on its own ref
-# (never `git push --tags`), per the release policy. Guardrails: each tag must
-# be release-shaped (`<name>@v<version>`), the target must be a full 40-char SHA
-# reachable from main (never an unreviewed commit), and an existing tag is never
-# moved — so a re-run after a partial failure only pushes what is still missing.
-#
-# `sha` defaults to the commit this run was dispatched against (`github.sha`).
-# Steady state: dispatch against `main` and omit `sha` — it tags the tip, which
-# is the release commit. Pass `sha` explicitly only to tag an out-of-line
-# reviewed commit (e.g. one that predates this workflow).
+# The deterministic tag/alias logic lives in ./.github/actions/release-tagger:
+# append-only release tags, plus a forward-only `v<major>` alias move for action
+# releases (v<major>.<minor>.<patch>) per .github/CLAUDE.md § Moving a sibling's
+# v1 tag. Tags are pushed with the App token, not GITHUB_TOKEN, so a tagged
+# publish workflow in the target repo still fires.
 on:
   workflow_dispatch:
     inputs:
       tags:
-        description: "Release tags to create, whitespace/comma separated (e.g. 'gear@v0.1.14 libharness@v1.2.1')"
+        description: "Release tags, whitespace/comma separated (package '<name>@v<ver>' or action 'v<maj>.<min>.<patch>')"
         required: true
         type: string
+      repo:
+        description: "Target repo (name or owner/name); defaults to this repo"
+        required: false
+        type: string
+        default: ""
       sha:
-        description: "Commit SHA to tag; defaults to the dispatched ref's commit. Must be a full 40-char SHA reachable from main."
+        description: "Commit to tag; defaults to the target repo's default-branch tip. Full 40-char SHA, reachable from that branch."
         required: false
         type: string
         default: ""
@@ -40,63 +37,33 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - name: Mint App token
+      - name: Resolve target repo
+        id: t
+        env:
+          REPO_INPUT: ${{ inputs.repo }}
+        run: |
+          # Accept "name" or "owner/name"; the token + clone use the bare name
+          # under this org.
+          repo="${REPO_INPUT##*/}"
+          echo "repo=${repo:-${GITHUB_REPOSITORY#*/}}" >> "$GITHUB_OUTPUT"
+
+      - name: Mint App token (scoped to target repo)
         id: app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ steps.t.outputs.repo }}
 
+      # Check out this repo so the local composite action resolves.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Push release tags
+        uses: ./.github/actions/release-tagger
         with:
-          fetch-depth: 0
+          owner: ${{ github.repository_owner }}
+          repo: ${{ steps.t.outputs.repo }}
+          tags: ${{ inputs.tags }}
+          sha: ${{ inputs.sha }}
           token: ${{ steps.app.outputs.token }}
-          persist-credentials: true
-
-      - name: Validate and push tags
-        env:
-          SHA_INPUT: ${{ inputs.sha }}
-          TAGS: ${{ inputs.tags }}
-        run: |
-          set -euo pipefail
-
-          # Default the target to the commit this run was dispatched against.
-          SHA="${SHA_INPUT:-$GITHUB_SHA}"
-
-          # The target commit is validated once — every tag in the list points
-          # at it. Reject anything that is not a full SHA reachable from main.
-          if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "::error::sha must be a full 40-char hex commit"; exit 1
-          fi
-          git fetch --no-tags origin main
-          if ! git merge-base --is-ancestor "$SHA" origin/main; then
-            echo "::error::sha $SHA is not reachable from main"; exit 1
-          fi
-
-          # Normalize separators (commas/newlines -> spaces) and validate the
-          # whole list before pushing any tag, so a bad entry fails the run
-          # before it half-applies.
-          tags="$(printf '%s' "$TAGS" | tr ',\n\r\t' '    ')"
-          count=0
-          for t in $tags; do
-            case "$t" in
-              *@v[0-9]*) ;;
-              *) echo "::error::tag '$t' must look like <name>@v<version>"; exit 1 ;;
-            esac
-            count=$((count + 1))
-          done
-          if [ "$count" -eq 0 ]; then
-            echo "::error::no tags supplied"; exit 1
-          fi
-
-          # Push each tag on its own ref — never `git push --tags`. An existing
-          # tag is skipped (idempotent re-run), never moved.
-          for t in $tags; do
-            if git ls-remote --tags --exit-code origin "refs/tags/$t" >/dev/null 2>&1; then
-              echo "$t already exists on origin — skipping"
-              continue
-            fi
-            git tag "$t" "$SHA"
-            git push origin "refs/tags/$t"
-            echo "Pushed $t -> $SHA"
-          done


### PR DESCRIPTION
## Summary

Extends the `Release: Tag` dispatch workflow so it can cut **sibling action releases** the sanctioned way, and factors the logic into a reviewable composite action.

- **`repo` input.** Mints an App installation token **scoped to the target repo** (the kata App is installed org-wide) and tags it from CI. One workflow now tags monorepo package releases *and* sibling action releases — without committing anything to the projection-only siblings (so `publish-actions`' non-force push stays intact).
- **Deterministic release logic** in new `./.github/actions/release-tagger`:
  - Release tags are **append-only** — an existing tag is never moved.
  - For an action release `v<major>.<minor>.<patch>`, the **`v<major>` alias moves forward-only**: only to the commit carrying the just-created release tag, only when that commit is reachable from the default branch, and only when the current alias target is its **ancestor** — any backward or off-line move is refused. Implements `.github/CLAUDE.md` § *Moving a sibling's v1 tag*. The alias can only move alongside a real `v<major>.<minor>.<patch>` release (a bare `v1` input is rejected).
- Tags are pushed with the **App token, not `GITHUB_TOKEN`**, so a tag-triggered publish workflow in the target repo still fires.

Backward-compatible with the existing single-repo use (monorepo `gear@v*` / `libharness@v*`): `repo` defaults to this repo, `sha` to the target's default-branch tip.

## Security

This makes the tagger an org-wide tag-pusher under the App identity. Mitigations: the token is scoped per-invocation to the single target repo; tags must be release-shaped; the target must be reachable from the default branch; the `v<major>` alias moves forward-only. Who may dispatch the workflow is the remaining control (repo Actions permissions) — worth a security-engineer confirm.

## Test plan

- [ ] CI green.
- [ ] After merge, dispatch against a sibling (`repo=bootstrap`, `tags="v1.0.11"`) and confirm the release tag + forward `v1` move land on the sibling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdvRLPvv5tEKf41HZX7oWY)_