### PR TITLE
ci(kata-agent): bump internal bootstrap pin to v1.0.11

### DIFF
--- a/products/kata/actions/kata-agent/action.yml
+++ b/products/kata/actions/kata-agent/action.yml
@@ -158,7 +158,7 @@ runs:
     # ./scripts/bootstrap.sh. The `token:` input gates wiki checkout —
     # leave it empty to skip wiki sync. The wiki is pushed back after the
     # agent run via forwardimpact/wiki below.
-    - uses: forwardimpact/bootstrap@c349e223de51a865ac223cc712972487393829b5 # v1.0.8
+    - uses: forwardimpact/bootstrap@af1f2e7950785db1ba3bee648cf75098c415fb42 # v1.0.11
       with:
         token: ${{ inputs.wiki == 'true' && steps.ci-app.outputs.token || '' }}
         app-slug: ${{ inputs.app-slug }}


### PR DESCRIPTION
## Summary

Bumps the `kata-agent` composite action's internal `bootstrap` pin from `v1.0.8` (`c349e223`) to `v1.0.11` (`af1f2e79`).

`kata-agent` bootstraps internally, so its pinned `bootstrap` is what installs the CLIs for storyboard/coaching/shift runs. `bootstrap@v1.0.11` installs the `claude` CLI and pins `gear@v0.1.14` (the recompiled `fit-harness` with the native-CLI fix, #1891). Without this bump, kata-agent consumers keep getting the old `fit-install.sh` and the `Native CLI binary not found` error persists.

On merge, `publish-actions.yml` reprojects the `kata-agent` sibling with the new pin; then `kata-agent@v1.0.6` is cut on the sibling and bionova-apps is bumped to it (tier 3→4).

## Test plan

- [ ] CI green.
- [ ] After merge, kata-agent sibling reprojected; cut `kata-agent@v1.0.6`; bump bionova-apps.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdvRLPvv5tEKf41HZX7oWY)_