### PR TITLE
fix(bootstrap): extract .tgz archives in fit-install.sh

### DIFF
--- a/.github/actions/bootstrap/fit-install.sh
+++ b/.github/actions/bootstrap/fit-install.sh
@@ -119,7 +119,7 @@ fetch_and_verify() {
 extract_archive() {
   local archive="$1" dest="$2" strip="${3:-0}"
   case "$archive" in
-    *.tar.gz)
+    *.tar.gz | *.tgz)
       if [ "$strip" -gt 0 ]; then
         tar -xz -C "$dest" --strip-components="$strip" -f "$archive"
       else


### PR DESCRIPTION
## Summary

Fixes the `claude` CLI install added in #1891. `install_tool`'s `extract_archive` matched only `*.tar.gz` and `*.zip`, so the `claude` npm tarball (`claude-agent-sdk-linux-x64-0.3.170.tgz`) fell through **unextracted** — leaving a dangling `$HOME/.local/bin/claude` symlink. `fit-harness` then found no runnable `claude` on PATH, so libharness passed no `pathToClaudeCodeExecutable` and the SDK threw `Native CLI binary for linux-x64 not found` again (observed in a live bionova-apps storyboard run).

One-line fix: match `*.tgz` in the tar branch. Verified by running the real `install_tool` → `extract_archive` path against the actual tarball — `claude --version` → `2.1.170` with a valid symlink. (My earlier local check used `tar -xz` directly and bypassed `extract_archive`, which is why this slipped through.)

Gear binaries and the npm package are unaffected — this is purely the bootstrap installer. Propagation: bootstrap → `kata-agent` → bionova-apps.

## Test plan

- [ ] CI green.
- [ ] After merge: cut `bootstrap@v1.0.12`, bump kata-agent's pin, cut `kata-agent@v1.0.7`, bump bionova-apps, and confirm a storyboard run gets past bootstrap.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdvRLPvv5tEKf41HZX7oWY)_