### PR TITLE
ci(kata-agent): bump internal bootstrap pin to v1.0.12

### DIFF
--- a/products/kata/actions/kata-agent/action.yml
+++ b/products/kata/actions/kata-agent/action.yml
@@ -158,7 +158,7 @@ runs:
     # ./scripts/bootstrap.sh. The `token:` input gates wiki checkout —
     # leave it empty to skip wiki sync. The wiki is pushed back after the
     # agent run via forwardimpact/wiki below.
-    - uses: forwardimpact/bootstrap@af1f2e7950785db1ba3bee648cf75098c415fb42 # v1.0.11
+    - uses: forwardimpact/bootstrap@c852d29b38edbb2e6c037bf3952aac339e9fe8b8 # v1.0.12
       with:
         token: ${{ inputs.wiki == 'true' && steps.ci-app.outputs.token || '' }}
         app-slug: ${{ inputs.app-slug }}


### PR DESCRIPTION
## Summary

Bumps kata-agent's internal `bootstrap` pin from `v1.0.11` to `v1.0.12` (`c852d29b`).

`bootstrap@v1.0.11` installed `claude` via a `.tgz` tarball that `extract_archive` never unpacked (it matched only `*.tar.gz`/`*.zip`), leaving a dangling `claude` symlink and reviving the SDK "Native CLI binary not found" error in kata runs. `bootstrap@v1.0.12` carries the `.tgz` extract fix (#1898), so `claude` actually installs.

On merge, `publish-actions` reprojects the kata-agent sibling; then `kata-agent@v1.0.7` is cut and bionova-apps bumped to it.

## Test plan

- [ ] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdvRLPvv5tEKf41HZX7oWY)_