### PR TITLE
ci(release): v1 alias tracks latest release, not forward-only

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -42,11 +42,10 @@ This pinning policy governs workflow `uses:` only; a sibling's internal `uses:`
 
 ### Moving a sibling's `v1` tag
 
-Monorepo consumption stays SHA-pinned; `v1` exists only for external
-consumers. Cutting a release moves `v1` only to an existing `v1.x.y`
-release commit — reachable from the sibling's `main` and a descendant of
-`v1`'s current target. Never backward, untagged, or off-`main`; any other move
-is a compromise indicator.
+`v1` exists only for external consumers; monorepo consumption stays SHA-pinned.
+Cutting a release moves `v1` to the new `v1.x.y` commit on the sibling's `main`
+— **not** forward-only, since subtree-split re-seeds orphan old commits. The
+only guard: a tagged release commit on `main`, never off-`main`.
 
 ### `IS_SANDBOX` for headless agents
 

--- a/.github/actions/release-tagger/action.yml
+++ b/.github/actions/release-tagger/action.yml
@@ -89,23 +89,23 @@ runs:
           tag_commit="$(git rev-parse "refs/tags/$t^{commit}")"
 
           # v1-move: only for exact v<major>.<minor>.<patch> action releases.
-          # The major alias tracks the release tag's commit, moving forward only.
+          # The major alias always tracks the latest release commit — NOT
+          # forward-only. Subtree-split projections are periodically re-seeded
+          # (an upstream history rewrite orphans older projected commits), so a
+          # new release legitimately lands off the previous alias lineage; an
+          # ancestor check would wedge the alias permanently. Safety is the
+          # lighter guard below: the target carries this release tag and is on
+          # the default branch (never an arbitrary or off-branch SHA).
           printf '%s' "$t" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' || continue
           major="${t%%.*}"
-          if git rev-parse -q --verify "refs/tags/$major^{commit}" >/dev/null 2>&1; then
-            old="$(git rev-parse "refs/tags/$major^{commit}")"
-            if [ "$old" = "$tag_commit" ]; then
-              echo "$major already at $tag_commit"
-            elif git merge-base --is-ancestor "$old" "$tag_commit"; then
-              git tag -f "$major" "$tag_commit"
-              git push --force --quiet origin "refs/tags/$major"
-              echo "moved $major: $old -> $tag_commit"
-            else
-              echo "::error::refusing to move $major: current target $old is not an ancestor of $tag_commit (backward or off-line move)"; exit 1
-            fi
+          if ! git merge-base --is-ancestor "$tag_commit" "$default_ref"; then
+            echo "::error::$t ($tag_commit) is not on ${default_ref#origin/}; refusing to move $major"; exit 1
+          fi
+          if [ "$(git rev-parse -q --verify "refs/tags/$major^{commit}" 2>/dev/null || true)" = "$tag_commit" ]; then
+            echo "$major already at $tag_commit"
           else
-            git tag "$major" "$tag_commit"
-            git push --quiet origin "refs/tags/$major"
-            echo "created alias $major -> $tag_commit"
+            git tag -f "$major" "$tag_commit"
+            git push --force --quiet origin "refs/tags/$major"
+            echo "set $major -> $tag_commit"
           fi
         done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,17 +192,17 @@ release-cutting environment can't push tags.
 sibling action repos too), and `sha` (default: the target's default-branch
 tip). It pushes each tag from CI with an App token — not `GITHUB_TOKEN`, so
 publish pipelines still fire — via
-[`release-tagger`](.github/actions/release-tagger/action.yml): tags are
-append-only, an action release's `v<major>` alias moves forward-only, and only
-commits reachable from the default branch are taggable. Squash-merge leaves a
-branch's own commits off `main`, so merge first, then tag the resulting `main`
-commit.
+[`release-tagger`](.github/actions/release-tagger/action.yml): release tags are
+append-only, an action release's `v<major>` alias always tracks the latest
+release, and only commits reachable from the default branch are taggable.
+Squash-merge leaves a branch's own commits off `main`, so merge first, then tag
+the resulting `main` commit.
 
 **Composite actions** use a separate tag space: append-only `v1.0.x` on the
-sibling repos, with `v1` a forward-only major alias (dispatch `Release: Tag`
-with `repo: <sibling>` and the `v1.0.x` tag). A push to `main` mirrors each
-action to its sibling by subtree split; the publish path and `v1`-move
-constraints live in [`.github/CLAUDE.md`](.github/CLAUDE.md).
+sibling repos, with `v1` a major alias that tracks the latest release (dispatch
+`Release: Tag` with `repo: <sibling>` and the `v1.0.x` tag). A push to `main`
+mirrors each action to its sibling by subtree split; the publish path and
+`v1`-move policy live in [`.github/CLAUDE.md`](.github/CLAUDE.md).
 
 Some changes span tags: a new binary is reachable only after every tier ships.
 Release producer before consumer, bottom-up: (1) the compiled binary/bundle;


### PR DESCRIPTION
## Summary

The forward-only ancestor guard on the `v<major>` alias is incompatible with how the sibling actions actually version. Subtree-split projections get periodically **re-seeded** (an upstream history rewrite orphans the older projected commits), so a new release legitimately lands off the previous alias lineage. An ancestor check then **wedges the alias permanently** — `kata-agent`'s `v1` has been stuck at `v1.0.3` since the late-June reseed for exactly this reason (v1.0.4–v1.0.7 are all on the new lineage; none is a descendant of v1.0.3).

An opt-in override would have to be set on essentially every post-reseed release, so it's friction, not a guard. Instead:

- **`release-tagger`**: drop the ancestor check. The `v<major>` alias now always tracks the latest release commit, guarded only by the lighter, meaningful check — the target is a tagged release commit reachable from the default branch (never arbitrary or off-`main`).
- **`.github/CLAUDE.md`** § *Moving a sibling's v1 tag*: rewrite the policy to match (not forward-only; guard is a tagged release commit on `main`).
- **CONTRIBUTING**: update the two "forward-only" references.

This also removes the ugly half-success failure mode (a refused alias move used to abort the run *after* the append-only release tag was already pushed).

## Test plan

- [ ] CI green (`coaligned instructions` word budgets pass for both CLAUDE.md and CONTRIBUTING.md).
- [ ] After merge, re-dispatch `Release: Tag` for `kata-agent v1.0.7` to re-point `v1`, and sweep the other siblings for the same stale-alias condition.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MdvRLPvv5tEKf41HZX7oWY)_