### PR TITLE
feat(libwiki): refresh creates the monthly storyboard when missing

### DIFF
--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -39,10 +39,10 @@ skill only for the full Participant Protocol below.
       artifact guidance.
 - [ ] Pick metrics CSVs from `wiki/metrics/` for participants to report.
       Participants — not the facilitator — run `npx fit-xmr analyze`.
-- [ ] Team runs: confirm each metric has its `<!-- xmr:... -->` marker (a
-      participant seeds missing ones from
-      [`storyboard-template.md`](references/storyboard-template.md)); blocks
-      render from the deterministic `fit-wiki refresh` step, never the
+- [ ] Team runs: `fit-wiki refresh` creates the storyboard and renders all
+      blocks before the meeting; a participant seeds any missing
+      `<!-- xmr:... -->` marker from
+      [`storyboard-template.md`](references/storyboard-template.md), never the
       facilitator.
 
 </read_do_checklist>

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -6,7 +6,7 @@ _The long-term direction that gives meaning to target conditions and
 experiments. Changes rarely — only when strategic direction shifts._
 _**Budget: ≤100 words.** State, not history._
 
-> [Write the challenge here.]
+> [product-manager writes the challenge here.]
 
 ## Target Condition
 
@@ -16,7 +16,7 @@ in terms verifiable with data from metrics CSVs._
 _**Budget: ≤900 words** (the per-dimension table dominates; prose intro stays
 short)._
 
-> [Write the target condition here. Include specific metrics and thresholds.]
+> [product-manager writes the target condition, with metrics and thresholds.]
 
 **Due:** YYYY-MM-DD (end of month)
 

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -13,15 +13,16 @@ Experiments. Full template, with per-section word budgets, at
 ## Planning vs. Review
 
 **Planning meeting** — first meeting of the month or no storyboard exists.
-Create the storyboard from [`storyboard-template.md`](storyboard-template.md):
-for every `wiki/metrics/{skill}/{YYYY}.csv`, instantiate one
-`#### {metric_name}` block under `### {skill}` with its
-`<!-- xmr:{metric}:{csv} -->` / `<!-- /xmr -->` marker pair. Besides the
-per-skill blocks, instantiate a `#### product_share` block under
-`### product-manager` from `wiki/metrics/product-mix/{YYYY}.csv`. Then lead the
-team through: the Challenge, the Target Condition (measurable, by month end),
-the Current Condition from metrics CSVs, initial Obstacles, and the first
-Experiment.
+`npx fit-wiki refresh` creates the monthly file (section skeleton +
+`obstacles`/`experiments` markers) before the meeting. It omits the per-metric
+XmR blocks: for every
+`wiki/metrics/{skill}/{YYYY}.csv`, a participant seeds one `#### {metric_name}`
+block under `### {skill}` with its `<!-- xmr:{metric}:{csv} -->` /
+`<!-- /xmr -->` pair, plus a `#### product_share` block under
+`### product-manager` from `wiki/metrics/product-mix/{YYYY}.csv`; the next
+refresh renders them. Then lead the team through the Challenge, Target Condition
+(measurable, by month end), Current Condition from metrics CSVs, initial
+Obstacles, and the first Experiment.
 
 **Review meeting** — all other team meetings. Walk through the five questions,
 update Current Condition with fresh metrics, record experiment outcomes (actual
@@ -64,8 +65,6 @@ preserved. Rendered contents — `**Latest:**` / `**Status:**`, the X+mR chart,
 `**Signals:**` — match the template; **do not restate `μ`, `UPL`, `LPL`, or zone
 values in prose** outside the chart.
 
-If a metric is missing its marker pair, a participant seeds it from
-[`storyboard-template.md`](storyboard-template.md); the next refresh renders it.
 Markers are the contract — never paste charts or issue lists by hand.
 
 Above the agent-domain sections, write a tight `### Headlines` list naming only

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -30,9 +30,9 @@ vs. expected), update Obstacles, and plan the next experiment.
 
 ## Question Wording (Team)
 
-1. **What is the target condition?** Read the target from the storyboard. Ground
-   the conversation in where the team is headed. If the target is unclear or
-   expired, update it (planning mode).
+1. **What is the target condition?** Read the target from the storyboard. If the
+   Challenge or Target Condition is unset or expired (planning mode), `Ask` the
+   product-manager to write it into the storyboard.
 2. **What is the actual condition now?** Each participant follows the
    Participant Protocol: measure with live data, record to CSV, run
    `npx fit-xmr analyze` on its own CSV, then report each metric's `status`,

--- a/libraries/libwiki/src/commands/refresh.js
+++ b/libraries/libwiki/src/commands/refresh.js
@@ -11,6 +11,7 @@ import {
   parseRepoSlug,
 } from "../issue-list-renderer.js";
 import { parseClaims, filterExpired, removeClaim } from "../active-claims.js";
+import { renderStoryboardSkeleton } from "../storyboard-skeleton.js";
 import { currentDayIso } from "../util/clock.js";
 import { resolveProjectRoot, resolveWikiRoot } from "../util/wiki-dir.js";
 
@@ -90,9 +91,8 @@ function spliceBlock(lines, block, rendered) {
   );
 }
 
-// A missing current-month storyboard (e.g. a coaching run early in the month,
-// before the storyboard meeting created it) is non-fatal: return null so the
-// deterministic refresh step exits cleanly instead of failing the job.
+// A missing current-month storyboard is non-fatal: return null so the caller
+// can create it (see createStoryboardSkeleton) rather than fail the job.
 function readStoryboardOrNull(runtime, storyboardPath) {
   try {
     return runtime.fsSync.readFileSync(storyboardPath, "utf-8");
@@ -100,6 +100,20 @@ function readStoryboardOrNull(runtime, storyboardPath) {
     if (err.code !== "ENOENT") throw err;
     return null;
   }
+}
+
+// Create the current-month storyboard from the minimal skeleton when it does
+// not exist. Refresh is the deterministic "freshen the wiki" step and runs
+// before the session (kata-agent pre-run), so creating here guarantees the file
+// is on disk before participants look for it — without any lead having a write
+// tool. The skeleton carries the section structure and the generic issue-list
+// markers; the render pass below fills them and participants seed metric blocks.
+function createStoryboardSkeleton(runtime, storyboardPath, logger) {
+  const skeleton = renderStoryboardSkeleton(currentDayIso(runtime));
+  runtime.fsSync.mkdirSync(path.dirname(storyboardPath), { recursive: true });
+  runtime.fsSync.writeFileSync(storyboardPath, skeleton);
+  logger.info("refresh", `created storyboard at ${storyboardPath}`);
+  return skeleton;
 }
 
 // Drop every MEMORY.md `## Active Claims` row past its `expires_at`, writing the
@@ -142,11 +156,11 @@ export async function runRefreshCommand(ctx) {
     projectRoot,
     ctx.args["storyboard-path"] || currentStoryboardRelPath(runtime),
   );
-  const text = readStoryboardOrNull(runtime, storyboardPath);
-  if (text === null) {
-    logger.warn("refresh", `no storyboard at ${storyboardPath}`);
-    return { ok: true };
-  }
+  const existing = readStoryboardOrNull(runtime, storyboardPath);
+  const created = existing === null;
+  const text = created
+    ? createStoryboardSkeleton(runtime, storyboardPath, logger)
+    : existing;
   const blocks = scanMarkers(text, {
     warn: (message) => logger.warn("refresh", message),
   });
@@ -200,7 +214,7 @@ export async function runRefreshCommand(ctx) {
   if (spliced) runtime.fsSync.writeFileSync(storyboardPath, lines.join("\n"));
   if (options.format === "json") {
     runtime.proc.stdout.write(
-      JSON.stringify({ blocks: blocks.length, spliced }) + "\n",
+      JSON.stringify({ blocks: blocks.length, spliced, created }) + "\n",
     );
   }
   return { ok: true };

--- a/libraries/libwiki/src/storyboard-skeleton.js
+++ b/libraries/libwiki/src/storyboard-skeleton.js
@@ -1,0 +1,106 @@
+/**
+ * Storyboard skeleton — the minimal, valid storyboard file `fit-wiki refresh`
+ * writes when the current-month board does not yet exist. It carries only the
+ * structural surface libwiki owns: the five Toyota Kata sections and the
+ * generic `obstacles`/`experiments` issue-list marker blocks that refresh
+ * renders from tracker state.
+ *
+ * Deliberately *not* here: the per-agent `#### {metric}` XmR blocks. Their
+ * agent→metric grouping is per-installation curation libwiki cannot infer, so a
+ * participant seeds each missing marker pair (see the kata-session skill) and a
+ * later refresh renders it. Section budgets and authoring prose ("write the
+ * challenge here") stay in the skill's `storyboard-template.md`, the L4
+ * authoring layer — this skeleton is content-free scaffolding.
+ */
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/** Whether `year` is a leap year under the Gregorian rule. */
+function isLeapYear(year) {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Last calendar day of the month containing `todayIso` (ISO `YYYY-MM-DD`).
+ * Pure integer/calendar math — no `Date`, so the module stays free of ambient
+ * time deps.
+ */
+function endOfMonthIso(todayIso) {
+  const [year, month] = todayIso.split("-").map(Number);
+  const lastDay =
+    month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month - 1];
+  return `${year}-${String(month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+}
+
+/**
+ * Render the minimal storyboard skeleton for the month containing `todayIso`.
+ * Pure — takes the day as an ISO string and returns markdown. The heading reads
+ * `# Storyboard — {YYYY} {Month}`; the marker blocks match the syntax the
+ * scanner (`marker-scanner.js`) and renderer (`commands/refresh.js`) expect.
+ *
+ * @param {string} todayIso - ISO date string (`YYYY-MM-DD`).
+ * @returns {string} The skeleton markdown, newline-terminated.
+ */
+export function renderStoryboardSkeleton(todayIso) {
+  const [year, month] = todayIso.split("-").map(Number);
+  const monthName = MONTH_NAMES[month - 1];
+  return `# Storyboard — ${year} ${monthName}
+
+## Challenge
+
+> [Set during the planning meeting.]
+
+## Target Condition
+
+**Due:** ${endOfMonthIso(todayIso)}
+
+> [Set during the planning meeting.]
+
+## Current Condition
+
+**Last updated:** ${todayIso}
+
+### Headlines
+
+None.
+
+## Obstacles
+
+### Active
+
+<!-- obstacles:open Do not edit. Auto-generated. -->
+<!-- /obstacles -->
+
+### Concluded (last 7 days)
+
+<!-- obstacles:closed Do not edit. Auto-generated. -->
+<!-- /obstacles -->
+
+## Experiments
+
+### Active
+
+<!-- experiments:open Do not edit. Auto-generated. -->
+<!-- /experiments -->
+
+### Concluded (last 7 days)
+
+<!-- experiments:closed Do not edit. Auto-generated. -->
+<!-- /experiments -->
+`;
+}

--- a/libraries/libwiki/src/storyboard-skeleton.js
+++ b/libraries/libwiki/src/storyboard-skeleton.js
@@ -63,13 +63,13 @@ export function renderStoryboardSkeleton(todayIso) {
 
 ## Challenge
 
-> [Set during the planning meeting.]
+> [product-manager sets this in the planning meeting.]
 
 ## Target Condition
 
 **Due:** ${endOfMonthIso(todayIso)}
 
-> [Set during the planning meeting.]
+> [product-manager sets this in the planning meeting.]
 
 ## Current Condition
 

--- a/libraries/libwiki/test/cli-refresh.integration.test.js
+++ b/libraries/libwiki/test/cli-refresh.integration.test.js
@@ -43,6 +43,28 @@ async function refresh(cwd, storyboardPath) {
   return harness;
 }
 
+// Refresh with a stubbed `gh` returning no issues, so a freshly created
+// skeleton's issue-list blocks render hermetically. Returns the resolved
+// storyboard path (explicit arg, or the current-month default under wiki/).
+async function refreshCreates(cwd, storyboardPath) {
+  const subprocess = createMockSubprocess({
+    responses: { gh: { stdout: "[]", exitCode: 0 } },
+  });
+  const harness = makeRuntime({ cwd, now: FIXED_NOW, subprocess });
+  const gitClient = new GitClient({ runtime: harness.runtime });
+  await runRefreshCommand(
+    ctxFor({
+      runtime: harness.runtime,
+      gitClient,
+      options: {},
+      args: storyboardPath ? { "storyboard-path": storyboardPath } : {},
+    }),
+  );
+  return storyboardPath
+    ? join(cwd, storyboardPath)
+    : join(cwd, "wiki", `storyboard-${yearMonth(FIXED_NOW)}.md`);
+}
+
 describe("fit-wiki refresh CLI (in-process)", () => {
   test("no markers — file unchanged", async () => {
     const dir = createProject();
@@ -119,10 +141,29 @@ describe("fit-wiki refresh CLI (in-process)", () => {
     assert.ok(readFileSync(storyboard, "utf-8").includes("preserved content"));
   });
 
-  test("missing storyboard file — no-op, exit 0", async () => {
+  test("missing storyboard file — creates skeleton, exit 0", async () => {
     const dir = createProject();
-    // No storyboard written at all.
-    await assert.doesNotReject(() => refresh(dir, "storyboard.md"));
+    // No storyboard written at all; refresh creates it from the skeleton.
+    const created = readFileSync(
+      await refreshCreates(dir, "storyboard.md"),
+      "utf-8",
+    );
+    assert.match(created, /^# Storyboard — 2026 May$/m);
+    assert.match(created, /^## Challenge$/m);
+    assert.match(created, /^\*\*Due:\*\* 2026-05-31$/m);
+    assert.ok(created.includes("<!-- obstacles:open"));
+    assert.ok(created.includes("<!-- experiments:closed"));
+  });
+
+  test("missing storyboard defaults to the current-month path", async () => {
+    const dir = createProject();
+    await refreshCreates(dir, undefined);
+    const defaultPath = join(
+      dir,
+      "wiki",
+      `storyboard-${yearMonth(FIXED_NOW)}.md`,
+    );
+    assert.ok(readFileSync(defaultPath, "utf-8").includes("# Storyboard —"));
   });
 
   test("clears expired MEMORY.md claims even with no storyboard", async () => {
@@ -142,7 +183,7 @@ describe("fit-wiki refresh CLI (in-process)", () => {
         "",
       ].join("\n"),
     );
-    await refresh(dir, "storyboard.md"); // no storyboard file on disk
+    await refreshCreates(dir, "storyboard.md"); // no storyboard file on disk
     const after = readFileSync(join(wikiDir, "MEMORY.md"), "utf-8");
     assert.ok(!after.includes("| old |"), "expired row removed");
     assert.ok(after.includes("| new |"), "unexpired row kept");

--- a/libraries/libwiki/test/storyboard-skeleton.test.js
+++ b/libraries/libwiki/test/storyboard-skeleton.test.js
@@ -1,0 +1,64 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { renderStoryboardSkeleton } from "../src/storyboard-skeleton.js";
+import { scanMarkers } from "../src/marker-scanner.js";
+
+describe("renderStoryboardSkeleton", () => {
+  test("heading names the year and month", () => {
+    assert.match(
+      renderStoryboardSkeleton("2026-07-04"),
+      /^# Storyboard — 2026 July$/m,
+    );
+    assert.match(
+      renderStoryboardSkeleton("2026-01-31"),
+      /^# Storyboard — 2026 January$/m,
+    );
+    assert.match(
+      renderStoryboardSkeleton("2026-12-01"),
+      /^# Storyboard — 2026 December$/m,
+    );
+  });
+
+  test("Due date is the last day of the month", () => {
+    assert.match(
+      renderStoryboardSkeleton("2026-07-04"),
+      /^\*\*Due:\*\* 2026-07-31$/m,
+    );
+    assert.match(
+      renderStoryboardSkeleton("2026-02-10"),
+      /^\*\*Due:\*\* 2026-02-28$/m,
+    );
+    assert.match(
+      renderStoryboardSkeleton("2028-02-10"),
+      /^\*\*Due:\*\* 2028-02-29$/m,
+    );
+  });
+
+  test("carries the five Toyota Kata sections", () => {
+    const text = renderStoryboardSkeleton("2026-07-04");
+    for (const heading of [
+      "## Challenge",
+      "## Target Condition",
+      "## Current Condition",
+      "## Obstacles",
+      "## Experiments",
+    ]) {
+      assert.match(text, new RegExp(`^${heading}$`, "m"));
+    }
+  });
+
+  test("emits four balanced, scannable issue-list markers and no xmr blocks", () => {
+    const blocks = scanMarkers(renderStoryboardSkeleton("2026-07-04"), {
+      warn: (m) => assert.fail(`dangling marker: ${m}`),
+    });
+    assert.equal(blocks.length, 4);
+    assert.deepEqual(blocks.map((b) => `${b.topic}:${b.state}`).sort(), [
+      "experiments:closed",
+      "experiments:open",
+      "obstacles:closed",
+      "obstacles:open",
+    ]);
+    assert.ok(blocks.every((b) => b.kind === "issue-list"));
+  });
+});


### PR DESCRIPTION
## Summary

The improvement coach facilitates the team storyboard as a pure lead with no write tool, so a greenfield or start-of-month run had no one to create `wiki/storyboard-YYYY-MNN.md` — the board was posted to the discussion thread and never persisted.

- **`fit-wiki refresh` now creates the monthly storyboard when it is missing**, auto-detecting the current-month path. A new `storyboard-skeleton` module renders the five Toyota Kata sections plus the generic `obstacles`/`experiments` issue-list markers; refresh writes it, then renders the markers in the same pass. Because refresh already runs before the session (kata-agent pre-run), the board exists on disk before participants look for it — no lead write tool needed. The per-metric XmR blocks stay out of the skeleton (their agent grouping is installation-specific); participants seed them and a later refresh renders them, as the kata-session skill already prescribes.
- **Challenge/Target authoring is routed to the product-manager participant.** Q1 of the team storyboard has the coach `Ask` the product-manager to write the Challenge/Target into the storyboard when unset, keeping the lead pure while the prose still lands on disk. Placeholder text in both the skeleton and the authoring template names product-manager as the owner.
- Updated the kata-session skill and team-storyboard overlay to say refresh creates the file; kept the authoring template as the guidance layer.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (libwiki suite; new `storyboard-skeleton` unit tests + refresh integration tests)
- [x] Real-CLI smoke test: `refresh` in an empty repo creates `wiki/storyboard-<current-month>.md` (`created:true`), correct title/dates/markers; a second run is idempotent (`created:false`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVCY7omfaJAyJLzGgZ7sDT)_