### PR TITLE
chore(release): cut libwiki@v0.2.34 and 29 dependents

### DIFF
--- a/libraries/libcli/package.json
+++ b/libraries/libcli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libcli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Agent-friendly CLIs — self-documenting entry points that humans and agents reach through the same interface.",
   "keywords": [
     "cli",

--- a/libraries/libconfig/package.json
+++ b/libraries/libconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libconfig",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "description": "Environment-aware application settings — services and CLIs load configuration without custom plumbing.",
   "keywords": [
     "config",

--- a/libraries/libformat/package.json
+++ b/libraries/libformat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libformat",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Render markdown to ANSI or HTML — formatted output in any surface without losing structure.",
   "keywords": [
     "markdown",

--- a/libraries/libindex/package.json
+++ b/libraries/libindex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libindex",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "JSONL-backed indexes with filtering and buffered writes — fast context lookup without an external search engine.",
   "keywords": [
     "index",

--- a/libraries/libmacos/package.json
+++ b/libraries/libmacos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libmacos",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "macOS bundle assembly, code signing, and OS permission helpers — desktop delivery without platform ceremony.",
   "keywords": [
     "macos",

--- a/libraries/libmcp/package.json
+++ b/libraries/libmcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libmcp",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Config-driven gRPC-to-MCP tool registration — expose protobuf services as agent tools without glue code.",
   "keywords": [
     "mcp",

--- a/libraries/libmock/package.json
+++ b/libraries/libmock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libmock",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Shared mocks and test fixtures so every library and service tests the same way.",
   "keywords": [
     "test",

--- a/libraries/libpolicy/package.json
+++ b/libraries/libpolicy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libpolicy",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "Access-control policy evaluation — scoped context access without per-service authorization logic.",
   "keywords": [
     "policy",

--- a/libraries/libprompt/package.json
+++ b/libraries/libprompt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libprompt",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Prompt templates from .prompt.md files — structured prompts without string concatenation.",
   "keywords": [
     "prompt",

--- a/libraries/libproto/package.json
+++ b/libraries/libproto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libproto",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Shared protobuf schemas — one editable source for the service contracts every product imports.",
   "keywords": [
     "proto",

--- a/libraries/librepl/package.json
+++ b/libraries/librepl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/librepl",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Agent-friendly interactive REPL — exploratory interfaces that humans and agents navigate the same way.",
   "keywords": [
     "repl",

--- a/libraries/libsecret/package.json
+++ b/libraries/libsecret/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libsecret",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Secret generation, JWT signing, and .env file management for services and CLIs.",
   "keywords": [
     "secret",

--- a/libraries/libsupervise/package.json
+++ b/libraries/libsupervise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libsupervise",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Process supervision driven by JSON daemon manifests — services stay running and recoverable without manual intervention.",
   "keywords": [
     "supervisor",

--- a/libraries/libtemplate/package.json
+++ b/libraries/libtemplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libtemplate",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Mustache template loader with project-level overrides — consistent rendered output across surfaces.",
   "keywords": [
     "template",

--- a/libraries/libtype/package.json
+++ b/libraries/libtype/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libtype",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "description": "Generated protobuf types and namespaces — one source of truth for service contracts.",
   "keywords": [
     "type",

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Agent-friendly web surfaces — share handler logic across web and terminal so capabilities ship once, not twice.",
   "keywords": [
     "ui",

--- a/libraries/libwiki/package.json
+++ b/libraries/libwiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libwiki",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Wiki lifecycle for agent teams — persistent memory, declarative integrity audits, and a collision ledger so coordination survives across sessions and parallel work.",
   "keywords": [
     "wiki",

--- a/products/landmark/package.json
+++ b/products/landmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/landmark",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Surface engineering progress from activity evidence — outcomes visible without singling out individuals.",
   "keywords": [
     "engineering",

--- a/products/map/package.json
+++ b/products/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/map",
-  "version": "0.15.61",
+  "version": "0.15.62",
   "description": "Validate, store, and publish agent-aligned engineering standards so expectations are operational, not tribal.",
   "homepage": "https://www.forwardimpact.team",
   "repository": {

--- a/products/summit/package.json
+++ b/products/summit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/summit",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Model team capability as a system — staffing decisions backed by evidence, not intuition.",
   "keywords": [
     "team",

--- a/services/bridge/package.json
+++ b/services/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svcbridge",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Canonical threaded-discussion store — single source of truth for GitHub/Microsoft Teams bridge state.",
   "keywords": [
     "discussion",

--- a/services/embedding/package.json
+++ b/services/embedding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svcembedding",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Text embeddings over gRPC — semantic representation without each product running its own inference.",
   "keywords": [
     "embedding",

--- a/services/ghserver/package.json
+++ b/services/ghserver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svcghserver",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "GitHub App key custody and short-lived installation-token minting surface for the hosted control plane.",
   "keywords": [
     "github",

--- a/services/graph/package.json
+++ b/services/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svcgraph",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "description": "RDF knowledge graph over gRPC — relationship queries without each product standing up its own store.",
   "keywords": [
     "graph",

--- a/services/map/package.json
+++ b/services/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svcmap",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Activity reads and writes over gRPC — the agent-facing gateway to Map's activity database.",
   "keywords": [
     "map",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svcmcp",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Unified MCP server — agents reach backend services as tools without per-service integration.",
   "keywords": [
     "mcp",

--- a/services/oauth/package.json
+++ b/services/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svcoauth",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OAuth 2.1 authorization server adapter — protocol-only HTTP front that delegates to a configured provider backend over gRPC.",
   "keywords": [
     "oauth",

--- a/services/pathway/package.json
+++ b/services/pathway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svcpathway",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Engineering standard queries over gRPC — career paths and agent profiles as derivable data for products.",
   "keywords": [
     "pathway",

--- a/services/trace/package.json
+++ b/services/trace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svctrace",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "description": "OpenTelemetry span ingestion and storage over gRPC — prove whether agent changes improved outcomes.",
   "keywords": [
     "trace",

--- a/services/vector/package.json
+++ b/services/vector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/svcvector",
-  "version": "0.1.129",
+  "version": "0.1.130",
   "description": "Vector similarity search over gRPC — semantic retrieval without a dedicated database per product.",
   "keywords": [
     "vector",


### PR DESCRIPTION
## Summary

Full-sweep release cut.

- **libwiki 0.2.33 → 0.2.34** — ships storyboard auto-creation on `fit-wiki refresh` (PR #1902).
- **29 dependents** — each carries the #1856 squash ride-along (README/bin scaffolds and dependency-range updates) that was never re-tagged. This sweep cuts a patch for each so their published artifacts match `main`.

Version bump rule: pre-1.0 packages patch on any change; `libui` (post-1.0) patch (no API change). Only `package.json` version fields change.

Tags are pushed after merge via the `Release: Tag` workflow (append-only, App token), pointing at the resulting `main` commit.

## Test plan

- [x] `bun install`
- [x] `bun run check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01PVCY7omfaJAyJLzGgZ7sDT)_