### PR TITLE
design(2170): reusable kata-interview action + fit-map/fit-harness CLI split

### DIFF
--- a/specs/2170-reusable-interview-action/design-a.md
+++ b/specs/2170-reusable-interview-action/design-a.md
@@ -1,0 +1,151 @@
+# Design 2170: Reusable interview action + CLI split
+
+Restates spec 2170: extract the generic switching-interview infrastructure into
+a published composite action, push its two untested inline-bash blocks into
+tested verbs on `fit-map` and `fit-harness`, parameterize the entry point, and
+reduce the workflow to a wrapper — so an external consumer (Polaris) can run its
+own interview.
+
+## Components
+
+| Component | Location | Purpose |
+| --- | --- | --- |
+| `kata-interview` action | `products/kata/actions/kata-interview/action.yml` | Composite action owning generic interview infra; published by subtree split, consumed SHA-pinned |
+| Action README | `products/kata/actions/kata-interview/README.md` | Input/output contract for external consumers |
+| Supabase-env emit | `products/map/src/commands/substrate-stage.js` (dispatched via `products/map/bin/dispatch-substrate.js`) | Emit `SUPABASE_URL`/`SUPABASE_ANON_KEY` as env-file lines |
+| Log secret scan | `libraries/libharness/` (`fit-harness scan-logs`) + `libraries/libharness/src/commands/` | Scan a run's log archive for secret literals; fail closed |
+| Workflow wrapper | `.github/workflows/kata-interview.yml` | Thin `workflow_dispatch` wrapper; passes inputs to the action and retains `concurrency` + job `timeout-minutes` (a composite action cannot declare either) |
+| Shape test | `.github/workflows/test/kata-interview-shape.test.js` | Assert generic substrate gating + sub-60 timeout |
+| Skill parameterization | `.claude/skills/kata-interview/{SKILL.md,references/job-handoff.md}` | Read entry-point URL from env, not hardcoded |
+| Reference wiring | `references/bionova-apps/` | Document a Polaris interview workflow wrapping the action |
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph consumer["Consumer workflow (this repo OR bionova-apps)"]
+        wf["kata-interview.yml — workflow_dispatch inputs"]
+    end
+    wf -->|uses, SHA-pinned| act
+
+    subgraph act["kata-interview composite action"]
+        ks["killswitch → token → checkout → bootstrap (+supabase)"]
+        tb["fit-terrain build"]
+        sub["substrate stage + env emit (if substrate)"]
+        run["fit-harness supervise — kata-interview skill"]
+        post["fit-trace cost → wiki push → scan-logs (if substrate)"]
+        ks --> tb --> sub --> run --> post
+    end
+
+    sub -->|"fit-map substrate ... --emit-env $GITHUB_ENV"| fm["fit-map"]
+    post -->|"fit-harness scan-logs --run-id ... --secret ..."| fh["fit-harness"]
+    run -->|"website-url in agent env; two Asks"| agent["isolated persona agent → website-url"]
+```
+
+## Action interface
+
+Inputs mirror `kata-agent` for the shared knobs (`app-id`, `app-private-key`,
+`anthropic-api-key`, `app-slug`, `max-turns`, `timeout-minutes`,
+`allowed-tools`, `killswitch`) and add the interview-specific ones:
+
+| Input | Required | Role |
+| --- | --- | --- |
+| `website-url` | yes | Entry point handed to the persona agent in Ask 2 |
+| `product` | no | Product to interview; empty lets the supervisor pick |
+| `job` | no | JTBD goal to test; empty lets the supervisor pick |
+| `task-amend` | no | Steering appended to the task prompt |
+| `substrate` | no (default `false`) | Whether to bring up the Supabase substrate + run the post-run secret scan |
+| `substrate-force-empty-corpus` | no | CI assertion toggle for the empty-corpus failure path (renames the workflow's current `empty-corpus-test` input for the substrate-generic vocabulary) |
+| `jwt-secret`, `service-role-key` | no | Substrate secrets, forwarded only when `substrate` |
+
+Composite actions cannot read `secrets.*` (`.github/CLAUDE.md`), so
+`jwt-secret`/`service-role-key` are **inputs** the wrapper passes from its own
+`secrets.*` — this is why the substrate secrets become action inputs rather than
+being read internally. Outputs pass through the harness
+`trace-file`/`trace-dir`. The action sets `WEBSITE_URL` (and, under substrate,
+`SUPABASE_URL`/`SUPABASE_ANON_KEY` via `$GITHUB_ENV`) into the run environment;
+the supervisor reads `WEBSITE_URL` when composing Ask 2. Substrate steps and the
+secret scan are gated on `inputs.substrate == 'true'`, replacing every
+`product == 'landmark'` literal.
+
+## CLI verb interfaces
+
+| Verb | Signature | Behaviour |
+| --- | --- | --- |
+| `fit-map substrate stage` | add `--emit-env <path>` | After the `url-discovery` phase, append `SUPABASE_URL=<url>` and `SUPABASE_ANON_KEY=<key>` lines to `<path>`; the action points it at `$GITHUB_ENV`. Removes the workflow's inline `supabase status --output json` + `python3`. |
+| `fit-harness scan-logs` | `--archive <zip>` \| `--run-id <id> --repo <owner/repo>`; repeatable `--secret <label>=<literal>` | Resolve a log archive (download via `gh` when `--run-id`), scan every entry for each non-empty secret literal, print `FAIL: <label> literal in run logs` per hit, exit non-zero on any hit; fail closed if the archive cannot be read. |
+
+`--emit-env` reuses the URL already parsed in the `url-discovery` phase, so no
+second `supabase status` call. `scan-logs` takes secret literals as inputs
+(never reads them from a fixed env name) so it is generic to any run; the action
+passes the persona JWT (from the `--stash` file), `jwt-secret`, and
+`service-role-key`.
+
+## Interview run wiring
+
+The action calls the harness `supervise` mode exactly as the workflow does today
+(`lead-profile: product-manager`, `supervisor-cwd: .`, `agent-cwd` = the staged
+temp dir, `IS_SANDBOX=1`, `task-text` = "Run the `kata-interview` skill"). The
+killswitch moves into the action as its first composite step (as `kata-agent`
+does); `concurrency` and the job `timeout-minutes` stay on the wrapper workflow,
+which a composite action cannot declare. The other additions are `WEBSITE_URL`
+on the run env and the generic substrate gating. The skill's Step 5 reads
+`WEBSITE_URL` from the environment; the `job-handoff` reference's Ask 2 template
+and both worked examples use that value instead of the literal
+`https://www.forwardimpact.team`. When unset (never, from the action), the skill
+errors rather than inventing a URL.
+
+## Key Decisions
+
+| Decision | Chosen | Rejected | Why |
+| --- | --- | --- | --- |
+| Split seam | `fit-map` owns Supabase-env emit; `fit-harness` owns log scan | One new `fit-interview` CLI / `libinterview` | Each block already has a domain owner; a new package would need to join the gear bundle and duplicate substrate/run ownership. Splitting keeps each verb beside the lifecycle it belongs to. |
+| Substrate gating | Generic `substrate` boolean input | Keep `product == 'landmark'` | The product-name predicate is monorepo-only; Polaris is substrate-backed but not named "landmark". A boolean makes the action reusable and keeps the shape invariant meaningful. |
+| Entry point | `website-url` input → `WEBSITE_URL` env → skill reads it | Hardcode per-consumer skill fork; or a skill config file | An env var threads cleanly from action input to the supervisor with no new file; the skill stays a single published artifact. A per-consumer fork defeats reuse. |
+| Publish path | Subtree-split sibling, SHA-pinned — one new `publish-actions.yml` matrix entry + path filter | Reference the action by local path only | Consumers are *other repos* (Polaris); only a published sibling is consumable cross-repo. The mechanism already ships `kata-agent`, so this reuses it rather than inventing one. |
+| `scan-logs` input model | Secret literals passed as `--secret` args | Read a fixed env var (`JWT_SECRET`, …) | Passing literals keeps the verb generic and unit-testable against a fixture archive with no CI secrets; the action supplies the three literals. |
+| `scan-logs` home | `fit-harness` | `fit-trace` | The GH log archive is not an NDJSON trace; scanning a run's own output for leaked secrets is a run-lifecycle concern `fit-harness` already owns. |
+| `fit-map` on PATH | Keep the documented `bunx fit-map` exception | Move `fit-map` into the gear bundle | Out of scope; `fit-map` ships in the `map@v*` release. The action documents the exception exactly as the workflow does today. |
+
+## Data flow — substrate interview
+
+```text
+bootstrap installs CLIs + supabase
+  → fit-terrain build                         (synthetic data)
+  → fit-map substrate stage --cwd $AGENT_CWD --emit-env $GITHUB_ENV
+       (init→stack→url-discovery→migrate→seed→provision→smoke;
+        SUPABASE_URL/SUPABASE_ANON_KEY appended to $GITHUB_ENV)
+  → supervisor: fit-map substrate pick / issue --stash $RUNNER_TEMP/.persona-jwt
+  → fit-harness supervise (kata-interview skill; WEBSITE_URL in agent env)
+  → fit-trace cost → wiki push
+  → fit-harness scan-logs --run-id $RUN_ID --repo $REPO \
+       --secret <persona-jwt> --secret <jwt-secret> --secret <service-role-key>
+```
+
+For a non-substrate interview (`substrate: false`), the substrate stage,
+env emit, `pick`/`issue`, and `scan-logs` steps are skipped; the persona is
+built from `story.dsl`/`prose-cache.json` as today.
+
+## Reference-app wiring
+
+`references/bionova-apps/` gains, in its spec/design prose (not a monorepo
+workflow), a documented `interview.yml` that wraps
+`forwardimpact/kata-interview@<sha>` with `website-url` = the Polaris entry
+point, `substrate: true`, and Polaris' `JWT_SECRET`/`SERVICE_ROLE_KEY`. Because
+Polaris already vendors `story.dsl` and runs `fit-terrain build`, the action's
+build + substrate + scan path applies unchanged. The interview needs none of
+spec 1160's `--output-root` prerequisite: it stages synthetic data into a temp
+`agent-cwd`, not the app tree, so the `rm -rf`-on-project-root hazard that flag
+addresses never arises here.
+
+## Test strategy
+
+- **`fit-map` emit** — unit test asserts `--emit-env <tmp>` writes the two
+  `KEY=value` lines from a stubbed status source.
+- **`fit-harness scan-logs`** — unit test builds a fixture archive, asserts
+  non-zero + `FAIL:` line on a planted literal and zero on a clean archive, and
+  asserts fail-closed on an unreadable archive.
+- **Shape test** — parses both files: on `action.yml`, substrate-only steps and
+  substrate-selecting env keys carry the `substrate` predicate and no
+  `product == 'landmark'` literal appears; on the wrapper workflow, the
+  interview job's `timeout-minutes < 60`.

--- a/specs/2170-reusable-interview-action/spec.md
+++ b/specs/2170-reusable-interview-action/spec.md
@@ -1,0 +1,211 @@
+# Spec 2170: Package the interview capability as a reusable published action
+
+**Classification:** Internal. The bulk of the change lands under `.github/`
+(a new composite action and a slimmed workflow), `libraries/libharness/` (a
+`fit-harness` verb), and `.claude/skills/` (skill parameterization). One verb
+lands under `products/map/` (`fit-map substrate`), but it extends substrate
+CI-provisioning machinery, not a persona-facing product feature. The change
+serves the **Platform Builders** persona indirectly by making the interview
+capability consumable by external teams, but no shipped end-user product
+surface changes behaviour.
+
+## Problem
+
+The JTBD switching-interview capability — build a persona from synthetic data,
+hand a job to an isolated agent at a public website, capture friction as issues
+— lives almost entirely as inline bash in one workflow,
+`.github/workflows/kata-interview.yml`. That workflow is not reusable:
+
+- **Generic infrastructure is welded to monorepo specifics.** Substrate
+  bring-up, Supabase URL discovery, cost reporting, and run-log secret scanning
+  are generic to any interview, but they sit beside a hardcoded
+  `inputs.product == 'landmark'` predicate, a hardcoded entry-point URL
+  (`https://www.forwardimpact.team`), and monorepo-only App slugs. A second
+  repository cannot run an interview without copying and editing the whole file.
+- **Load-bearing logic is untested inline bash.** Supabase status is parsed
+  with an inline `python3` snippet; the secret-literal log scan is ~50 lines of
+  inline bash that downloads a log archive, unzips it, and greps. Neither has a
+  unit test — only the workflow *shape* is asserted
+  (`.github/workflows/test/kata-interview-shape.test.js`).
+- **The reference app has no path to interview itself.** Spec 1160
+  (`references/bionova-apps/`) builds Polaris, a patient-facing product that
+  runs `fit-terrain` over the same synthetic DSL and is backed by a self-hosted
+  Supabase stack. Proving Forward Impact's method for an external team should
+  include interviewing Polaris the same way this repo interviews its own
+  products — but the interview workflow cannot be consumed, only forked.
+
+Every other Kata CI capability is a published, SHA-pinned composite action with
+its glue extracted into tested CLIs (`kata-agent` wraps `bootstrap`, `harness`,
+`wiki`). The interview is the exception.
+
+### Who is affected
+
+- **The Kata team** — the interview workflow is unmaintainable inline bash and
+  its critical secret-scan gate is untestable.
+- **External teams / Platform Builders** — no reusable way to run switching
+  interviews against their own product; the pitch to leaders lacks a running
+  external example of the interview loop.
+- **The BioNova Polaris reference** — cannot demonstrate the interview
+  capability, weakening the "the method works outside the monorepo" proof.
+
+## Proposal
+
+Extract the generic interview capability into a **published composite action**,
+push its load-bearing bash into **tested CLI verbs split across `fit-map` and
+`fit-harness`**, and **parameterize the target** so a consumer supplies its own
+entry point and product. Reduce `kata-interview.yml` to a thin wrapper over the
+action, and update the Polaris reference to wrap the same action.
+
+### A reusable `kata-interview` action
+
+A new composite action, canonical source at
+`products/kata/actions/kata-interview/`, published to a `forwardimpact/`
+sibling by subtree split and consumed SHA-pinned — the mechanism that already
+ships `kata-agent`. It owns the **generic** interview infrastructure:
+
+- Killswitch, installation-token minting, checkout, and environment bootstrap
+  (including installing the CLIs the run needs and the Supabase CLI). A
+  composite action cannot declare `concurrency` or a job-level
+  `timeout-minutes`, so those stay on the thin wrapper workflow (§ Scope).
+- Synthetic-data build (`fit-terrain build`).
+- Optional substrate + Supabase bring-up and env propagation, gated on a
+  generic `substrate` input — **not** a hardcoded product name.
+- The supervised interview run via the harness in `supervise` mode.
+- Cost reporting, wiki push, and run-log secret scanning.
+
+It exposes **app-specific** choices as inputs: the entry-point `website-url`,
+`product`, `job`, steering `task-amend`, whether the run is `substrate`-backed,
+and the usual auth and turn/timeout knobs. A consumer wraps the action in its
+own workflow, passing these; the action contributes no monorepo-specific
+assumptions.
+
+### CLI split — the right seam between `fit-map` and `fit-harness`
+
+The two untested inline-bash blocks move to the CLI that already owns their
+domain. Each verb ships with a unit test, which the inline bash never had. The
+seam rationale (which CLI, and why not `fit-trace`) is a design concern.
+
+| Capability | Home CLI |
+| --- | --- |
+| Emit `SUPABASE_URL` + `SUPABASE_ANON_KEY` as env-file lines after substrate bring-up | `fit-map substrate` (owns the substrate lifecycle) |
+| Scan a completed run's log archive for secret literals and fail closed on any hit | `fit-harness` (owns the agent-run lifecycle) |
+
+`scan-logs` does not read secrets from fixed env names — the caller passes the
+literals to check. The action supplies three: the persona JWT (from the
+`fit-map substrate issue --stash` file), plus the substrate `jwt-secret` and
+`service-role-key`. This cross-CLI handoff (one `fit-map` verb produces a
+literal a `fit-harness` verb consumes) is expressed through the verb's input
+list, not a hidden coupling.
+
+### Parameterized target — reads inputs, no hardcoded entry point
+
+The `kata-interview` skill and its `job-handoff` reference stop hardcoding
+`https://www.forwardimpact.team` — including the two worked examples in
+`job-handoff.md`, which switch to a `<website-url>` placeholder so the file
+carries no literal entry point. The action passes the consumer's `website-url`
+into the run environment; the supervisor reads it when composing Ask 2. Product
+and job selection already read `JTBD.md` and `products/` — surfaces every
+MONOREPO.md-compliant installation carries — so no further generalization of
+selection is required. Substrate gating moves from the `landmark` product name
+to the generic `substrate` input the action already carries.
+
+### Reference-app enablement (secondary goal)
+
+The monorepo deliverable is the action, the CLI verbs, and the parameterized
+skill. The reference-side deliverable is **documentation only**: the
+`references/bionova-apps/` staging area (this repo, per `references/CLAUDE.md`)
+gains prose describing an interview workflow that wraps the published action
+against Polaris' Supabase stack and `https://` entry point. It does not require
+Polaris application code to exist or run — building Polaris is spec 1160 work in
+the external repo, tracked separately. Because the interview stages synthetic
+data into a temporary agent working directory (never the app tree), it needs no
+part of the Polaris build beyond the vendored `story.dsl` every installation
+already carries.
+
+## Scope
+
+### Included
+
+- New composite action `products/kata/actions/kata-interview/` (`action.yml` +
+  `README.md`), wired into the subtree-split publish set.
+- `fit-map substrate` gains a way to emit `SUPABASE_URL`/`SUPABASE_ANON_KEY` as
+  env-file lines to a caller-named path, with a unit test.
+- `fit-harness` gains a `scan-logs` verb that scans a run's log archive for a
+  set of secret literals and exits non-zero on any hit, with a unit test.
+- `.github/workflows/kata-interview.yml` refactored to a thin wrapper over the
+  action; its inline `python3` parse and inline log-scan bash removed.
+- Substrate gating expressed as a generic `substrate` input, replacing the
+  `inputs.product == 'landmark'` predicate throughout the workflow and action.
+- `website-url` action input threaded into the run; `kata-interview` SKILL.md
+  and `references/job-handoff.md` read the entry point rather than hardcoding
+  `forwardimpact.team`.
+- The shape-invariant test updated to assert the generic `substrate` gating on
+  the action's substrate-only steps and the sub-60-minute `timeout-minutes` on
+  the wrapper workflow's job (`concurrency` and the job timeout stay on the
+  wrapper, since a composite action cannot declare either).
+- Reference update in `references/bionova-apps/` documenting a Polaris interview
+  workflow that wraps the published action.
+
+### Excluded
+
+- Renaming any sibling repo or CLI, or moving `fit-map` into the gear bundle —
+  the action keeps the documented `bunx fit-map` exception.
+- Changing the interview loop itself — the two-Ask handoff, persona isolation,
+  and finding-classification Process in the skill are unchanged.
+- Changing the harness `supervise` contract or the `fit-trace cost` report.
+- Managed Supabase, or any Polaris application code (that is spec 1160 work in a
+  separate repo).
+- Publishing a `fit-interview` CLI or a new library — the logic splits onto the
+  two existing surfaces.
+
+## Prerequisites
+
+- None blocking. The co-located action home (`products/kata/actions/`) and the
+  subtree-split publish mechanism (`.github/workflows/publish-actions.yml`)
+  already exist and already ship `kata-agent`; adding `kata-interview` is one
+  matrix entry and one path filter. **Spec 2140 — subtree-split actions** (plan
+  approved) is related work on that mechanism, not a hard dependency.
+
+## Success Criteria
+
+1. `products/kata/actions/kata-interview/action.yml` exists, declares the inputs
+   in § A reusable `kata-interview` action, and emits a `trace-file` output.
+   Verify (manual acceptance, not a merge-gate check): a `workflow_dispatch` of
+   the wrapper with `substrate: false` yields a non-empty `trace-file` output
+   and a cost line in the step summary.
+
+2. The `kata-interview.yml` workflow contains no inline `python3` Supabase parse
+   and no inline log-scan bash. Verify:
+   `rg 'python3|supabase status' .github/workflows/kata-interview.yml` returns
+   nothing, and the workflow calls the action.
+
+3. `fit-map substrate stage` gains a flag/mode that emits the Supabase URL and
+   anon key as env-file lines to a caller-named path. Verify: with the flag set,
+   the verb writes `SUPABASE_URL=` and `SUPABASE_ANON_KEY=` lines to the path,
+   covered by a passing unit test.
+
+4. `fit-harness scan-logs` accepts a resolved log archive plus secret literals,
+   owns the archive download when given a run id, and exits non-zero when any
+   supplied literal appears in the logs and zero when none do. Verify: a unit
+   test asserts both the hit (non-zero) and clean (zero) paths against a fixture
+   archive.
+
+5. Substrate steps are gated on the generic `substrate` input, with no
+   `product == 'landmark'` literal in the workflow or action. Verify: the shape
+   test asserts substrate steps carry the `substrate` predicate and
+   `rg "product\s*==\s*'landmark'"` over the workflow and action returns
+   nothing.
+
+6. The entry-point URL is not hardcoded in the interview skill. Verify:
+   `rg 'forwardimpact\.team' .claude/skills/kata-interview/` returns nothing;
+   the skill reads the URL from the run environment.
+
+7. The wrapper workflow's interview job declares a `timeout-minutes` strictly
+   under 60 (kept at the current `50`) so a stalled run cannot outlive its
+   1-hour App token; the composite action cannot set this. Verify: the shape
+   test asserts the wrapper job's `timeout-minutes < 60`.
+
+8. `references/bionova-apps/` prose documents a Polaris interview workflow that
+   wraps the published `kata-interview` action with Polaris' entry point and
+   `substrate: true` (documentation only; no Polaris code required). Verify:
+   the reference names the action and passes `website-url` + `substrate` inputs.


### PR DESCRIPTION
## Summary

Combined spec + design (lockstep co-execution) for spec 2170. Packages the JTBD
switching-interview capability — today almost entirely inline bash in
`.github/workflows/kata-interview.yml` — into a reusable, published composite
action, and splits its two untested inline-bash blocks into tested CLI verbs.

- **Reusable action** — new `products/kata/actions/kata-interview/`, published
  by subtree split and consumed SHA-pinned (the mechanism that already ships
  `kata-agent`). It owns the generic interview infra: killswitch, token,
  checkout, bootstrap, `fit-terrain build`, optional substrate/Supabase
  bring-up, the harness `supervise` run, cost, wiki push, and log scan.
- **CLI split across two existing surfaces** — `fit-map substrate stage`
  gains an env-emit mode for `SUPABASE_URL`/`SUPABASE_ANON_KEY` (removes the
  inline `supabase status` + `python3`); `fit-harness` gains a `scan-logs`
  verb (removes the inline secret-literal log scan). Both get unit tests.
- **Parameterized target** — substrate gating moves from the hardcoded
  `product == 'landmark'` to a generic `substrate` input, and the entry point
  moves from a hardcoded `forwardimpact.team` to a `website-url` input the
  skill reads. This is what lets the BioNova Polaris reference
  (`references/bionova-apps/`) interview its own product.
- The workflow shrinks to a thin wrapper (which retains `concurrency` and the
  job `timeout-minutes`, since a composite action cannot declare either).

Files: `specs/2170-reusable-interview-action/spec.md` and `design-a.md`. This is
a design-phase PR; `wiki/STATUS.md` row 2170 is at `design approved`.

Reviewed by a product + technical panel on the spec and a technical panel on
the design; blocker/high/medium findings addressed before opening.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01C7dESxLduP3KkzZauo679w

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7dESxLduP3KkzZauo679w)_