### PR TITLE
plan(2170): reusable interview action + CLI split

### DIFF
--- a/specs/2170-reusable-interview-action/plan-a-01.md
+++ b/specs/2170-reusable-interview-action/plan-a-01.md
@@ -1,0 +1,116 @@
+# Plan 2170 — Part 01: CLI verbs
+
+Extract the two untested inline-bash blocks into tested verbs on the CLIs that
+own their domain. Independently landable; lands before part 02.
+
+Libraries used: libcli, libutil (`runtime`), and the archive download/unzip
+pattern in `libraries/libharness/src/trace-github.js`.
+
+## Step 1 — `fit-map substrate stage --emit-env`
+
+Emit `SUPABASE_URL`/`SUPABASE_ANON_KEY` as env-file lines after the
+`url-discovery` phase, reusing the URL already parsed there.
+
+Files:
+
+- Modified: `products/map/src/commands/substrate-stage.js`
+- Modified: `products/map/bin/fit-map.js`
+- Modified: `products/map/bin/dispatch-substrate.js`
+- Modified: `products/map/test/activity/substrate-stage.test.js`
+
+Change:
+
+- `runStageCommand` gains an `emitEnv` param (the caller-named path). In the
+  `url-discovery` phase, after `runtime.proc.env.SUPABASE_URL`/`SUPABASE_ANON_KEY`
+  are set, when `emitEnv` is set append these two lines to that path via
+  `runtime.fs.appendFile` (create-if-absent):
+
+  ```text
+  SUPABASE_URL=<API_URL>
+  SUPABASE_ANON_KEY=<ANON_KEY>
+  ```
+
+- **Declare the flag on the CLI.** The `substrate stage` command in
+  `products/map/bin/fit-map.js` currently declares only `cwd` (lines 95–100);
+  add an `"emit-env": { type: "string", description: "…" }` option beside it.
+  Without this, libcli's strict `parseArgs` throws `ERR_PARSE_ARGS_UNKNOWN_OPTION`
+  on the action's `bunx fit-map substrate stage --emit-env …` and the substrate
+  leg crashes before staging.
+- `dispatchSubstrate` threads `values["emit-env"]` into the `stage` case:
+  `runStageCommand({ config, target: values.cwd, emitEnv: values["emit-env"], runtime })`.
+
+Verification: `bunx fit-map substrate stage --emit-env /tmp/env.out --cwd /tmp/x`
+parses without an unknown-option error (exercises the real `fit-map` libcli path,
+not the `dispatch-substrate.js` USAGE string); the unit test below passes.
+
+## Step 2 — `fit-map` emit unit test
+
+Assert `--emit-env <tmp>` writes exactly the two `KEY=value` lines from the
+stubbed status source, and that omitting it writes nothing.
+
+Files:
+
+- Modified: `products/map/test/activity/substrate-stage.test.js`
+
+Change: add a `describe("substrate-stage --emit-env")` block. With the existing
+`buildDeps` stub (`API_URL: http://supabase.local`, `ANON_KEY: anon-key`), pass
+`emitEnv` = a path in an injected in-memory fs (or a real `mkdtemp`), run
+`runStageCommand`, and assert the file contains
+`SUPABASE_URL=http://supabase.local\nSUPABASE_ANON_KEY=anon-key\n`. A second case
+asserts no file is written when `emitEnv` is unset.
+
+Verification: `bun test products/map/test/activity/substrate-stage.test.js`
+passes.
+
+## Step 3 — `fit-harness scan-logs` verb
+
+Scan a run's log archive for a set of secret literals and exit non-zero on any
+hit; fail closed if the archive cannot be read.
+
+Files:
+
+- Created: `libraries/libharness/src/commands/scan-logs.js`
+- Modified: `libraries/libharness/bin/fit-harness.js`
+
+Change:
+
+- New `runScanLogsCommand(ctx)` returning the standard `{ok, code, error}`
+  envelope. Options: `--archive <zip>` (a resolved archive) **or**
+  `--run-id <id> --repo <owner/repo>` (download the run's log archive), plus
+  repeatable `--secret <label>=<literal>` declared with **`multiple: true`** (a
+  repeated flag is collected into an array only when the option declares
+  `multiple: true`; without it `parseArgs` keeps only the last `--secret`, so the
+  scan would silently check one literal instead of three). Parse each
+  `label=literal` and skip empties.
+- Resolution: with `--archive`, read it directly. With `--run-id`, download the
+  **run-log** archive from `/repos/{repo}/actions/runs/{runId}/logs` (a direct
+  302-to-zip — not the `/artifacts` listing API `downloadTrace` uses). Reuse only
+  the fetch → `pipeline` → `runtime.subprocess.run("unzip", …)` mechanics from
+  `trace-github.js:238–265` (bearer-token fetch, stream to a temp zip, unzip),
+  driven by `GH_TOKEN`. Fail closed (`{ok:false}`) if download or unzip fails.
+- Scan every extracted file for each non-empty literal; print
+  `FAIL: <label> literal in run logs` per hit to stderr; return `{ok:false}` if
+  any hit, `{ok:true}` if none. `scan-logs` never reads a fixed secret env name —
+  `GH_TOKEN` is auth only, not a scanned value.
+- Wire the command into `fit-harness.js`: import `runScanLogsCommand`, add a
+  `{ name: "scan-logs", args: [], handler: runScanLogsCommand, description, options }`
+  entry with the three options, and add an `examples` line.
+
+Verification: `fit-harness scan-logs --help` lists `--archive`, `--run-id`,
+`--repo`, `--secret`; the unit test below passes.
+
+## Step 4 — `fit-harness scan-logs` unit test
+
+Assert the hit, clean, and fail-closed paths against a fixture archive.
+
+Files:
+
+- Created: `libraries/libharness/test/scan-logs.test.js`
+
+Change: build a fixture zip in a `mkdtemp` dir (write a log file, zip it with
+`runtime.subprocess.run("zip", …)` — CI carries `zip`/`unzip`). Assert:
+(a) a planted literal ⇒ non-zero envelope + `FAIL:` on stderr;
+(b) a clean archive ⇒ zero envelope, no `FAIL:`;
+(c) a non-existent/unreadable `--archive` path ⇒ non-zero envelope (fail closed).
+
+Verification: `bun test libraries/libharness/test/scan-logs.test.js` passes.

--- a/specs/2170-reusable-interview-action/plan-a-02.md
+++ b/specs/2170-reusable-interview-action/plan-a-02.md
@@ -1,0 +1,108 @@
+# Plan 2170 — Part 02: Composite action + publish wiring
+
+Create the `kata-interview` composite action owning the generic interview
+infrastructure, and wire it into the subtree-split publish set. Merging to
+`main` splits it to the `forwardimpact/kata-interview` sibling.
+
+Libraries used: none (YAML + Markdown + workflow config).
+
+## Step 1 — `kata-interview` action
+
+Author the composite action that mirrors `kata-agent`'s shared knobs and adds
+the interview-specific inputs, gating substrate steps on the generic
+`substrate` input.
+
+Files:
+
+- Created: `products/kata/actions/kata-interview/action.yml`
+
+Change (structure; mirror `products/kata/actions/kata-agent/action.yml`):
+
+- **Inputs** — shared: `app-id`, `app-private-key`, `anthropic-api-key`,
+  `app-slug` (default `kata-agent-team`), `max-turns` (default `200`),
+  `timeout-minutes`, `allowed-tools`, `killswitch`. Interview-specific:
+  `website-url` (required), `product`, `job`, `task-amend`,
+  `substrate` (default `"false"`), `substrate-force-empty-corpus`,
+  `jwt-secret`, `service-role-key`.
+- **Outputs**: `trace-file` and `trace-dir`, both passed through from the inner
+  harness step (`${{ steps.interview.outputs.trace-file }}` /
+  `…trace-dir }}`) — matches design § Action interface.
+- **Steps** (composite):
+  1. `Kata killswitch` — first step, reads `inputs.killswitch` (copy
+     `kata-agent`'s killswitch step).
+  2. `Generate installation token` (create-github-app-token) → checkout
+     (`fetch-depth: 0`, App token) → `forwardimpact/bootstrap@<sha>` with
+     `token: ${{ steps.ci-app.outputs.token }}` (gates wiki checkout — the
+     skill's Step 0 boot and the `always()` wiki-push step depend on it),
+     `app-slug`, `app-id`, and
+     `clis: fit-terrain fit-trace fit-harness fit-wiki` (no `fit-map`).
+  3. `Prepare interview workspace` — `mktemp -d`, `fit-terrain build`,
+     `bun install -g supabase`, export `dir` to `$GITHUB_OUTPUT`.
+  4. `Substrate stage` — `if: inputs.substrate == 'true'`; runs
+     `bunx fit-map substrate stage --cwd <dir> --emit-env "$GITHUB_ENV"`
+     (this single call stages **and** emits `SUPABASE_URL`/`SUPABASE_ANON_KEY`
+     — no inline `supabase status` / `python3`). Env: `JWT_SECRET`,
+     `SUPABASE_SERVICE_ROLE_KEY`, `SUBSTRATE_FORCE_EMPTY_CORPUS` from the
+     matching inputs.
+  5. `Compose task amendment` — as today, from `product`/`job`/`task-amend`.
+  6. `Run interview` (id `interview`) — `forwardimpact/harness@<sha>`,
+     `mode: supervise`, `lead-profile: product-manager`, `supervisor-cwd: .`,
+     `agent-cwd: <dir>`, `max-turns`, `timeout-minutes` (from the input),
+     `allowed-tools`,
+     `supervisor-allowed-tools: Bash,Read,Glob,Grep,Write,Edit,Skill,TodoWrite`,
+     `task-text` = "Run the `kata-interview` skill." (verbatim from today),
+     `task-amend` from step 5. Env: `ANTHROPIC_API_KEY`, `GH_TOKEN`,
+     `CLAUDE_CODE_USE_BEDROCK: "0"`, `IS_SANDBOX: "1"`, `WEBSITE_URL: ${{ inputs.website-url }}`
+     (always), and the substrate ternaries
+     `AGENT_CWD`/`JWT_SECRET`/`SUPABASE_SERVICE_ROLE_KEY` =
+     `${{ inputs.substrate == 'true' && <value> || '' }}`.
+  7. `Report run cost` — `if: always()`,
+     `fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"`.
+  8. `Push wiki changes` — `if: always()`, `forwardimpact/wiki@<sha>`,
+     `command: push`, `app-id`/`app-private-key` inputs.
+  9. `Scan logs for sensitive values` — `if: always() && inputs.substrate == 'true'`;
+     read the persona-JWT stash (`$RUNNER_TEMP/.persona-jwt`, guarded for
+     absence, `::add-mask::`), then
+     `fit-harness scan-logs --run-id "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --secret persona-jwt=<val> --secret jwt-secret=<val> --secret service-role-key=<val>`
+     (empty literals skipped by the verb). Env: `GH_TOKEN` from the in-action
+     `create-github-app-token` step (`${{ steps.ci-app.outputs.token }}`, not an
+     input); `JWT_SECRET`/`SERVICE_ROLE_KEY` from the matching inputs.
+
+Verification: `rg "product\s*==\s*'landmark'"` over `action.yml` returns
+nothing; the shape test (part 03) asserts the substrate gating.
+
+## Step 2 — Action README
+
+Document the input/output contract for external consumers.
+
+Files:
+
+- Created: `products/kata/actions/kata-interview/README.md`
+
+Change: mirror `kata-agent/README.md` shape — purpose, a `Usage` block wrapping
+`forwardimpact/kata-interview@v1` with `website-url`, `substrate`, and the auth
+inputs; a `Prerequisites` list (App with `Actions: Read`, secrets); and an
+`Inputs` table covering every input from Step 1. Use fully-qualified public URLs
+only; no relative paths into the monorepo.
+
+Verification: the README names every action input and the `trace-file` output.
+
+## Step 3 — Publish wiring
+
+Add `kata-interview` to the subtree-split publish set.
+
+Files:
+
+- Modified: `.github/workflows/publish-actions.yml`
+
+Change: add a `paths` filter entry `products/kata/actions/kata-interview/**` and
+a matrix entry
+`{ prefix: products/kata/actions/kata-interview, repo: kata-interview }`.
+
+No `.github/dependabot.yml` edit is needed: its github-actions ecosystem already
+scans directory `/`, which covers every workflow `uses:` including the wrapper's
+new `forwardimpact/kata-interview` pin, so weekly SHA bumps flow with no
+per-sibling entry.
+
+Verification: a YAML parse of `publish-actions.yml` succeeds; the matrix entry
+and path filter name `kata-interview`.

--- a/specs/2170-reusable-interview-action/plan-a-03.md
+++ b/specs/2170-reusable-interview-action/plan-a-03.md
@@ -1,0 +1,108 @@
+# Plan 2170 — Part 03: Consumer flip
+
+Flip the monorepo's consumer surfaces onto the published action. **Precondition:
+part 02 merged and `publish-actions.yml` succeeded**, so
+`forwardimpact/kata-interview` carries the action on its `main` and the split
+commit SHA is resolvable.
+
+Libraries used: none (YAML + JS test + Markdown).
+
+## Step 1 — Wrapper workflow
+
+Reduce `kata-interview.yml` to a thin wrapper over the published action, keeping
+only what a composite action cannot declare.
+
+Files:
+
+- Modified: `.github/workflows/kata-interview.yml`
+
+Change: replace the whole `steps:` body with a single
+`uses: forwardimpact/kata-interview@<published-sha> # v<x.y.z>` step. Keep
+`concurrency`, `permissions: contents: read`, and the job's
+`timeout-minutes: 50`. Rename the `empty-corpus-test` dispatch input to
+`substrate-force-empty-corpus`; add `website-url` (default
+`https://www.forwardimpact.team`) and `substrate` (boolean, default `false`)
+dispatch inputs — `substrate` replaces the old `product == 'landmark'`
+derivation, so no `landmark` literal remains in the workflow. Pass to the action:
+`app-id`/`app-private-key`/`anthropic-api-key` from `secrets.*`, `killswitch`
+from `${{ vars.KATA_KILLSWITCH }}`, `website-url`/`product`/`job`/`task-amend`/
+`substrate`/`substrate-force-empty-corpus` from inputs, and
+`jwt-secret`/`service-role-key` from `secrets.SUPABASE_JWT_SECRET` /
+`secrets.SUPABASE_SERVICE_ROLE_KEY`.
+
+Verification: `rg 'python3|supabase status' .github/workflows/kata-interview.yml`
+returns nothing; `rg "product\s*==\s*'landmark'"` over the workflow returns
+nothing; the workflow calls `forwardimpact/kata-interview`.
+
+## Step 2 — Shape test rewrite
+
+Re-target the shape invariant onto the generic `substrate` gating (on the
+action) and the sub-60 timeout (on the wrapper).
+
+Files:
+
+- Modified: `.github/workflows/test/kata-interview-shape.test.js`
+
+Change: parse **both** files. On
+`products/kata/actions/kata-interview/action.yml`: assert the substrate-only
+steps (`Substrate stage`, `Scan logs for sensitive values`) carry
+`if: inputs.substrate == 'true'`; assert the `Run interview` env keys
+`AGENT_CWD`/`JWT_SECRET`/`SUPABASE_SERVICE_ROLE_KEY` carry the
+`inputs.substrate == 'true' && … || ''` ternary; assert no
+`product == 'landmark'` literal appears anywhere in the action source. On
+`.github/workflows/kata-interview.yml`: assert `jobs.interview.timeout-minutes`
+is a number `< 60`, and that a step `uses:` names `forwardimpact/kata-interview`.
+
+Verification: `bun test .github/workflows/test/kata-interview-shape.test.js`
+passes.
+
+## Step 3 — Skill + reference parameterization
+
+Stop hardcoding the entry point; read it from `WEBSITE_URL`.
+
+Files:
+
+- Modified: `.claude/skills/kata-interview/SKILL.md`
+- Modified: `.claude/skills/kata-interview/references/job-handoff.md`
+
+Change:
+
+- SKILL.md Step 5: state that the website URL comes from the `WEBSITE_URL`
+  environment variable (set by the action); if `WEBSITE_URL` is unset the skill
+  errors rather than inventing a URL.
+- `job-handoff.md`: replace the literal `https://www.forwardimpact.team` in the
+  Ask 2 template **and both worked examples (A and B)** with a `<website-url>`
+  placeholder sourced from `WEBSITE_URL`, so the file carries no literal entry
+  point.
+
+Verification: `rg 'forwardimpact\.team' .claude/skills/kata-interview/` returns
+nothing.
+
+## Step 4 — BioNova reference prose
+
+Document a Polaris interview workflow that wraps the published action
+(documentation only; no Polaris code).
+
+Files:
+
+- Modified: `references/bionova-apps/design-a.md` (the design prose is the
+  documentation home, per design § Reference-app wiring)
+- Optionally modified: `references/bionova-apps/spec.md` (exists; add a Scope
+  line only if the interview belongs in the reference's scope)
+
+Change: add a short section describing an `interview.yml` in the `bionova-apps`
+repo that wraps `forwardimpact/kata-interview@<sha>` with `website-url` = the
+Polaris entry point, `substrate: true`, and Polaris'
+`JWT_SECRET`/`SERVICE_ROLE_KEY`. Note that Polaris already vendors `story.dsl`
+and runs `fit-terrain build`, so the action's build + substrate + scan path
+applies unchanged, and that the interview stages synthetic data into a temp
+`agent-cwd` (never the app tree), so spec 1160's `--output-root` prerequisite
+does not apply.
+
+Verification: `rg -n "kata-interview" references/bionova-apps/` shows the
+reference naming the action and passing `website-url` + `substrate`.
+
+## Manual acceptance (spec Success Criterion 1)
+
+After merge, `workflow_dispatch` the wrapper with `substrate: false` and confirm
+a non-empty `trace-file` output and a cost line in the step summary.

--- a/specs/2170-reusable-interview-action/plan-a.md
+++ b/specs/2170-reusable-interview-action/plan-a.md
@@ -1,0 +1,76 @@
+# Plan 2170: Reusable interview action + CLI split
+
+Executes [design-a.md](design-a.md) for [spec.md](spec.md).
+
+## Approach
+
+The work splits along the publish boundary. First land the two tested CLI
+verbs the action will call (`fit-map substrate stage --emit-env`,
+`fit-harness scan-logs`). Then land the composite action, its README, and its
+publish wiring — merging to `main` splits the action to the
+`forwardimpact/kata-interview` sibling. Only then flip the consumer surfaces
+(the wrapper workflow, the shape test, the skill, the reference prose) onto the
+now-published action, pinning the SHA the split produced. The verbs and the
+action carry no monorepo-specific assumptions; the wrapper supplies the
+monorepo's own `website-url` literal and `substrate` choice as inputs.
+
+## Part Index
+
+| Part | Title | Depends on |
+| --- | --- | --- |
+| [01](plan-a-01.md) | CLI verbs — `fit-map substrate stage --emit-env` + `fit-harness scan-logs`, each unit-tested | — |
+| [02](plan-a-02.md) | Composite action `kata-interview` + README + publish wiring | 01 (logical) |
+| [03](plan-a-03.md) | Consumer flip — wrapper workflow, shape test, skill + reference parameterization, BioNova reference prose | 02 published |
+
+## Execution
+
+Land the parts in order **01 → 02 → 03**. Parts 01 and 02 may be *drafted* in
+parallel, but 01 lands first so the published action never references verbs that
+do not yet exist on `main`. Merging part 02 to `main` triggers
+`publish-actions.yml`, which splits the action to the sibling's `main`; part 03
+then pins that published commit SHA on the wrapper's `uses:` line. Part 03's
+manual acceptance (spec Success Criterion 1) runs after the sibling exists.
+
+Route all three parts to an engineering agent (`staff-engineer`). Part 03's
+final step (BioNova reference prose) may hand to `technical-writer`.
+
+## Cross-cutting concerns
+
+- **Composite-action constraints** (`.github/CLAUDE.md`): a composite action
+  cannot read `secrets.*`, declare `concurrency`, or set a job
+  `timeout-minutes`. Substrate secrets are therefore action **inputs** the
+  wrapper passes from its own `secrets.*`; `concurrency` and `timeout-minutes`
+  stay on the wrapper workflow. `IS_SANDBOX=1` stays on the agent-spawning step
+  inside the action.
+- **`fit-map` off PATH**: `fit-map` ships in the `map@v*` release, not the gear
+  bundle, so the action invokes it as `bunx fit-map` — the documented exception,
+  kept verbatim. Every other CLI (`fit-terrain`, `fit-harness`, `fit-trace`,
+  `fit-wiki`) runs as a bootstrap-installed binary.
+- **SHA-pin publish loop**: consumers reach the action via a Dependabot SHA-bump,
+  never by moving `v1`. Part 02 adds the sibling to `.github/dependabot.yml` so
+  future bumps flow.
+- **`bun run context:fix`** is not needed — no `package.json` `description`/`jobs`
+  metadata changes (the verbs are new subcommands on existing CLIs).
+
+## Risks
+
+- **First-publish bootstrap.** The `forwardimpact/kata-interview` sibling does
+  not exist until part 02 merges to `main` and `publish-actions.yml` runs. Part
+  03's wrapper cannot pin a real SHA before then. Do not merge part 03 until the
+  publish job for part 02 has succeeded and the split commit SHA is resolvable on
+  the sibling — otherwise the wrapper points at a non-existent ref. The wrapper
+  is `workflow_dispatch`-only, so a stale ref does not break push/PR CI, but a
+  dispatch would fail until the SHA resolves.
+- **App installation `Actions: Read` scope.** `scan-logs --run-id` downloads the
+  run's own log archive through the GitHub API; the minting App must carry
+  `Actions: Read`. This is unchanged from today's inline scan, but the verb now
+  fails closed (non-zero) if the download 403s, so a missing scope surfaces as a
+  hard failure rather than a silent skip.
+- **`WEBSITE_URL` must always be set.** The skill errors rather than inventing a
+  URL when `WEBSITE_URL` is absent. The action sets it unconditionally from
+  `inputs.website-url` (a required input), so the only way to hit the error is a
+  malformed wrapper — surface it loudly in the skill rather than defaulting.
+
+Libraries used: libcli (`createCli`, `dispatch`), libutil (`runtime` — `fs`,
+`fsSync`, `subprocess`), and the existing `trace-github.js` archive
+download/unzip pattern in libharness.


### PR DESCRIPTION
Execution-ready plan for spec 2170, translating the approved
`specs/2170-reusable-interview-action/design-a.md` into concrete steps.

## Plan

- **[plan-a.md](../blob/claude/kata-plan-spec-2170-jrn6ph/specs/2170-reusable-interview-action/plan-a.md)** — approach, part index, execution order, cross-cutting concerns, risks.
- **plan-a-01** — CLI verbs: `fit-map substrate stage --emit-env` and `fit-harness scan-logs`, each unit-tested.
- **plan-a-02** — `kata-interview` composite action + README + subtree-split publish wiring.
- **plan-a-03** — consumer flip: thin wrapper workflow, shape-test rewrite, skill/reference parameterization, BioNova reference prose.

## Why decomposed

The three parts land in order around the **publish boundary**: the CLI verbs
first, then the action (merging to `main` splits it to the
`forwardimpact/kata-interview` sibling), then the consumer flip — which pins the
SHA that split produced. This isolates the first-publish bootstrap dependency
into the final part.

## Review

Reviewed by a clean three-reviewer `kata-review` panel. Addressed findings:

- **Blocker (3/3)** — declare the `--emit-env` option on `fit-map`'s
  `substrate stage` command (`products/map/bin/fit-map.js`); libcli's strict
  `parseArgs` would otherwise throw `ERR_PARSE_ARGS_UNKNOWN_OPTION` and crash the
  substrate leg.
- **High (2/3)** — `scan-logs --secret` declared with `multiple: true`, else
  only the last of three literals is scanned.
- **Medium (2/3)** — dropped a no-op Dependabot edit (the `/` ecosystem already
  scans workflow `uses:`).
- **Lows** — bootstrap wiki `token:`, `GH_TOKEN` source, `trace-github` reuse
  citation, `trace-dir` passthrough output, `timeout-minutes` wiring.
- **False positive recorded** — reviewers claimed `references/bionova-apps/spec.md`
  is absent; it exists, so the plan targets `design-a.md` (the documented home)
  with `spec.md` as an optional scope line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpcJRA58ZNTN4u8anFHXzU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpcJRA58ZNTN4u8anFHXzU)_