### PR TITLE
design(2170): revise — generic fit-terrain substrate verb for external reusability

### DIFF
--- a/specs/2170-reusable-interview-action/design-a.md
+++ b/specs/2170-reusable-interview-action/design-a.md
@@ -1,151 +1,153 @@
-# Design 2170: Reusable interview action + CLI split
+# Design 2170: Reusable interview action + generic substrate verb
 
-Restates spec 2170: extract the generic switching-interview infrastructure into
-a published composite action, push its two untested inline-bash blocks into
-tested verbs on `fit-map` and `fit-harness`, parameterize the entry point, and
-reduce the workflow to a wrapper — so an external consumer (Polaris) can run its
-own interview.
+Restates spec 2170: extract the switching-interview capability into a published
+composite action, and give the generic Supabase bring-up a home in `fit-terrain`
+so a different-domain Supabase app (Polaris) can interview itself — not just
+repos running the full FI stack.
+
+## The seam (revision)
+
+The prior draft hardcoded `fit-map substrate stage` as the "generic" substrate
+step. It is not generic: `fit-map` is an FI product whose stage knows the map
+schema, roster invariants, and Landmark smoke, and whose phases share
+in-process env with a map client. Polaris cannot use it. Two layers:
+
+- **Generic Supabase bring-up** (opinionated: the consumer uses Supabase) —
+  start the stack, discover the URL, emit env. Every Supabase-backed consumer
+  needs exactly this. → **add** a `fit-terrain substrate up` verb (`fit-terrain`
+  is generic, already Supabase-aware, already on PATH in the action).
+- **FI persona + seed layer** — the map-schema seed, `auth.users` provision,
+  roster `pick`, JWT `issue`, Landmark smoke. → **stays in `fit-map`**, invoked
+  through a *pluggable* action command so Polaris substitutes its own.
+
+We **add** rather than **move**: relocating `fit-map`'s stage into `fit-terrain`
+would close a `libterrain → @forwardimpact/map → libterrain` dependency cycle
+(libterrain already depends on map), break the in-process env its map client
+reads, and disrupt `activity.js`'s use of the shared spawner. So `fit-terrain
+substrate up` is a clean generic primitive; `fit-map substrate stage` keeps its
+richer pipeline and only gains an `--emit-env` output. Convergence (map stage
+delegating to the verb once the spawner is extracted to a lower shared library)
+is future work, out of scope.
 
 ## Components
 
 | Component | Location | Purpose |
 | --- | --- | --- |
-| `kata-interview` action | `products/kata/actions/kata-interview/action.yml` | Composite action owning generic interview infra; published by subtree split, consumed SHA-pinned |
+| `kata-interview` action | `products/kata/actions/kata-interview/action.yml` | Composite action; orchestration + generic infra, domain steps delegated to injected commands |
 | Action README | `products/kata/actions/kata-interview/README.md` | Input/output contract for external consumers |
-| Supabase-env emit | `products/map/src/commands/substrate-stage.js` (dispatched via `products/map/bin/dispatch-substrate.js`) | Emit `SUPABASE_URL`/`SUPABASE_ANON_KEY` as env-file lines |
-| Log secret scan | `libraries/libharness/` (`fit-harness scan-logs`) + `libraries/libharness/src/commands/` | Scan a run's log archive for secret literals; fail closed |
-| Workflow wrapper | `.github/workflows/kata-interview.yml` | Thin `workflow_dispatch` wrapper; passes inputs to the action and retains `concurrency` + job `timeout-minutes` (a composite action cannot declare either) |
-| Shape test | `.github/workflows/test/kata-interview-shape.test.js` | Assert generic substrate gating + sub-60 timeout |
-| Skill parameterization | `.claude/skills/kata-interview/{SKILL.md,references/job-handoff.md}` | Read entry-point URL from env, not hardcoded |
-| Reference wiring | `references/bionova-apps/` | Document a Polaris interview workflow wrapping the action |
+| Generic substrate | `libraries/libterrain/` (`fit-terrain substrate up`) | Supabase bring-up: `start` → discover → `--emit-env`. Own thin, cwd-explicit spawner. No schema/migration knowledge |
+| FI emit hook | `products/map/src/commands/substrate-stage.js` | Existing phases unchanged; gains an `--emit-env` output after `url-discovery` |
+| Log secret scan | `libraries/libharness/` (`fit-harness scan-logs`) | Scan a run's log archive for secret literals; fail closed |
+| Workflow wrapper | `.github/workflows/kata-interview.yml` | Thin wrapper; supplies FI substrate + persona commands; keeps `concurrency` + job `timeout-minutes` |
+| Skill parameterization | `.claude/skills/kata-interview/{SKILL.md,references/job-handoff.md}` | Read `WEBSITE_URL`; run the injected persona-select command instead of hardcoding `fit-map` |
+| Reference wiring | `references/bionova-apps/` | Document Polaris supplying its own substrate command + anonymous access |
 
 ## Architecture
 
 ```mermaid
 graph TD
-    subgraph consumer["Consumer workflow (this repo OR bionova-apps)"]
-        wf["kata-interview.yml — workflow_dispatch inputs"]
-    end
-    wf -->|uses, SHA-pinned| act
-
+    wf["wrapper workflow (monorepo OR bionova-apps)"] -->|uses| act
     subgraph act["kata-interview composite action"]
-        ks["killswitch → token → checkout → bootstrap (+supabase)"]
         tb["fit-terrain build"]
-        sub["substrate stage + env emit (if substrate)"]
+        sub["run substrate-setup-command (if set) → emits SUPABASE_URL/KEY"]
         run["fit-harness supervise — kata-interview skill"]
         post["fit-trace cost → wiki push → scan-logs (if substrate)"]
-        ks --> tb --> sub --> run --> post
+        tb --> sub --> run --> post
     end
-
-    sub -->|"fit-map substrate ... --emit-env $GITHUB_ENV"| fm["fit-map"]
-    post -->|"fit-harness scan-logs --run-id ... --secret ..."| fh["fit-harness"]
-    run -->|"website-url in agent env; two Asks"| agent["isolated persona agent → website-url"]
+    sub -.monorepo.-> fm["bunx fit-map substrate stage --cwd $AGENT_CWD --emit-env"]
+    sub -.polaris.-> pol["fit-terrain substrate up --emit-env + supabase db push + seed"]
+    run -->|"PERSONA_SELECT_COMMAND (optional) + WEBSITE_URL"| skill["supervisor builds persona, two Asks"]
+    post --> fh["fit-harness scan-logs"]
 ```
 
 ## Action interface
 
-Inputs mirror `kata-agent` for the shared knobs (`app-id`, `app-private-key`,
-`anthropic-api-key`, `app-slug`, `max-turns`, `timeout-minutes`,
-`allowed-tools`, `killswitch`) and add the interview-specific ones:
+Shared `kata-agent` knobs (`app-id`, `app-private-key`, `anthropic-api-key`,
+`app-slug`, `max-turns`, `timeout-minutes`, `allowed-tools`, `killswitch`) plus:
 
 | Input | Required | Role |
 | --- | --- | --- |
 | `website-url` | yes | Entry point handed to the persona agent in Ask 2 |
-| `product` | no | Product to interview; empty lets the supervisor pick |
-| `job` | no | JTBD goal to test; empty lets the supervisor pick |
-| `task-amend` | no | Steering appended to the task prompt |
-| `substrate` | no (default `false`) | Whether to bring up the Supabase substrate + run the post-run secret scan |
-| `substrate-force-empty-corpus` | no | CI assertion toggle for the empty-corpus failure path (renames the workflow's current `empty-corpus-test` input for the substrate-generic vocabulary) |
-| `jwt-secret`, `service-role-key` | no | Substrate secrets, forwarded only when `substrate` |
+| `product`, `job`, `task-amend` | no | Selection + steering, as today |
+| `substrate-setup-command` | no | Shell command that brings up the substrate and emits `SUPABASE_URL`/`SUPABASE_ANON_KEY` to `$GITHUB_ENV`. Non-empty ⇒ the substrate path (bring-up + post-run scan). Empty ⇒ file-only interview. |
+| `persona-select-command` | no | Command the supervisor runs to seal a persona + stash a JWT. Empty ⇒ persona from `story.dsl` / anonymous access. |
+| `jwt-secret`, `service-role-key` | no | Substrate secrets, forwarded to the setup/persona commands only when the substrate path is active |
 
-Composite actions cannot read `secrets.*` (`.github/CLAUDE.md`), so
-`jwt-secret`/`service-role-key` are **inputs** the wrapper passes from its own
-`secrets.*` — this is why the substrate secrets become action inputs rather than
-being read internally. Outputs pass through the harness
-`trace-file`/`trace-dir`. The action sets `WEBSITE_URL` (and, under substrate,
-`SUPABASE_URL`/`SUPABASE_ANON_KEY` via `$GITHUB_ENV`) into the run environment;
-the supervisor reads `WEBSITE_URL` when composing Ask 2. Substrate steps and the
-secret scan are gated on `inputs.substrate == 'true'`, replacing every
-`product == 'landmark'` literal.
+Composite actions cannot read `secrets.*`, declare `concurrency`, or set a job
+`timeout-minutes` — so secrets arrive as inputs and the last two stay on the
+wrapper. Outputs pass through the harness `trace-file`/`trace-dir`. The action
+sets `WEBSITE_URL` and (when set) `PERSONA_SELECT_COMMAND` into the run env.
+Substrate steps and the scan gate on `inputs.substrate-setup-command != ''` — no
+`product == 'landmark'` literal anywhere.
 
 ## CLI verb interfaces
 
 | Verb | Signature | Behaviour |
 | --- | --- | --- |
-| `fit-map substrate stage` | add `--emit-env <path>` | After the `url-discovery` phase, append `SUPABASE_URL=<url>` and `SUPABASE_ANON_KEY=<key>` lines to `<path>`; the action points it at `$GITHUB_ENV`. Removes the workflow's inline `supabase status --output json` + `python3`. |
-| `fit-harness scan-logs` | `--archive <zip>` \| `--run-id <id> --repo <owner/repo>`; repeatable `--secret <label>=<literal>` | Resolve a log archive (download via `gh` when `--run-id`), scan every entry for each non-empty secret literal, print `FAIL: <label> literal in run logs` per hit, exit non-zero on any hit; fail closed if the archive cannot be read. |
+| `fit-terrain substrate up` (new) | `--cwd <dir> --emit-env <path>` | Opinionated Supabase bring-up: `supabase start` (from `<cwd>`), parse `status --output json`, append `SUPABASE_URL=`/`SUPABASE_ANON_KEY=` to `<path>`. Migration/seed are the consumer's concern — this verb only brings up + discovers. |
+| `fit-map substrate stage` | add `--emit-env <path>` | Phases unchanged; after `url-discovery`, also append the two lines to `<path>`. No delegation, no spawner move. `pick`/`issue` unchanged. |
+| `fit-harness scan-logs` | `--archive <zip>` \| `--run-id <id> --repo <owner/repo>`; repeatable `--secret <label>=<literal>` | Resolve/extract the archive (download via `gh` for `--run-id`), scan for each literal, `FAIL: <label> literal in run logs` per hit, non-zero on any hit, fail closed on unreadable archive. |
 
-`--emit-env` reuses the URL already parsed in the `url-discovery` phase, so no
-second `supabase status` call. `scan-logs` takes secret literals as inputs
-(never reads them from a fixed env name) so it is generic to any run; the action
-passes the persona JWT (from the `--stash` file), `jwt-secret`, and
-`service-role-key`.
+`fit-terrain substrate up` carries its own minimal Supabase spawner (start +
+status via `runtime.subprocess`), taking `cwd` explicitly rather than resolving
+a package root — so it is portable to Polaris' checkout. `libterrain` already
+declares `@supabase/supabase-js`; nothing moves out of `products/map`.
 
-## Interview run wiring
+## Persona selection (pluggable)
 
-The action calls the harness `supervise` mode exactly as the workflow does today
-(`lead-profile: product-manager`, `supervisor-cwd: .`, `agent-cwd` = the staged
-temp dir, `IS_SANDBOX=1`, `task-text` = "Run the `kata-interview` skill"). The
-killswitch moves into the action as its first composite step (as `kata-agent`
-does); `concurrency` and the job `timeout-minutes` stay on the wrapper workflow,
-which a composite action cannot declare. The other additions are `WEBSITE_URL`
-on the run env and the generic substrate gating. The skill's Step 5 reads
-`WEBSITE_URL` from the environment; the `job-handoff` reference's Ask 2 template
-and both worked examples use that value instead of the literal
-`https://www.forwardimpact.team`. When unset (never, from the action), the skill
-errors rather than inventing a URL.
+The skill's Step 3a stops calling `fit-map` directly. The supervisor runs
+`$PERSONA_SELECT_COMMAND` when set: it must seal identity into `$AGENT_CWD` and
+stash a bare JWT for the post-run scan — the contract `fit-map substrate issue`
+already satisfies (it writes `.env` + `.substrate.json` at `--cwd` and a bare
+JWT at `--stash`; the FI command chains `pick` → `issue --stash`). When unset,
+the supervisor builds identity from `story.dsl` and issues no JWT. `WEBSITE_URL`
+handling in Ask 2 is unchanged from the merged design.
 
 ## Key Decisions
 
 | Decision | Chosen | Rejected | Why |
 | --- | --- | --- | --- |
-| Split seam | `fit-map` owns Supabase-env emit; `fit-harness` owns log scan | One new `fit-interview` CLI / `libinterview` | Each block already has a domain owner; a new package would need to join the gear bundle and duplicate substrate/run ownership. Splitting keeps each verb beside the lifecycle it belongs to. |
-| Substrate gating | Generic `substrate` boolean input | Keep `product == 'landmark'` | The product-name predicate is monorepo-only; Polaris is substrate-backed but not named "landmark". A boolean makes the action reusable and keeps the shape invariant meaningful. |
-| Entry point | `website-url` input → `WEBSITE_URL` env → skill reads it | Hardcode per-consumer skill fork; or a skill config file | An env var threads cleanly from action input to the supervisor with no new file; the skill stays a single published artifact. A per-consumer fork defeats reuse. |
-| Publish path | Subtree-split sibling, SHA-pinned — one new `publish-actions.yml` matrix entry + path filter | Reference the action by local path only | Consumers are *other repos* (Polaris); only a published sibling is consumable cross-repo. The mechanism already ships `kata-agent`, so this reuses it rather than inventing one. |
-| `scan-logs` input model | Secret literals passed as `--secret` args | Read a fixed env var (`JWT_SECRET`, …) | Passing literals keeps the verb generic and unit-testable against a fixture archive with no CI secrets; the action supplies the three literals. |
-| `scan-logs` home | `fit-harness` | `fit-trace` | The GH log archive is not an NDJSON trace; scanning a run's own output for leaked secrets is a run-lifecycle concern `fit-harness` already owns. |
-| `fit-map` on PATH | Keep the documented `bunx fit-map` exception | Move `fit-map` into the gear bundle | Out of scope; `fit-map` ships in the `map@v*` release. The action documents the exception exactly as the workflow does today. |
+| Generic substrate | **Add** `fit-terrain substrate up` (bring-up + emit only) | **Move** `fit-map substrate stage` into `fit-terrain` | A move closes a `libterrain → map` cycle, breaks the map client's in-process env, and disrupts `activity.js`; adding a clean primitive avoids all three and still gives Polaris a generic bring-up. |
+| Bring-up scope | Start + discover + emit only | Also apply migrations/seed | Migrations and seed are schema-specific (map vs Polaris, different dirs); keeping them in the consumer's command keeps the verb truly generic. |
+| Domain substrate | Injected `substrate-setup-command` | Hardcode `fit-map substrate stage` | The FI seed/provision/smoke is product-specific; Polaris supplies `fit-terrain substrate up` + `supabase db push` + its seed. |
+| Persona selection | Injected `persona-select-command`, `fit-map issue` contract | Hardcode `fit-map` in the skill | Persona invariants are FI-only; the `.env`/`.substrate.json`/stash contract lets Polaris substitute or omit it. |
+| `scan-logs` home | `fit-harness` | `fit-trace` | A GH log archive is not an NDJSON trace; scanning a run's own output is a run-lifecycle concern. |
 
 ## Data flow — substrate interview
 
 ```text
 bootstrap installs CLIs + supabase
-  → fit-terrain build                         (synthetic data)
-  → fit-map substrate stage --cwd $AGENT_CWD --emit-env $GITHUB_ENV
-       (init→stack→url-discovery→migrate→seed→provision→smoke;
-        SUPABASE_URL/SUPABASE_ANON_KEY appended to $GITHUB_ENV)
-  → supervisor: fit-map substrate pick / issue --stash $RUNNER_TEMP/.persona-jwt
-  → fit-harness supervise (kata-interview skill; WEBSITE_URL in agent env)
+  → fit-terrain build                              (synthetic data)
+  → run $substrate-setup-command                   (emits SUPABASE_URL/ANON_KEY → $GITHUB_ENV)
+       monorepo: bunx fit-map substrate stage --cwd $AGENT_CWD --emit-env $GITHUB_ENV
+       polaris:  fit-terrain substrate up --cwd . --emit-env $GITHUB_ENV && supabase db push && <embed>
+  → fit-harness supervise (skill; WEBSITE_URL + PERSONA_SELECT_COMMAND in env)
+       supervisor runs $PERSONA_SELECT_COMMAND (if set) → seals persona + stashes JWT
   → fit-trace cost → wiki push
-  → fit-harness scan-logs --run-id $RUN_ID --repo $REPO \
-       --secret <persona-jwt> --secret <jwt-secret> --secret <service-role-key>
+  → fit-harness scan-logs --run-id … --repo … --secret persona-jwt=… --secret …
 ```
 
-For a non-substrate interview (`substrate: false`), the substrate stage,
-env emit, `pick`/`issue`, and `scan-logs` steps are skipped; the persona is
-built from `story.dsl`/`prose-cache.json` as today.
+File-only interview (`substrate-setup-command` empty): setup, persona command,
+and scan are skipped; persona built from `story.dsl` as today.
 
 ## Reference-app wiring
 
-`references/bionova-apps/` gains, in its spec/design prose (not a monorepo
-workflow), a documented `interview.yml` that wraps
-`forwardimpact/kata-interview@<sha>` with `website-url` = the Polaris entry
-point, `substrate: true`, and Polaris' `JWT_SECRET`/`SERVICE_ROLE_KEY`. Because
-Polaris already vendors `story.dsl` and runs `fit-terrain build`, the action's
-build + substrate + scan path applies unchanged. The interview needs none of
-spec 1160's `--output-root` prerequisite: it stages synthetic data into a temp
-`agent-cwd`, not the app tree, so the `rm -rf`-on-project-root hazard that flag
-addresses never arises here.
+`references/bionova-apps/` documents (prose, not a monorepo workflow) a Polaris
+`interview.yml` wrapping `forwardimpact/kata-interview@<sha>` with `website-url`
+= the Polaris entry point and `substrate-setup-command` = `npx fit-terrain
+substrate up --cwd . --emit-env "$GITHUB_ENV"` followed by Polaris' own
+`supabase db push` + embed seed. Patient interviews use anonymous access (no
+`persona-select-command`); staff interviews pass a Polaris persona command. It
+needs no `fit-map` and no map schema.
 
 ## Test strategy
 
-- **`fit-map` emit** — unit test asserts `--emit-env <tmp>` writes the two
-  `KEY=value` lines from a stubbed status source.
-- **`fit-harness scan-logs`** — unit test builds a fixture archive, asserts
-  non-zero + `FAIL:` line on a planted literal and zero on a clean archive, and
-  asserts fail-closed on an unreadable archive.
-- **Shape test** — parses both files: on `action.yml`, substrate-only steps and
-  substrate-selecting env keys carry the `substrate` predicate and no
-  `product == 'landmark'` literal appears; on the wrapper workflow, the
-  interview job's `timeout-minutes < 60`.
+- **`fit-terrain substrate up`** — unit test with a stubbed Supabase spawner
+  asserts `--emit-env` writes both `KEY=value` lines from a stubbed `status`.
+- **`fit-map substrate stage --emit-env`** — test asserts the two lines are
+  written after `url-discovery`, with the existing phases stubbed.
+- **`fit-harness scan-logs`** — hit (non-zero), clean (zero), unreadable
+  archive (fail closed).
+- **Shape test** — on `action.yml`, substrate steps + the scan gate on
+  `substrate-setup-command != ''`, no `product == 'landmark'`; on the wrapper,
+  the interview job's `timeout-minutes < 60`.

--- a/specs/2170-reusable-interview-action/plan-a.md
+++ b/specs/2170-reusable-interview-action/plan-a.md
@@ -1,49 +1,70 @@
-# Plan 2170-a: Reusable interview action + CLI split
+# Plan 2170-a: Reusable interview action + substrate re-layering
 
 Implements [design-a.md](design-a.md) for [spec.md](spec.md).
 
 ## Approach
 
-Build bottom-up: land the two CLI verbs first (they are runtime dependencies of
-the action), then the composite action that orchestrates them, then the wrapper
-workflow that shrinks to call it, then the skill parameterization, the shape
-test, the publish wiring, and the reference prose. Each CLI verb keeps the
-existing injectable-deps pattern so its new behaviour is unit-tested without
-Supabase, `gh`, or CI. The monorepo's own wrapper consumes the action by local
-path (`./products/kata/actions/kata-interview`) to stay always-in-sync and avoid
-a publish-before-pin bootstrap; external consumers use the published sibling.
+Build bottom-up. Three independent CLI additions — a generic `fit-terrain
+substrate up` verb, an `--emit-env` output on the existing `fit-map substrate
+stage`, and a `fit-harness scan-logs` verb — then the composite action whose
+domain steps are injected commands, then the wrapper, the skill, the shape test,
+the publish wiring, and the reference prose. CLI verbs keep the injectable-deps
+pattern so behaviour is unit-tested without Supabase, `gh`, or CI. Nothing moves
+between packages (a move would cycle `libterrain → map`). The monorepo wrapper
+consumes the action by local path (`./products/kata/actions/kata-interview`);
+external consumers use the published sibling. The generic layer is opinionated
+on Supabase by design.
 
-Libraries used: libcli (command definition, dispatch, `options.multiple`),
-libutil (runtime `fs` + `subprocess`).
+Libraries used: libcli (command def, dispatch, `options.multiple`), libutil
+(runtime `fs` + `subprocess`), libterrain (new `substrate up` verb with its own
+Supabase spawner).
 
-## Step 1: `fit-map substrate stage --emit-env <path>`
+## Step 1: `fit-terrain substrate up`
 
-Emit the discovered Supabase URL + anon key as env-file lines.
+Add a generic Supabase bring-up verb (bring-up + emit only). Nothing moves out
+of `products/map` — a move would close a `libterrain → @forwardimpact/map`
+cycle and break `fit-map`'s in-process env and `activity.js`.
 
-- **Modified:** `products/map/bin/fit-map.js`,
-  `products/map/bin/dispatch-substrate.js`,
-  `products/map/src/commands/substrate-stage.js`
+- **Modified:** `libraries/libterrain/bin/fit-terrain.js` (add the command to
+  the existing `createCli` definition, wired like its siblings)
+- **Created:** `libraries/libterrain/src/commands/substrate-up.js` (with its own
+  thin `supabase` spawner over `runtime.subprocess`, `cwd` explicit — no
+  package-root resolution), `libraries/libterrain/test/substrate-up.test.js`
+
+Changes:
+
+- `substrate-up.js` — export `runSubstrateUp({ cwd, emitEnv, runtime })`:
+  `supabase start` from `<cwd>`; parse `status --output json`; if `emitEnv`,
+  append `SUPABASE_URL=<API_URL>\nSUPABASE_ANON_KEY=<ANON_KEY>\n` via
+  `runtime.fs.appendFile`. No `db reset`/seed — those are the consumer's. Inject
+  the spawner for tests. `libterrain` already declares `@supabase/supabase-js`.
+- `fit-terrain.js` — add the `substrate up` command with options `cwd`,
+  `emit-env`, following the file's existing command/dispatch shape.
+- Verification: unit test with a stubbed spawner asserts both `KEY=value` lines
+  are written to a temp path.
+  `bun test libraries/libterrain/test/substrate-up.test.js`.
+
+## Step 2: `fit-map substrate stage --emit-env`
+
+Add an emit output to the existing stage — no delegation, no phase refactor.
+
+- **Modified:** `products/map/bin/fit-map.js` (add `emit-env` option to the
+  `substrate stage` command), `products/map/bin/dispatch-substrate.js` (thread
+  `emitEnv: values["emit-env"]`), `products/map/src/commands/substrate-stage.js`
 - **Created:** `products/map/test/substrate-stage.test.js`
 
 Changes:
 
-- `fit-map.js` — add to the `substrate stage` command's `options`:
-  `"emit-env": { type: "string", description: "Append SUPABASE_URL / SUPABASE_ANON_KEY lines to this env file" }`
-  (no CI-only reference in the help string — external `npx fit-map` users read
-  it, per products/CLAUDE.md § Audience).
-- `dispatch-substrate.js` — in the `stage` case, pass
-  `emitEnv: values["emit-env"]` into `runStageCommand`.
-- `substrate-stage.js` — accept `emitEnv` in the destructured params; inside the
-  `url-discovery` phase, after setting `runtime.proc.env.SUPABASE_URL` /
-  `SUPABASE_ANON_KEY`, when `emitEnv` is set append
-  `SUPABASE_URL=<url>\nSUPABASE_ANON_KEY=<key>\n` to that path via
-  `runtime.fs.appendFile`.
-- Verification: new test injects stub `createSupabaseCli` (whose `capture`
-  returns `{"API_URL":…,"ANON_KEY":…}`) plus no-op stubs for the other phase
-  loaders, runs with `emitEnv` at a temp path, and asserts the file holds both
-  `KEY=value` lines. `bun test products/map/test/substrate-stage.test.js`.
+- `substrate-stage.js` — accept `emitEnv`; inside the existing `url-discovery`
+  phase, after setting `runtime.proc.env.SUPABASE_URL`/`SUPABASE_ANON_KEY`, when
+  `emitEnv` is set append the two lines via `runtime.fs.appendFile`. All other
+  phases (`init`, `copy-activity`, `seed`, `provision`, `smoke`) and the
+  in-process env they rely on are untouched.
+- Verification: test injects the phase stubs and a stubbed `capture` returning
+  `{"API_URL":…,"ANON_KEY":…}`, runs with `emitEnv` at a temp path, and asserts
+  both lines. `bun test products/map/test/substrate-stage.test.js`.
 
-## Step 2: `fit-harness scan-logs`
+## Step 3: `fit-harness scan-logs`
 
 Scan a run's log archive for secret literals; fail closed.
 
@@ -53,179 +74,168 @@ Scan a run's log archive for secret literals; fail closed.
 
 Changes:
 
-- `scan-logs.js` — export `runScanLogsCommand(ctx)` and a pure
-  `scanDirectory({ dir, secrets, runtime })`:
-  - `scanDirectory` walks `dir`, and for each `{ label, value }` with non-empty
-    `value`, records `label` if `value` occurs in any file; returns
-    `{ failures: string[] }`.
-  - `runScanLogsCommand` takes its runtime from `ctx.deps.runtime` (as
-    `tee.js`/`callback.js` do) and reads flags from `ctx.options`. Parse each
-    repeated `--secret` (`label=literal`) into `secrets`, **splitting on the
-    first `=` only** (JWTs and base64 keys contain `=`; a greedy split truncates
-    the literal and silently disarms the scan). `ctx.options.secret` is **always
-    an array** (libcli forwards `multiple:true` to node `parseArgs`), including
-    the single- and zero-occurrence cases — iterate it directly. Resolve a logs
-    dir — extract `--archive <zip>` via
-    `runtime.subprocess.run("unzip", …)`, or when `--run-id`/`--repo` are given,
-    download with `gh api /repos/<repo>/actions/runs/<id>/logs` to a temp zip
-    then extract. Fail closed (`{ ok: false, code: 1, error }`) if download or
-    extract fails. Print `FAIL: <label> literal in run logs` per failure; return
-    `{ ok: failures.length === 0, code: failures.length ? 1 : 0 }`.
-- `fit-harness.js` — `import { runScanLogsCommand }`; add a `commands[]` entry:
-  `{ name: "scan-logs", args: [], handler: runScanLogsCommand, description: "Scan a run's log archive for secret literals; non-zero on any hit", options: { archive: {type:"string",…}, "run-id": {type:"string",…}, repo: {type:"string",…}, secret: {type:"string", multiple:true, description:"label=literal, repeatable"} } }`.
-  Dispatch already routes through `cli.dispatch`.
-- Verification: test asserts `scanDirectory` returns the label on a planted
-  literal (temp dir) and `[]` on a clean dir, and that `runScanLogsCommand` with
-  a nonexistent `--archive` returns `ok:false`.
+- `scan-logs.js` — export `runScanLogsCommand(ctx)` and pure
+  `scanDirectory({ dir, secrets, runtime })`. Take runtime from
+  `ctx.deps.runtime`; read flags from `ctx.options`. Parse each `--secret`
+  (`label=literal`) **splitting on the first `=` only** (JWTs/base64 keys
+  contain `=`). `ctx.options.secret` is **always an array** (libcli `multiple` →
+  node `parseArgs`) — iterate it. Resolve a logs dir: extract `--archive <zip>`
+  via `runtime.subprocess.run("unzip", …)`, or
+  `gh api /repos/<repo>/actions/runs/<id>/logs` → temp zip → extract for
+  `--run-id`/`--repo`. Fail closed on download/extract failure. `scanDirectory`
+  records a label if its non-empty literal occurs in any file; print
+  `FAIL: <label> literal in run logs` per hit; return
+  `{ ok: failures.length === 0, code: failures.length ? 1 : 0 }`.
+- `fit-harness.js` — import the handler; add a `commands[]` entry `scan-logs`
+  with options `archive`, `run-id`, `repo`, `secret` (`multiple: true`).
+- Verification: test asserts `scanDirectory` hit (label) / clean (`[]`) and
+  `runScanLogsCommand` fail-closed on a nonexistent `--archive`.
   `bun test libraries/libharness/test/scan-logs.test.js`.
 
-## Step 3: `kata-interview` composite action
+## Step 4: `kata-interview` composite action
 
 - **Created:** `products/kata/actions/kata-interview/action.yml`,
   `products/kata/actions/kata-interview/README.md`
 
-Model on `products/kata/actions/kata-agent/action.yml`. Inputs per design
-§ Action interface (`website-url` required; `substrate` default `false`;
-`substrate-force-empty-corpus`, `jwt-secret`, `service-role-key`; plus the
-`kata-agent` shared knobs). Composite steps in order:
+Model on `kata-agent`. Inputs per design § Action interface: `website-url`
+(required), `product`, `job`, `task-amend`, `substrate-setup-command`,
+`persona-select-command`, `jwt-secret`, `service-role-key`, plus the shared
+knobs. Composite steps:
 
-1. Kata killswitch (first step, as `kata-agent`).
-2. Generate installation token; `actions/checkout` (fetch-depth 0).
-3. `bootstrap@<sha>` with `clis: fit-terrain fit-trace fit-harness fit-wiki`.
+1. Kata killswitch (first).
+2. Generate token; `actions/checkout` (fetch-depth 0).
+3. `bootstrap@<sha>` with `clis: fit-terrain fit-trace fit-harness fit-wiki`
+   (`fit-terrain` now also provides substrate bring-up — no `fit-map` in
+   `clis`).
 4. Prepare workspace: `agent_dir=$(mktemp -d)`, `fit-terrain build`,
-   `bun install -g supabase`; export `agent_dir` as a step output.
-5. Substrate stage — `if: inputs.substrate == 'true'`: `bunx fit-map substrate
-   stage --cwd "$agent_dir" --emit-env "$GITHUB_ENV"` (env `JWT_SECRET`,
-   `SUPABASE_SERVICE_ROLE_KEY`, `SUBSTRATE_FORCE_EMPTY_CORPUS` from the
-   `substrate-force-empty-corpus` input). `fit-map` is deliberately **not** in
-   the bootstrap `clis:` — it ships in the `map@v*` release, so `bunx fit-map`
-   is the documented exception (as the current workflow notes); do not add it to
-   `clis`.
-6. Compose task amendment from `product`/`job`/`task-amend` (as today).
-7. Run interview — `harness@<sha>` (step `id: interview`), `mode: supervise`,
+   `bun install -g supabase`; export `agent_dir`.
+5. Substrate setup — `if: inputs.substrate-setup-command != ''`: run that
+   command with `AGENT_CWD=$agent_dir`, `GITHUB_ENV` available, and
+   `JWT_SECRET`/`SUPABASE_SERVICE_ROLE_KEY` env. It must emit
+   `SUPABASE_URL`/`SUPABASE_ANON_KEY` to `$GITHUB_ENV`.
+6. Compose task amendment from `product`/`job`/`task-amend`.
+7. Run interview — `harness@<sha>` (`id: interview`), `mode: supervise`,
    `lead-profile: product-manager`, `supervisor-cwd: .`,
    `agent-cwd: $agent_dir`, `task-text: "Run the kata-interview skill."`, env
-   `WEBSITE_URL`, `IS_SANDBOX=1`, and the substrate secrets gated by the
-   `inputs.substrate == 'true' && … || ''` ternary.
-8. Report cost (`always()`) — via a
-   `TRACE_FILE: ${{ steps.interview.outputs.trace-file }}` step env,
-   `fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"` (the
-   `kata-agent` pattern).
+   `WEBSITE_URL`, `PERSONA_SELECT_COMMAND` (from the input), `IS_SANDBOX=1`, and
+   the substrate secrets gated by the
+   `inputs.substrate-setup-command != '' && … || ''` ternary.
+8. Report cost (`always()`) via `TRACE_FILE:
+   ${{ steps.interview.outputs.trace-file }}` step env.
 9. Push wiki via `wiki@<sha>` (`always()`).
-10. Scan logs — `if: always() && inputs.substrate == 'true'`: if the
-    `$RUNNER_TEMP/.persona-jwt` stash exists, read it and `echo
-    "::add-mask::$persona_jwt"` before use (the stash JWT is runtime-generated,
-    not an auto-masked repo secret); if absent, degrade to an empty persona
-    literal and continue (as today). Then `fit-harness scan-logs --run-id
-    ${{ github.run_id }} --repo ${{ github.repository }} --secret
-    persona-jwt=<stash> --secret jwt-secret=<secret> --secret
-    service-role-key=<secret>` (skip empty literals).
+10. Scan logs — `if: always() && inputs.substrate-setup-command != ''`: if the
+    `$RUNNER_TEMP/.persona-jwt` stash exists, read + `echo "::add-mask::"` it;
+    else empty. `fit-harness scan-logs --run-id ${{ github.run_id }} --repo
+    ${{ github.repository }} --secret persona-jwt=<stash> --secret
+    jwt-secret=<secret> --secret service-role-key=<secret>` (skip empties).
 
-The persona-JWT stash the scan step (item 10) reads is produced *inside* the
-harness step (item 7): the supervisor running the `kata-interview` skill calls
-`fit-map substrate issue --stash "$RUNNER_TEMP/.persona-jwt"` (skill Step 3a).
-No action step writes it — item 10's missing-file guard covers a run that
-skipped `issue`.
+The persona-JWT stash (item 10) is produced inside the harness step (item 7):
+the supervisor runs `$PERSONA_SELECT_COMMAND`, whose FI form is
+`fit-map substrate pick` → `issue --stash "$RUNNER_TEMP/.persona-jwt"` (skill
+Step 3a). No action step writes it — the missing-file guard covers an unset
+command.
 
-Outputs: `trace-file`, `trace-dir` passed through from the harness step. README
-documents every input/output for external consumers.
+Outputs: `trace-file`, `trace-dir` from the harness step. README documents every
+input/output. Composite actions cannot declare `concurrency`/`timeout-minutes`
+or read `secrets.*` — hence the wrapper and the secret inputs.
 
-- Verification: the Step 6 shape test parses `action.yml` and asserts the
-  declared inputs and substrate gating.
+- Verification: the Step 7 shape test parses `action.yml`.
 
-## Step 4: Workflow wrapper
+## Step 5: Workflow wrapper
 
 - **Modified:** `.github/workflows/kata-interview.yml`
 
-Reduce to a `workflow_dispatch` wrapper: inputs `product`, `job`, `task-amend`,
-`substrate` (boolean, default false), `website-url` (default
-`https://www.forwardimpact.team`), `empty-corpus-test` (passed to the action's
-`substrate-force-empty-corpus` input). Keep `concurrency` and
-`timeout-minutes: 50` on the `interview` job. One step:
-`uses: ./products/kata/actions/kata-interview` passing inputs and secrets
-(`KATA_APP_ID`, `KATA_APP_PRIVATE_KEY`, `ANTHROPIC_API_KEY`,
-`SUPABASE_JWT_SECRET`→`jwt-secret`,
-`SUPABASE_SERVICE_ROLE_KEY`→`service-role-key`, `KATA_KILLSWITCH`→`killswitch`).
-Remove all inline `python3`, `supabase status`, and log-scan bash.
+`workflow_dispatch` wrapper: inputs `product`, `job`, `task-amend`,
+`website-url` (default `https://www.forwardimpact.team`), `empty-corpus-test`.
+Keep `concurrency` + `timeout-minutes: 50`. One step
+`uses: ./products/kata/actions/kata-interview` supplying the FI commands:
+`substrate-setup-command: bunx fit-map substrate stage --cwd "$AGENT_CWD" --emit-env "$GITHUB_ENV"`
+and `persona-select-command:` the FI pick+issue sequence (via a small script or
+`bunx fit-map` calls), plus secrets (`KATA_APP_ID`, `KATA_APP_PRIVATE_KEY`,
+`ANTHROPIC_API_KEY`, `SUPABASE_JWT_SECRET` →`jwt-secret`,
+`SUPABASE_SERVICE_ROLE_KEY`→`service-role-key`, `KATA_KILLSWITCH`→`killswitch`);
+map `empty-corpus-test` into the setup command's `SUBSTRATE_FORCE_EMPTY_CORPUS`.
+Remove all inline `python3`/`supabase status`/ log-scan bash. `bunx fit-map`
+here is the sole remaining documented exception.
 
 - Verification:
   `rg 'python3|supabase status|== .landmark.' .github/workflows/kata-interview.yml`
-  returns nothing; workflow references the action.
+  returns nothing.
 
-## Step 5: Skill parameterization
+## Step 6: Skill parameterization
 
 - **Modified:** `.claude/skills/kata-interview/SKILL.md`,
   `.claude/skills/kata-interview/references/job-handoff.md`
-- SKILL.md Step 5 — state that the entry-point URL is provided in the
-  `WEBSITE_URL` environment variable; the supervisor reads it and uses it in
-  Ask 2 (error if unset, do not invent).
-- `job-handoff.md` — replace the literal `https://www.forwardimpact.team` in the
-  Ask 2 template and both worked examples with a `<website-url>` placeholder,
-  noting it is the `WEBSITE_URL` value.
-- Verification: `rg 'forwardimpact\.team' .claude/skills/kata-interview/`
-  returns nothing.
+- Step 3 staging table — generalize the substrate-backed row: the workspace is
+  staged by the injected substrate-setup step, not a hardcoded `fit-map
+  substrate stage`. Remove the `npx fit-map` reference from that row.
+- Step 3a — when `PERSONA_SELECT_COMMAND` is set, the supervisor runs it (it
+  seals `.env`/`.substrate.json` into `$AGENT_CWD` and stashes a JWT); when
+  unset, build identity from `story.dsl` and issue no JWT. Drop the direct
+  `fit-map substrate pick/issue` instructions in favour of the command contract.
+- Step 5 — read the entry point from `WEBSITE_URL` (error if unset).
+- `job-handoff.md` — replace the literal URL in the Ask 2 template and both
+  worked examples with a `<website-url>` placeholder.
+- Verification: `rg 'forwardimpact\.team' .claude/skills/kata-interview/` and
+  `rg 'fit-map substrate' .claude/skills/kata-interview/SKILL.md` return
+  nothing.
 
-## Step 6: Shape test
+## Step 7: Shape test
 
 - **Modified:** `.github/workflows/test/kata-interview-shape.test.js`
 
-Fully replace the existing `ADDED_STEPS` / `ADDED_RUN_ENV_KEYS` landmark
-assertions (`.github/workflows/test/kata-interview-shape.test.js:24-57`) — they
-match the old `product == 'landmark'` gating that Step 4 removes, so leaving
-them breaks the suite. Parse both
-`products/kata/actions/kata-interview/action.yml` and the wrapper workflow.
-Assert: every substrate-only action step (`Substrate stage`, `Scan logs …`) has
-`if` matching `inputs.substrate == 'true'`; the substrate-selecting`Run
-interview` env keys carry the `inputs.substrate == 'true' && … || ''` ternary;
-no `product == 'landmark'` literal appears in the action; the wrapper job's
-`timeout-minutes` is a number `< 60`.
+Fully replace the `ADDED_STEPS`/`ADDED_RUN_ENV_KEYS` landmark assertions. Parse
+`action.yml` + the wrapper. Assert: substrate-only action steps (setup, scan)
+gate on `inputs.substrate-setup-command != ''`; substrate-selecting
+`Run interview` env keys carry that ternary; no `product == 'landmark'` literal
+in the action; the wrapper job's `timeout-minutes` is a number `< 60`.
 
 - Verification: `bun test .github/workflows/test/kata-interview-shape.test.js`.
 
-## Step 7: Publish wiring
+## Step 8: Publish wiring
 
 - **Modified:** `.github/workflows/publish-actions.yml`
 
-Add `- "products/kata/actions/kata-interview/**"` to the `paths` filter and a
-matrix entry `{ prefix: products/kata/actions/kata-interview, repo:
-kata-interview }` (mirroring the `kata-agent` entry, whose bare `repo:` scopes
-the App token via `repositories: ${{ matrix.action.repo }}`). The sibling
+Add `- "products/kata/actions/kata-interview/**"` to `paths` and a matrix entry
+`{ prefix: products/kata/actions/kata-interview, repo: kata-interview }`
+(mirroring `kata-agent`, whose bare `repo:` scopes the token). The sibling
 `forwardimpact/kata-interview` repo must exist and be seeded before the first
-publish — `split-and-push` rejects a non-fast-forward into a repo with unrelated
-history.
+publish — `split-and-push` rejects a non-fast-forward.
 
 - Verification: `rg 'kata-interview' .github/workflows/publish-actions.yml`
   shows both the path filter and the matrix entry.
 
-## Step 8: Reference prose
+## Step 9: Reference prose
 
 - **Modified:** `references/bionova-apps/design-a.md`
 
-Add a short "Interviewing Polaris" section: a documented `interview.yml` in the
-Polaris repo wrapping `forwardimpact/kata-interview@<sha>` with `website-url` =
-the Polaris entry point, `substrate: true`, and Polaris'
-`JWT_SECRET`/`SERVICE_ROLE_KEY`, noting the interview stages into a temp
-`agent-cwd` so it needs no Polaris application code.
+Add an "Interviewing Polaris" section: a Polaris `interview.yml` wrapping
+`forwardimpact/kata-interview@<sha>` with `website-url` = the Polaris entry
+point and `substrate-setup-command: npx fit-terrain substrate up --cwd
+"$AGENT_CWD" --emit-env "$GITHUB_ENV"` followed by Polaris' seed; patient
+interviews omit `persona-select-command` (anonymous). Note it needs no `fit-map`
+and no map schema, and stages into a temp `agent-cwd`.
 
-- Verification: `rg -n 'kata-interview' references/bionova-apps/design-a.md`
-  shows the wrapper with `website-url` + `substrate`.
+- Verification:
+  `rg -n 'kata-interview|substrate up' references/bionova-apps/design-a.md`.
 
 ## Risks
 
-- **`--secret` parsing** — `options.multiple` yields an array in every case
-  (zero/one/many), so the parser iterates it and splits each on the first `=`;
-  the fail-open trap is a greedy split, not the arity.
-- **`unzip`/`gh` availability** — both are present on the bootstrapped runner;
-  `scan-logs` fails closed if either is absent, so a missing tool surfaces as a
-  loud non-zero, not a silent pass.
-- **Local-path action `uses:`** — the wrapper's `./products/kata/actions/…`
-  resolves against the workflow checkout; the sibling SHA-pin form is only for
-  external consumers (design § Publish path).
+- **`--secret` parsing** — `options.multiple` yields an array in every case;
+  split each on the first `=`. The fail-open trap is a greedy split, not arity.
+- **No spawner move** — `fit-terrain substrate up` carries its own spawner;
+  `products/map/src/lib/supabase-cli.js` stays put (used by `activity.js` and
+  the stage), so there is no `libterrain → map` cycle and no `activity.js` cwd
+  change.
+- **`unzip`/`gh` availability** — present on the runner; `scan-logs` fails
+  closed if absent.
+- **Persona-command contract** — the skill and the FI command must agree on the
+  `.env`/`.substrate.json`/stash outputs (which `fit-map substrate issue`
+  already writes); the contract is stated in the skill.
 
 ## Execution
 
-Single engineering agent, sequential: Steps 1–2 (CLI verbs, `bun test`) before
-Step 3 (the action depends on them at runtime), then Steps 4–8 in order. The
-skill and reference text (Steps 5, 8) are small and coupled to the action's
-inputs, so they stay with the same agent rather than routing to
-`technical-writer`.
+Single engineering agent, sequential. Steps 1–3 (independent CLI additions,
+each `bun test`) can be done in any order but all precede Step 4 (the action
+invokes them). Steps 5–9 follow. Skill/reference text (6, 9) stays with the same
+agent — it is coupled to the action's inputs.

--- a/specs/2170-reusable-interview-action/spec.md
+++ b/specs/2170-reusable-interview-action/spec.md
@@ -1,13 +1,13 @@
 # Spec 2170: Package the interview capability as a reusable published action
 
-**Classification:** Internal. The bulk of the change lands under `.github/`
-(a new composite action and a slimmed workflow), `libraries/libharness/` (a
-`fit-harness` verb), and `.claude/skills/` (skill parameterization). One verb
-lands under `products/map/` (`fit-map substrate`), but it extends substrate
-CI-provisioning machinery, not a persona-facing product feature. The change
-serves the **Platform Builders** persona indirectly by making the interview
-capability consumable by external teams, but no shipped end-user product
-surface changes behaviour.
+**Classification:** Internal. The bulk of the change lands under `.github/` (a
+new composite action and a slimmed workflow) and `libraries/` (`fit-terrain`
+gains a generic substrate verb, `fit-harness` a scan verb), plus `.claude/`
+(skill parameterization). A small `--emit-env` output is added to `fit-map
+substrate` under `products/map/`, not a persona-facing feature. The change
+serves the **Platform Builders**
+persona indirectly by making the interview capability consumable by external
+teams; no shipped end-user product surface changes behaviour.
 
 ## Problem
 
@@ -51,10 +51,12 @@ its glue extracted into tested CLIs (`kata-agent` wraps `bootstrap`, `harness`,
 ## Proposal
 
 Extract the generic interview capability into a **published composite action**,
-push its load-bearing bash into **tested CLI verbs split across `fit-map` and
-`fit-harness`**, and **parameterize the target** so a consumer supplies its own
-entry point and product. Reduce `kata-interview.yml` to a thin wrapper over the
-action, and update the Polaris reference to wrap the same action.
+split its load-bearing bash along the generic-vs-FI seam into **tested CLI
+verbs** (generic Supabase bring-up in `fit-terrain`, run-log scan in
+`fit-harness`), and **make the domain steps pluggable** so a consumer supplies
+its own entry point, substrate bring-up, and persona selection. Reduce
+`kata-interview.yml` to a thin wrapper, and give the Polaris reference a working
+wire-up.
 
 ### A reusable `kata-interview` action
 
@@ -68,95 +70,113 @@ ships `kata-agent`. It owns the **generic** interview infrastructure:
   composite action cannot declare `concurrency` or a job-level
   `timeout-minutes`, so those stay on the thin wrapper workflow (§ Scope).
 - Synthetic-data build (`fit-terrain build`).
-- Optional substrate + Supabase bring-up and env propagation, gated on a
-  generic `substrate` input — **not** a hardcoded product name.
+- Optional substrate bring-up by running a consumer-supplied
+  `substrate-setup-command` (which emits the Supabase URL/anon key), gated on
+  that command being non-empty — **not** a hardcoded product name.
 - The supervised interview run via the harness in `supervise` mode.
 - Cost reporting, wiki push, and run-log secret scanning.
 
 It exposes **app-specific** choices as inputs: the entry-point `website-url`,
-`product`, `job`, steering `task-amend`, whether the run is `substrate`-backed,
-and the usual auth and turn/timeout knobs. A consumer wraps the action in its
-own workflow, passing these; the action contributes no monorepo-specific
-assumptions.
+`product`, `job`, steering `task-amend`, the `substrate-setup-command` and
+`persona-select-command`, and the usual auth and turn/timeout knobs. A consumer
+wraps the action in its own workflow, passing these; the action contributes no
+monorepo-specific assumptions.
 
-### CLI split — the right seam between `fit-map` and `fit-harness`
+### Substrate re-layering — generic to `fit-terrain`, FI-specific pluggable
 
-The two untested inline-bash blocks move to the CLI that already owns their
-domain. Each verb ships with a unit test, which the inline bash never had. The
-seam rationale (which CLI, and why not `fit-trace`) is a design concern.
+The substrate work splits along a **generic vs Forward-Impact-specific** seam.
+The generic half is Supabase orchestration every Supabase-backed consumer needs;
+the FI half knows the map schema and persona invariants and cannot serve a
+different-domain app. Each moves to the layer that owns it (opinionated: the
+consumer uses Supabase — a lowest-common-denominator abstraction would be
+useless):
 
-| Capability | Home CLI |
-| --- | --- |
-| Emit `SUPABASE_URL` + `SUPABASE_ANON_KEY` as env-file lines after substrate bring-up | `fit-map substrate` (owns the substrate lifecycle) |
-| Scan a completed run's log archive for secret literals and fail closed on any hit | `fit-harness` (owns the agent-run lifecycle) |
+| Capability | Home | Why |
+| --- | --- | --- |
+| Bring up Supabase: start, discover URL, emit `SUPABASE_URL`/`SUPABASE_ANON_KEY` | `fit-terrain` (new `substrate up`) | Generic and Supabase-aware already; every consumer runs `fit-terrain`, and it is already on PATH in the action |
+| FI seed/persona layer: map-schema seed, `auth.users` provision, roster `pick`, JWT `issue`, Landmark smoke | `fit-map substrate stage` (kept), invoked through a **pluggable action command** | Product-specific; Polaris substitutes its own |
+| Scan a run's log archive for secret literals, fail closed | `fit-harness` (`scan-logs`) | A run-lifecycle concern, not substrate or trace |
 
-`scan-logs` does not read secrets from fixed env names — the caller passes the
-literals to check. The action supplies three: the persona JWT (from the
-`fit-map substrate issue --stash` file), plus the substrate `jwt-secret` and
-`service-role-key`. This cross-CLI handoff (one `fit-map` verb produces a
-literal a `fit-harness` verb consumes) is expressed through the verb's input
-list, not a hidden coupling.
+The generic bring-up is **added** to `fit-terrain`, not moved out of `fit-map`:
+relocating `fit-map`'s stage would close a `libterrain → @forwardimpact/map`
+dependency cycle, break the in-process env its map client reads, and disrupt
+`fit-map activity`'s use of the shared spawner. So `fit-terrain substrate up` is
+a clean generic primitive (bring-up + emit only; migrations and seed stay with
+the consumer), and `fit-map substrate stage` keeps its pipeline unchanged apart
+from gaining an `--emit-env` output. The action's substrate bring-up is a
+consumer-supplied command (monorepo: `fit-map substrate stage`; Polaris:
+`fit-terrain substrate up` + `supabase db push` + its seed), and persona
+selection is a second pluggable command with the `.env`/`.substrate.json`/stash
+contract `fit-map substrate issue` already satisfies (empty ⇒ `story.dsl`
+identity / anonymous access).
 
 ### Parameterized target — reads inputs, no hardcoded entry point
 
 The `kata-interview` skill and its `job-handoff` reference stop hardcoding
 `https://www.forwardimpact.team` — including the two worked examples in
-`job-handoff.md`, which switch to a `<website-url>` placeholder so the file
-carries no literal entry point. The action passes the consumer's `website-url`
-into the run environment; the supervisor reads it when composing Ask 2. Product
-and job selection already read `JTBD.md` and `products/` — surfaces every
-MONOREPO.md-compliant installation carries — so no further generalization of
-selection is required. Substrate gating moves from the `landmark` product name
-to the generic `substrate` input the action already carries.
+`job-handoff.md`, which switch to a `<website-url>` placeholder. The action
+passes the consumer's `website-url` into the run environment; the supervisor
+reads it in Ask 2. Product and job selection already read `JTBD.md` and
+`products/`. The skill's Step 3a stops calling `fit-map` directly and instead
+runs the injected `persona-select-command`. Substrate steps gate on a non-empty
+`substrate-setup-command`, replacing the `landmark` product predicate.
 
 ### Reference-app enablement (secondary goal)
 
-The monorepo deliverable is the action, the CLI verbs, and the parameterized
-skill. The reference-side deliverable is **documentation only**: the
-`references/bionova-apps/` staging area (this repo, per `references/CLAUDE.md`)
-gains prose describing an interview workflow that wraps the published action
-against Polaris' Supabase stack and `https://` entry point. It does not require
-Polaris application code to exist or run — building Polaris is spec 1160 work in
-the external repo, tracked separately. Because the interview stages synthetic
-data into a temporary agent working directory (never the app tree), it needs no
-part of the Polaris build beyond the vendored `story.dsl` every installation
-already carries.
+The monorepo deliverable is the action, the CLI verbs, the `fit-map` refactor,
+and the parameterized skill. The reference-side deliverable is documentation in
+the `references/bionova-apps/` staging area (per `references/CLAUDE.md`): a
+Polaris `interview.yml` wrapping the published action with
+`substrate-setup-command` = `fit-terrain substrate up` plus Polaris' seed, and
+anonymous (or Polaris-supplied) persona access. This is a **working wire-up** —
+it needs no `fit-map` and no map schema — not the placeholder the prior draft
+settled for. It does not require Polaris application code to run here; the
+interview stages into a temp `agent-cwd`, and Polaris already vendors
+`story.dsl` and runs `fit-terrain`.
 
 ## Scope
 
 ### Included
 
 - New composite action `products/kata/actions/kata-interview/` (`action.yml` +
-  `README.md`), wired into the subtree-split publish set.
-- `fit-map substrate` gains a way to emit `SUPABASE_URL`/`SUPABASE_ANON_KEY` as
-  env-file lines to a caller-named path, with a unit test.
+  `README.md`), wired into the subtree-split publish set, with
+  `substrate-setup-command` and `persona-select-command` inputs.
+- `fit-terrain` gains a `substrate up` verb (Supabase-opinionated: start,
+  discover, `--emit-env` — bring-up only, no migration/seed) with its own thin
+  cwd-explicit spawner and a unit test. Nothing moves out of `products/map`.
+- `fit-map substrate stage` gains an `--emit-env` output after its existing
+  `url-discovery` phase — no delegation, no refactor of its phases — with a
+  test.
 - `fit-harness` gains a `scan-logs` verb that scans a run's log archive for a
   set of secret literals and exits non-zero on any hit, with a unit test.
-- `.github/workflows/kata-interview.yml` refactored to a thin wrapper over the
-  action; its inline `python3` parse and inline log-scan bash removed.
-- Substrate gating expressed as a generic `substrate` input, replacing the
-  `inputs.product == 'landmark'` predicate throughout the workflow and action.
-- `website-url` action input threaded into the run; `kata-interview` SKILL.md
-  and `references/job-handoff.md` read the entry point rather than hardcoding
+- `.github/workflows/kata-interview.yml` refactored to a thin wrapper that
+  supplies the FI `substrate-setup-command` and `persona-select-command`; its
+  inline `python3` parse and inline log-scan bash removed.
+- Substrate gating expressed as a non-empty `substrate-setup-command`, replacing
+  the `inputs.product == 'landmark'` predicate throughout.
+- `website-url` threaded into the run; SKILL.md Step 3a runs the injected
+  `persona-select-command` instead of calling `fit-map`; SKILL.md and
+  `references/job-handoff.md` read the entry point rather than hardcoding
   `forwardimpact.team`.
-- The shape-invariant test updated to assert the generic `substrate` gating on
-  the action's substrate-only steps and the sub-60-minute `timeout-minutes` on
-  the wrapper workflow's job (`concurrency` and the job timeout stay on the
-  wrapper, since a composite action cannot declare either).
+- The shape-invariant test updated to assert substrate gating on
+  `substrate-setup-command != ''` and the sub-60-minute `timeout-minutes` on the
+  wrapper job (`concurrency` and the job timeout stay on the wrapper).
 - Reference update in `references/bionova-apps/` documenting a Polaris interview
-  workflow that wraps the published action.
+  workflow whose `substrate-setup-command` uses `fit-terrain substrate up`.
 
 ### Excluded
 
-- Renaming any sibling repo or CLI, or moving `fit-map` into the gear bundle —
-  the action keeps the documented `bunx fit-map` exception.
+- Renaming any sibling repo or CLI, or moving `fit-map` into the gear bundle.
+  The generic bring-up now runs via `fit-terrain` (already on PATH); the only
+  remaining `bunx fit-map` use is the monorepo wrapper's own FI substrate
+  command, which stays the documented exception.
 - Changing the interview loop itself — the two-Ask handoff, persona isolation,
   and finding-classification Process in the skill are unchanged.
 - Changing the harness `supervise` contract or the `fit-trace cost` report.
 - Managed Supabase, or any Polaris application code (that is spec 1160 work in a
   separate repo).
-- Publishing a `fit-interview` CLI or a new library — the logic splits onto the
-  two existing surfaces.
+- Publishing a `fit-interview` CLI or a new library — the generic substrate
+  layer lands in `fit-terrain`, the scan in `fit-harness`.
 
 ## Prerequisites
 
@@ -169,20 +189,22 @@ already carries.
 ## Success Criteria
 
 1. `products/kata/actions/kata-interview/action.yml` exists, declares the inputs
-   in § A reusable `kata-interview` action, and emits a `trace-file` output.
-   Verify (manual acceptance, not a merge-gate check): a `workflow_dispatch` of
-   the wrapper with `substrate: false` yields a non-empty `trace-file` output
-   and a cost line in the step summary.
+   in § Action interface (incl. `substrate-setup-command`,
+   `persona-select-command`), and emits a `trace-file` output. Verify (manual
+   acceptance): a `workflow_dispatch` of the wrapper with an empty
+   `substrate-setup-command` yields a non-empty `trace-file` and a cost line in
+   the step summary.
 
 2. The `kata-interview.yml` workflow contains no inline `python3` Supabase parse
    and no inline log-scan bash. Verify:
    `rg 'python3|supabase status' .github/workflows/kata-interview.yml` returns
    nothing, and the workflow calls the action.
 
-3. `fit-map substrate stage` gains a flag/mode that emits the Supabase URL and
-   anon key as env-file lines to a caller-named path. Verify: with the flag set,
-   the verb writes `SUPABASE_URL=` and `SUPABASE_ANON_KEY=` lines to the path,
-   covered by a passing unit test.
+3. `fit-terrain substrate up --emit-env <path>` brings up Supabase generically
+   (start + discover) and writes `SUPABASE_URL=`/`SUPABASE_ANON_KEY=` lines to
+   `<path>`; `fit-map substrate stage --emit-env <path>` writes the same two
+   lines after its `url-discovery` phase. Verify: a unit test with a stubbed
+   Supabase spawner asserts both lines for each verb.
 
 4. `fit-harness scan-logs` accepts a resolved log archive plus secret literals,
    owns the archive download when given a run id, and exits non-zero when any
@@ -190,9 +212,9 @@ already carries.
    test asserts both the hit (non-zero) and clean (zero) paths against a fixture
    archive.
 
-5. Substrate steps are gated on the generic `substrate` input, with no
-   `product == 'landmark'` literal in the workflow or action. Verify: the shape
-   test asserts substrate steps carry the `substrate` predicate and
+5. Substrate steps and the scan are gated on a non-empty
+   `substrate-setup-command`, with no `product == 'landmark'` literal in the
+   workflow or action. Verify: the shape test asserts the gate and
    `rg "product\s*==\s*'landmark'"` over the workflow and action returns
    nothing.
 
@@ -206,6 +228,7 @@ already carries.
    test asserts the wrapper job's `timeout-minutes < 60`.
 
 8. `references/bionova-apps/` prose documents a Polaris interview workflow that
-   wraps the published `kata-interview` action with Polaris' entry point and
-   `substrate: true` (documentation only; no Polaris code required). Verify:
-   the reference names the action and passes `website-url` + `substrate` inputs.
+   wraps the published action with Polaris' entry point and a
+   `substrate-setup-command` built on `fit-terrain substrate up` (no `fit-map`,
+   no map schema). Verify: the reference names the action and passes
+   `website-url` + a `fit-terrain`-based `substrate-setup-command`.


### PR DESCRIPTION
## Summary

Revises the merged spec/design/plan for 2170 after an assessment showed the
previous version could not actually serve a different-domain Supabase app
(BioNova Polaris): its "generic" substrate step was `fit-map substrate stage`,
which is FI-specific (map schema, roster invariants, Landmark smoke). The
secondary Polaris goal was therefore only met on paper.

### The correction (answers "what can move from `fit-map` to `fit-terrain`?")

The generic Supabase bring-up moves to `fit-terrain`; the FI persona/seed layer
stays in `fit-map` and becomes pluggable:

- **Add** a generic `fit-terrain substrate up --cwd --emit-env` verb — Supabase
  `start` + URL discovery + emit only (opinionated on Supabase; migrations/seed
  stay with the consumer). `fit-terrain` is already generic, Supabase-aware, and
  on PATH in the action.
- **Do not move** `fit-map`'s stage. A move would close a `libterrain →
  @forwardimpact/map` dependency cycle, break the in-process env its map client
  reads, and disrupt `fit-map activity`'s shared spawner. `fit-map substrate
  stage` keeps its pipeline and gains only an `--emit-env` output.
- Make the action's substrate bring-up and persona selection **pluggable
  command inputs** (`substrate-setup-command`, `persona-select-command`). The
  monorepo passes the FI commands; Polaris passes `fit-terrain substrate up` +
  `supabase db push` + its seed, with anonymous persona access. This is a
  working wire-up — no `fit-map`, no map schema.

Updates `spec.md`, `design-a.md`, and `plan-a.md` together; `wiki/STATUS.md` row
2170 reopened to `design draft`.

### Review

A two-reviewer panel found the cycle / env-break / migration-source blockers in
an interim version; this revision resolves all three (confirmed by a third
reviewer: no move → no cycle; emit appends after `url-discovery` → no env break;
`substrate up` is bring-up-only → no migration ambiguity), plus a stale
`fit-map` reference in the skill's staging table.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01C7dESxLduP3KkzZauo679w

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7dESxLduP3KkzZauo679w)_