### PR TITLE
feat(kata): package the interview capability as a reusable published action (#2170)

### DIFF
--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -89,29 +89,24 @@ Copy the subset the chosen product needs into `$AGENT_CWD`:
 | Guide, Outpost   | nothing                                                                                                                                            |
 | Pathway          | `data/pathway/`                                                                                                                                    |
 | Map              | `data/pathway/` and `data/activity/`                                                                                                               |
-| Substrate-backed | `data/pathway/`; automated workflows commonly bring up the substrate already — otherwise `npx fit-map substrate stage --cwd "$AGENT_CWD"`         |
+| Substrate-backed | `data/pathway/`; the workflow's substrate-setup step brings the substrate up and emits its URL/key — the skill stages no substrate itself |
 | Summit           | `data/pathway/` and `data/activity/raw/activity/summit.yaml` (as `summit.yaml` at root)                                                            |
 
 Use `cp -r data/pathway "$AGENT_CWD/data/pathway"` and similar.
 
-### Step 3a: Pick the Persona (substrate-backed products only)
+### Step 3a: Select the Persona (when a persona-select command is set)
 
-For **substrate-backed products**, the substrate is already up (per
-Step 3). Pick a persona and seal identity via two `fit-map substrate`
-verbs — see the
-[`fit-map` skill § Substrate](https://github.com/forwardimpact/monorepo/blob/main/.claude/skills/fit-map/SKILL.md)
-for verb mechanics, invariants, and exit codes:
+Persona selection is driven by an injected command, not hardcoded here, so
+the loop works for any substrate a consumer supplies.
 
-1. `npx fit-map substrate pick --format json` — read `email`, `name`,
-   `github_username`, `team_name`, `department_name`,
-   `parent.{name,github_username,level}`, `repos`, `teammates`, and
-   `scenario` off the returned persona; no follow-up reads of
-   `data/synthetic/` are needed.
-2. `npx fit-map substrate issue --email <picked> --cwd "$AGENT_CWD"
-   --stash "$RUNNER_TEMP/.persona-jwt"` — `--stash` is for the post-run
-   log scan; the agent has no `$RUNNER_TEMP` access.
-
-On non-zero exit, write a diagnostic naming the verb and exit the skill.
+- **`PERSONA_SELECT_COMMAND` set** — run it. Its contract: seal a persona
+  identity (`.env` + `.substrate.json`) into `$AGENT_CWD` and stash a bare
+  JWT for the post-run log scan (the agent has no `$RUNNER_TEMP` access).
+  Read the persona it prints (name, team, manager, teammates, repos, and
+  scenario) from the command's output for Step 4. On non-zero exit, write a
+  diagnostic and exit the skill.
+- **`PERSONA_SELECT_COMMAND` unset** — issue no JWT; build the persona
+  identity from `data/synthetic/story.dsl` and `prose-cache.json` (Step 4).
 
 ### Step 4: Craft the Persona
 
@@ -119,8 +114,9 @@ Write `$AGENT_CWD/CLAUDE.md`. The persona file carries **who** and **the
 situation** — never the job. Two sources:
 
 - **Identity** (name, team, manager, teammates, repos, recent project,
-  company facts) — substrate-backed: Step 3a's persona row. Others:
-  `data/synthetic/story.dsl` and `prose-cache.json`.
+  company facts) — when a persona-select command ran (Step 3a), from the
+  persona it printed. Otherwise from `data/synthetic/story.dsl` and
+  `prose-cache.json`.
 - **Situation** (Trigger, Forces, Competes With) — from the chosen JTBD
   entry, rephrased into the persona's voice.
 
@@ -136,8 +132,9 @@ Worked examples:
 Hand off in **two `Ask` calls** so persona and job both surface inline in
 the trace. **Ask 1** opens with an introduction prompt; the agent's
 `Answer` brings the persona, Trigger, and Forces inline. **Ask 2**
-delivers the job (Big Hire + Little Hire as the persona's own want); the
-website URL is in the Ask 2 template.
+delivers the job (Big Hire + Little Hire as the persona's own want) and the
+entry point. Read the entry point from `WEBSITE_URL` in the environment; if
+it is unset, write a diagnostic and exit the skill.
 
 Templates and worked examples:
 [`references/job-handoff.md`](references/job-handoff.md). If the task

--- a/.claude/skills/kata-interview/references/job-handoff.md
+++ b/.claude/skills/kata-interview/references/job-handoff.md
@@ -16,10 +16,11 @@ it automatically).
 ## Ask 2 — Job Delivery
 
 Three sentences, composed from the chosen JTBD entry. No product name.
+`<website-url>` is the entry point read from `WEBSITE_URL` (SKILL.md § Step 5).
 
 > Today you want to <Big Hire text, product names after `→` stripped>.
 > Specifically: <Little Hire text, also stripped>. Start at
-> <https://www.forwardimpact.team> — that's the only entry point. Note
+> `<website-url>` — that's the only entry point. Note
 > friction in your final output, not in files.
 
 ## Worked Examples
@@ -43,7 +44,7 @@ Ask 2:
 > Today you want to get career guidance and evidence grounded in BioNova's
 > engineering standard, not impressions or generic advice. Specifically:
 > ask a growth question and check whether your recent Oncora work shows
-> progress toward J070. Start at <https://www.forwardimpact.team> — that's
+> progress toward J070. Start at `<website-url>` — that's
 > the only entry point. Note friction in your final output, not in files.
 
 ### Example B — *Engineering Leaders: Staff Teams to Succeed*
@@ -61,5 +62,5 @@ Ask 2:
 > each role on your Platform Engineering team actually requires.
 > Specifically: spot the capability gaps the v2.1 post-mortem surfaced and
 > check whether the candidate you've been considering fills them. Start at
-> <https://www.forwardimpact.team> — that's the only entry point. Note
+> `<website-url>` — that's the only entry point. Note
 > friction in your final output, not in files.

--- a/.claude/skills/kata-interview/test/skill-shape.test.js
+++ b/.claude/skills/kata-interview/test/skill-shape.test.js
@@ -1,8 +1,9 @@
 /**
  * Shape assertion for the kata-interview SKILL.md. Guards:
  *   - Step 3 staging table carries a substrate-backed-products row.
- *   - Step 3a persona-pick names the substrate verbs the reframe
- *     invokes (`substrate pick` + `substrate issue`).
+ *   - Step 3a persona selection is driven by the injected
+ *     `PERSONA_SELECT_COMMAND` (no hardcoded `fit-map` verbs) and reads the
+ *     entry point from `WEBSITE_URL`.
  *   - The read-do-checklist line carries the amended wording (the
  *     literal "No product names anywhere agent-visible" must be gone, so
  *     production CLI env vars stay permitted).
@@ -28,9 +29,16 @@ describe("kata-interview SKILL.md amendments", () => {
     assert.match(skill, /\| Substrate-backed\s+\|.*substrate.*\|/);
   });
 
-  it("Step 3a persona-pick names the substrate verbs", () => {
-    assert.match(skillFlat, /fit-map substrate pick/);
-    assert.match(skillFlat, /fit-map substrate issue/);
+  it("Step 3a persona selection is driven by PERSONA_SELECT_COMMAND", () => {
+    // The reframe drops hardcoded fit-map verbs in favour of the injected
+    // command contract, so the skill stays generic across substrates.
+    assert.doesNotMatch(skillFlat, /fit-map substrate pick/);
+    assert.doesNotMatch(skillFlat, /fit-map substrate issue/);
+    assert.match(skillFlat, /PERSONA_SELECT_COMMAND/);
+  });
+
+  it("Step 5 reads the entry point from WEBSITE_URL", () => {
+    assert.match(skillFlat, /WEBSITE_URL/);
   });
 
   it("read-do checklist line is amended verbatim", () => {

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -6,8 +6,8 @@ actions (`actions/`) they consume.
 ## Third-party actions
 
 <!-- enum:sibling-composite-actions:count -->
-Five composite actions are co-located in this monorepo and published to
-`forwardimpact/` siblings, SHA-pinned with a `# v1` marker on `uses:` lines:
+Six composite actions are co-located here and published to `forwardimpact/`
+siblings, SHA-pinned (`# v1`) on `uses:` lines:
 <!-- /enum -->
 
 | Action (`@v1`) | Purpose |
@@ -17,6 +17,7 @@ Five composite actions are co-located in this monorepo and published to
 | [benchmark](https://github.com/forwardimpact/benchmark) | Coding-agent benchmarks |
 | [harness](https://github.com/forwardimpact/harness) | Agent task execution |
 | [kata-agent](https://github.com/forwardimpact/kata-agent) | Full Kata run (auth, checkout, bootstrap, harness, wiki) |
+| [kata-interview](https://github.com/forwardimpact/kata-interview) | JTBD switching interview run |
 
 Every workflow calls `bootstrap@v1` for the environment; `kata-agent`
 delegates to bootstrap/harness/wiki internally. `bootstrap` only **checks

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -15,6 +15,11 @@ on:
         description: "Additional text appended to the task prompt for steering"
         required: false
         type: string
+      website-url:
+        description: "Public entry point handed to the persona agent"
+        required: false
+        type: string
+        default: "https://www.forwardimpact.team"
       empty-corpus-test:
         description: "Force substrate-stage to see an empty corpus (CI assertion)"
         required: false
@@ -31,204 +36,29 @@ permissions:
 jobs:
   interview:
     runs-on: ubuntu-latest
+    # A composite action cannot declare concurrency or a job timeout — both
+    # stay here. Keep timeout-minutes strictly under 60 so a stalled run
+    # cannot outlive its 1-hour App token.
     timeout-minutes: 50
     steps:
-      # Killswitch first: fail before any token minting or agent work so one
-      # repository variable halts every kata-* workflow at once.
-      - name: Kata killswitch
-        shell: bash
-        env:
-          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
-        run: |
-          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off) ;;
-            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH})." >&2; exit 1 ;;
-          esac
-
-      - name: Generate installation token
-        id: ci-app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      # Thin wrapper over the reusable action. The only monorepo-specific
+      # knowledge lives here: which products are substrate-backed, and the FI
+      # substrate + persona commands. The action gates all substrate steps on
+      # `substrate-setup-command != ''` — so a file-only product passes an
+      # empty command and skips bring-up, persona selection, and the log scan.
+      # `bunx fit-map` is the sole remaining documented exception (fit-map
+      # ships in the map release, not the gear bundle on PATH).
+      - uses: ./products/kata/actions/kata-interview
         with:
-          app-id: ${{ secrets.KATA_APP_ID }}
-          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          fetch-depth: 0
-          token: ${{ steps.ci-app.outputs.token }}
-
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
-        with:
-          token: ${{ steps.ci-app.outputs.token }}
-          app-slug: kata-agent-team
-          app-id: ${{ secrets.KATA_APP_ID }}
-          # fit-harness (the Run interview step), the terrain/cost steps, and
-          # the fit-wiki push step run straight off PATH. fit-map is NOT
-          # installed here: it ships in the map@v* release, not the gear bundle,
-          # so the substrate step below keeps bunx as a documented exception
-          # until fit-map joins gear.
-          clis: fit-terrain fit-trace fit-harness fit-wiki
-
-      - name: Prepare interview workspace
-        id: agent-workspace
-        shell: bash
-        run: |
-          agent_dir=$(mktemp -d)
-
-          # Build synthetic data so the supervisor can stage the right
-          # subset into the agent CWD per the chosen product. The skill's
-          # staging table decides what gets copied.
-          fit-terrain build
-
-          # Install the Supabase CLI globally — npm's global install is
-          # blocked by supabase's postinstall script, so we use bun.
-          bun install -g supabase
-
-          echo "dir=$agent_dir" >> "$GITHUB_OUTPUT"
-
-      - name: Substrate stage
-        id: substrate-stage
-        if: inputs.product == 'landmark'
-        shell: bash
-        env:
-          JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUBSTRATE_FORCE_EMPTY_CORPUS: ${{ inputs.empty-corpus-test }}
-        run: |
-          # fit-map is a product CLI published in the map@v* release, not the
-          # gear bundle that fit-install.sh / fit-bootstrap clis draws from, so
-          # it cannot be installed onto PATH here. bunx is a deliberate
-          # exception until fit-map joins gear; every other CLI below runs as a
-          # binary.
-          bunx fit-map substrate stage --cwd "${{ steps.agent-workspace.outputs.dir }}"
-
-          # Propagate the local Supabase URL + anon key to subsequent
-          # workflow steps. The Node process running `bunx fit-map
-          # substrate stage` sets these in its own process.env only;
-          # the supervisor's later `bunx fit-map substrate roster/issue`
-          # invocations and the agent's `fit-landmark` spawns need them
-          # via $GITHUB_ENV.
-          status_json=$(bunx --no-install -- supabase status --output json)
-          api_url=$(echo "$status_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["API_URL"])')
-          anon_key=$(echo "$status_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["ANON_KEY"])')
-          if [ -z "$api_url" ] || [ -z "$anon_key" ]; then
-            echo "FAIL: supabase status did not yield API_URL + ANON_KEY" >&2
-            exit 1
-          fi
-          echo "SUPABASE_URL=$api_url" >> "$GITHUB_ENV"
-          echo "SUPABASE_ANON_KEY=$anon_key" >> "$GITHUB_ENV"
-
-      - name: Compose task amendment
-        id: amend
-        shell: bash
-        env:
-          PRODUCT: ${{ inputs.product }}
-          JOB: ${{ inputs.job }}
-          USER_AMEND: ${{ inputs.task-amend }}
-        run: |
-          {
-            echo 'amend<<AMEND_EOF'
-            [ -n "$PRODUCT" ] && echo "Product: $PRODUCT"
-            [ -n "$JOB" ] && echo "Job: $JOB"
-            [ -n "$USER_AMEND" ] && echo "$USER_AMEND"
-            echo 'AMEND_EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Run interview
-        id: interview
-        uses: forwardimpact/harness@b7409ad9a1df4ff75eca8fe68041b5384f75bd7e # v1.0.3
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-          CLAUDE_CODE_USE_BEDROCK: "0"
-          AGENT_CWD: ${{ inputs.product == 'landmark' && steps.agent-workspace.outputs.dir || '' }}
-          JWT_SECRET: ${{ inputs.product == 'landmark' && secrets.SUPABASE_JWT_SECRET || '' }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ inputs.product == 'landmark' && secrets.SUPABASE_SERVICE_ROLE_KEY || '' }}
-        with:
-          mode: "supervise"
-          task-text: |
-            Run the `kata-interview` skill.
-
-            If a `Product:` or `Job:` line is appended below, honour it;
-            otherwise the skill picks. Any other appended text is steering
-            — pass it through.
-          supervisor-cwd: "."
-          agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
-          lead-profile: "product-manager"
-          max-turns: "200"
-          allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,WebFetch,WebSearch"
-          supervisor-allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,Skill,TodoWrite"
-          task-amend: ${{ steps.amend.outputs.amend }}
-
-      # fit-trace cost tolerates a missing trace, so no file guard is needed.
-      - name: Report run cost
-        if: always()
-        shell: bash
-        env:
-          TRACE_FILE: ${{ steps.interview.outputs.trace-file }}
-        run: fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Push wiki changes
-        if: always()
-        uses: forwardimpact/wiki@f88ea81402d4d3411baf9ca0a38cafb11dfa7f60 # v1.0.1
-        with:
-          command: push
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-
-      - name: Scan logs for sensitive values
-        if: always() && inputs.product == 'landmark'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-          JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
-          SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: |
-          stash="$RUNNER_TEMP/.persona-jwt"
-          if [ ! -f "$stash" ]; then
-            echo "No persona-JWT stash at $stash — substrate issue did not run."
-            persona_jwt=""
-          else
-            persona_jwt=$(cat "$stash")
-            echo "::add-mask::$persona_jwt"
-          fi
-
-          # Download the in-progress run's log archive. GH serves the
-          # archive of all completed-step logs even while the run is
-          # active; only the scan step's own logs are excluded — fine,
-          # since the scan step never echoes the JWT. Spec § Success
-          # Criteria row 8 requires the assertion to fire non-zero on a
-          # literal hit; a fail-open `exit 0` on download failure would
-          # silently disarm the gate, so we fail closed.
-          if ! gh api -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/logs" \
-              > /tmp/run-logs.zip 2>/tmp/gh-err.log; then
-            echo "FAIL: log archive download failed — gh api stderr:" >&2
-            cat /tmp/gh-err.log >&2
-            echo "App installation must carry 'Actions: Read'; see PR description." >&2
-            exit 1
-          fi
-          if ! unzip -q /tmp/run-logs.zip -d /tmp/run-logs/; then
-            echo "FAIL: log archive empty/unreadable — cannot verify scan." >&2
-            exit 1
-          fi
-
-          fail=0
-          # Scan the run logs for all three secret literals.
-          # GH Actions auto-masks the two repo secrets, so grepping for
-          # them is normally a no-op — but the scan still performs the
-          # grep so the criterion is satisfied literally and to catch the
-          # unlikely case where GH's masker fails on a partial match.
-          for pair in \
-              "persona-jwt:$persona_jwt" \
-              "jwt-secret:$JWT_SECRET" \
-              "service-role-key:$SERVICE_ROLE_KEY"; do
-            label="${pair%%:*}"
-            value="${pair#*:}"
-            [ -z "$value" ] && continue
-            if grep -RFq -- "$value" /tmp/run-logs/; then
-              echo "FAIL: $label literal in run logs" >&2
-              fail=1
-            fi
-          done
-          exit $fail
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          website-url: ${{ inputs.website-url }}
+          product: ${{ inputs.product }}
+          job: ${{ inputs.job }}
+          task-amend: ${{ inputs.task-amend }}
+          substrate-setup-command: ${{ contains(fromJSON('["landmark"]'), inputs.product) && format('SUBSTRATE_FORCE_EMPTY_CORPUS={0} bunx fit-map substrate stage --cwd "$AGENT_CWD" --emit-env "$GITHUB_ENV"', inputs.empty-corpus-test) || '' }}
+          persona-select-command: ${{ contains(fromJSON('["landmark"]'), inputs.product) && 'persona=$(bunx fit-map substrate pick --format json) && printf ''%s\n'' "$persona" && email=$(printf ''%s'' "$persona" | jq -r .email) && bunx fit-map substrate issue --email "$email" --cwd "$AGENT_CWD" --stash "$RUNNER_TEMP/.persona-jwt"' || '' }}
+          jwt-secret: ${{ secrets.SUPABASE_JWT_SECRET }}
+          service-role-key: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          killswitch: ${{ vars.KATA_KILLSWITCH }}

--- a/.github/workflows/publish-actions.yml
+++ b/.github/workflows/publish-actions.yml
@@ -17,6 +17,7 @@ on:
       - "libraries/libharness/actions/benchmark/**"
       - "libraries/libwiki/actions/wiki/**"
       - "products/kata/actions/kata-agent/**"
+      - "products/kata/actions/kata-interview/**"
       - ".github/actions/bootstrap/**"
       - ".github/actions/split-and-push/**"
       - ".github/workflows/publish-actions.yml"
@@ -41,6 +42,8 @@ jobs:
             repo: wiki
           - prefix: products/kata/actions/kata-agent
             repo: kata-agent
+          - prefix: products/kata/actions/kata-interview
+            repo: kata-interview
           - prefix: .github/actions/bootstrap
             repo: bootstrap
     steps:

--- a/.github/workflows/test/kata-interview-shape.test.js
+++ b/.github/workflows/test/kata-interview-shape.test.js
@@ -1,11 +1,17 @@
 /**
- * Workflow-shape assertion guarding the *Non-Landmark interviews are
- * not regressed* invariant. Parses `.github/workflows/kata-interview.yml`
- * as YAML and verifies every Landmark-only step + every Run-interview
- * env key that selects the Landmark path carries a Landmark predicate,
- * and the interview job declares a timeout-minutes strictly less than
- * the JWT's 1-hour default TTL so a stalled run cannot outlive its
- * credentials.
+ * Workflow/action-shape assertions for the reusable kata-interview action and
+ * its thin wrapper.
+ *
+ * The interview capability moved into a composite action whose substrate steps
+ * are gated on a non-empty `substrate-setup-command` (no hardcoded product
+ * name). This guards two invariants:
+ *   1. Substrate-only action steps and the substrate-selecting env keys gate on
+ *      `substrate-setup-command != ''` — so a file-only interview skips
+ *      bring-up, persona selection, and the log scan — and no
+ *      `product == 'landmark'` literal survives in the action.
+ *   2. The wrapper job declares a `timeout-minutes` strictly under 60 (the
+ *      composite action cannot), so a stalled run cannot outlive its 1-hour App
+ *      token.
  */
 
 import { describe, it } from "node:test";
@@ -17,43 +23,78 @@ import { parse } from "yaml";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WORKFLOW_PATH = join(__dirname, "..", "kata-interview.yml");
+const ACTION_PATH = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "products",
+  "kata",
+  "actions",
+  "kata-interview",
+  "action.yml",
+);
 
+const actionSrc = readFileSync(ACTION_PATH, "utf8");
+const action = parse(actionSrc);
+const actionSteps = action.runs.steps;
 const wf = parse(readFileSync(WORKFLOW_PATH, "utf8"));
-const steps = wf.jobs.interview.steps;
 
-const ADDED_STEPS = ["Substrate stage", "Scan logs for sensitive values"];
-// Every key on `Run interview`'s env that selects the Landmark-only
-// interview path. SUPABASE_URL is propagated via $GITHUB_ENV from the
-// Substrate stage and does not appear in the env: map here.
-const ADDED_RUN_ENV_KEYS = [
-  "AGENT_CWD",
+// Substrate-only steps in the action — present only on the substrate path.
+const SUBSTRATE_STEPS = ["Substrate setup", "Scan logs for sensitive values"];
+// Every `Run interview` env key that selects the substrate path. SUPABASE_URL
+// is propagated via $GITHUB_ENV from the setup command, not this env: map.
+const SUBSTRATE_RUN_ENV_KEYS = [
+  "PERSONA_SELECT_COMMAND",
   "JWT_SECRET",
   "SUPABASE_SERVICE_ROLE_KEY",
 ];
+const GATE = /inputs\.substrate-setup-command\s*!=\s*''/;
 
-describe("kata-interview.yml non-Landmark invariant", () => {
-  it("every Landmark-only step carries the Landmark predicate", () => {
-    for (const name of ADDED_STEPS) {
-      const step = steps.find((s) => s.name === name);
-      assert.ok(step, `expected step "${name}"`);
+describe("kata-interview action substrate gating", () => {
+  it("every substrate-only step gates on substrate-setup-command != ''", () => {
+    for (const name of SUBSTRATE_STEPS) {
+      const step = actionSteps.find((s) => s.name === name);
+      assert.ok(step, `expected action step "${name}"`);
       assert.match(
         String(step.if),
-        /inputs\.product\s*==\s*'landmark'/,
-        `step "${name}" missing Landmark gating`,
+        GATE,
+        `step "${name}" missing substrate-setup-command gate`,
       );
     }
   });
 
-  it("every Landmark-only Run-interview env key is Landmark-gated", () => {
-    const run = steps.find((s) => s.name === "Run interview");
+  it("every substrate-selecting Run interview env key carries the ternary", () => {
+    const run = actionSteps.find((s) => s.name === "Run interview");
     assert.ok(run, "expected 'Run interview' step");
-    for (const key of ADDED_RUN_ENV_KEYS) {
+    for (const key of SUBSTRATE_RUN_ENV_KEYS) {
       assert.match(
         String(run.env[key]),
-        /inputs\.product\s*==\s*'landmark'\s*&&[^|]+\|\|\s*''/,
-        `${key} missing Landmark ternary`,
+        /inputs\.substrate-setup-command\s*!=\s*''\s*&&[^|]+\|\|\s*''/,
+        `${key} missing substrate-setup-command ternary`,
       );
     }
+  });
+
+  it("carries no product == 'landmark' literal", () => {
+    assert.doesNotMatch(
+      actionSrc,
+      /product\s*==\s*'landmark'/,
+      "action must not hardcode the landmark product predicate",
+    );
+  });
+
+  it("emits a trace-file output", () => {
+    assert.ok(action.outputs?.["trace-file"], "expected trace-file output");
+  });
+});
+
+describe("kata-interview.yml wrapper", () => {
+  it("delegates to the local composite action", () => {
+    const step = wf.jobs.interview.steps.find(
+      (s) => s.uses === "./products/kata/actions/kata-interview",
+    );
+    assert.ok(step, "wrapper must call ./products/kata/actions/kata-interview");
   });
 
   it("interview job declares timeout-minutes < 60", () => {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ npm. It is the source of truth for `forwardimpact/*` sibling repos:
   ([`.github/CLAUDE.md`](.github/CLAUDE.md)):
 
   <!-- enum:sibling-composite-actions:list -->
-  `benchmark`, `bootstrap`, `harness`, `kata-agent`, `wiki`
+  `benchmark`, `bootstrap`, `harness`, `kata-agent`, `kata-interview`, `wiki`
   <!-- /enum -->
 
 Published skills teach how products **work** and **use**, not how they're

--- a/KATA.md
+++ b/KATA.md
@@ -37,7 +37,7 @@ surfaces and sessions.
 Local composite actions under `.github/actions/` encapsulate shared CI steps:
 `audit/` and `coaligned-check/`.
 <!-- enum:sibling-composite-actions:count -->
-Five composite actions are co-located here and published to `forwardimpact/`
+Six composite actions are co-located here and published to `forwardimpact/`
 siblings:
 <!-- /enum -->
 
@@ -47,6 +47,7 @@ siblings:
 - `harness` — agent task execution
 - `wiki` — agent-memory commands with fresh App token
 - `kata-agent` — full Kata workflow (auth, checkout, bootstrap, eval, wiki push)
+- `kata-interview` — JTBD switching interview run
 <!-- /enum -->
 
 Publish, pinning, and release mechanics live in

--- a/libraries/libharness/bin/fit-harness.js
+++ b/libraries/libharness/bin/fit-harness.js
@@ -13,6 +13,7 @@ import { runSuperviseCommand } from "../src/commands/supervise.js";
 import { runFacilitateCommand } from "../src/commands/facilitate.js";
 import { runDiscussCommand } from "../src/commands/discuss.js";
 import { runCallbackCommand } from "../src/commands/callback.js";
+import { runScanLogsCommand } from "../src/commands/scan-logs.js";
 import { AGENT_MODEL, LEAD_MODEL } from "@forwardimpact/libutil/models";
 
 const LEAD_OPTIONS = {
@@ -276,6 +277,35 @@ const definition = {
           type: "string",
           description:
             "Discussion id (fallback when the trace lacks a meta event)",
+        },
+      },
+    },
+    {
+      name: "scan-logs",
+      args: [],
+      argsUsage: "",
+      handler: runScanLogsCommand,
+      description:
+        "Scan a run's log archive for secret literals; exit non-zero on any hit, fail closed on an unreadable archive",
+      options: {
+        archive: {
+          type: "string",
+          description: "Path to an already-resolved log archive (.zip)",
+        },
+        "run-id": {
+          type: "string",
+          description:
+            "GitHub Actions run id to download the log archive for (with --repo)",
+        },
+        repo: {
+          type: "string",
+          description: "owner/repo for the --run-id download",
+        },
+        secret: {
+          type: "string",
+          multiple: true,
+          description:
+            "Repeatable label=literal; the literal (everything after the first =) is searched for in the logs",
         },
       },
     },

--- a/libraries/libharness/src/commands/scan-logs.js
+++ b/libraries/libharness/src/commands/scan-logs.js
@@ -142,9 +142,9 @@ export async function runScanLogsCommand(ctx) {
   try {
     dir = await resolveLogsDir({ options, runtime });
   } catch (err) {
-    // Fail closed: an unresolvable archive must not pass as "no leak".
-    runtime.proc.stderr.write(`FAIL: scan-logs: ${err.message}\n`);
-    return { ok: false, code: 1, error: err.message };
+    // Fail closed: an unresolvable archive must not pass as "no leak". The
+    // dispatcher prints the returned `error`, so don't also write it here.
+    return { ok: false, code: 1, error: `scan-logs: ${err.message}` };
   }
 
   const failures = await scanDirectory({ dir, secrets, runtime });

--- a/libraries/libharness/src/commands/scan-logs.js
+++ b/libraries/libharness/src/commands/scan-logs.js
@@ -1,0 +1,155 @@
+/**
+ * `fit-harness scan-logs` — scan a run's log archive for secret literals and
+ * fail closed.
+ *
+ * A run-lifecycle concern (not an NDJSON trace, so it lives here rather than
+ * in `fit-trace`): after a CI run that handled secrets, download or accept the
+ * run's own log archive and assert none of a supplied set of literals leaked
+ * into it. Any hit exits non-zero; any download/extract failure also exits
+ * non-zero — the gate must never silently disarm.
+ *
+ * Log resolution:
+ *   - `--archive <zip>` — an already-resolved archive (extracted locally).
+ *   - `--run-id <id> --repo <owner/repo>` — download this run's archive via
+ *     `gh` first, then extract.
+ *
+ * Secrets are `--secret <label>=<literal>`, repeatable. The literal is
+ * everything after the FIRST `=` (JWTs and base64 keys contain `=`); the label
+ * is only cosmetic, named in the `FAIL:` line.
+ */
+
+import { join } from "node:path";
+
+/**
+ * Parse repeatable `--secret label=literal` flags. libcli's `multiple: true`
+ * yields an array from node's parseArgs in every case; tolerate a bare string
+ * or undefined defensively. Split on the FIRST `=` only.
+ *
+ * @param {string[]|string|undefined} secretOpt
+ * @returns {{label: string, literal: string}[]}
+ */
+export function parseSecrets(secretOpt) {
+  const arr = Array.isArray(secretOpt)
+    ? secretOpt
+    : secretOpt
+      ? [secretOpt]
+      : [];
+  return arr.map((s) => {
+    const idx = s.indexOf("=");
+    if (idx === -1) return { label: s, literal: "" };
+    return { label: s.slice(0, idx), literal: s.slice(idx + 1) };
+  });
+}
+
+/**
+ * Walk a directory tree and return every file path. Uses per-level readdir so
+ * it works against both node:fs and the libmock fs (no `recursive` reliance).
+ */
+async function collectFiles(dir, runtime) {
+  const out = [];
+  const entries = await runtime.fs.readdir(dir, { withFileTypes: true });
+  for (const ent of entries) {
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      out.push(...(await collectFiles(full, runtime)));
+    } else if (ent.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Scan every file under `dir` for each secret literal. Returns the labels of
+ * secrets whose non-empty literal appears in any file (empty literals are
+ * skipped — a secret the run never set cannot leak).
+ *
+ * @param {object} params
+ * @param {string} params.dir
+ * @param {{label: string, literal: string}[]} params.secrets
+ * @param {import('@forwardimpact/libutil/runtime').Runtime} params.runtime
+ * @returns {Promise<string[]>} labels that hit
+ */
+export async function scanDirectory({ dir, secrets, runtime }) {
+  const files = await collectFiles(dir, runtime);
+  const contents = await Promise.all(
+    files.map((f) => runtime.fs.readFile(f, "utf8").catch(() => "")),
+  );
+  const failures = [];
+  for (const { label, literal } of secrets) {
+    if (!literal) continue;
+    if (contents.some((c) => c.includes(literal))) failures.push(label);
+  }
+  return failures;
+}
+
+/**
+ * Resolve a directory of extracted log files, downloading the archive first
+ * when given a run id. Throws (→ fail closed) on any download or extract
+ * failure or on missing/invalid inputs.
+ */
+async function resolveLogsDir({ options, runtime }) {
+  const tmpRoot = runtime.proc.env.RUNNER_TEMP || "/tmp";
+  const dir = await runtime.fs.mkdtemp(join(tmpRoot, "scan-logs-"));
+  let zip = options.archive;
+
+  if (!zip) {
+    const runId = options["run-id"];
+    const repo = options.repo;
+    if (!runId || !repo) {
+      throw new Error("requires --archive, or --run-id and --repo");
+    }
+    if (!/^\d+$/.test(String(runId))) {
+      throw new Error("--run-id must be numeric");
+    }
+    if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+      throw new Error("--repo must be owner/name");
+    }
+    zip = join(dir, "run-logs.zip");
+    const dl = await runtime.subprocess.run("bash", [
+      "-c",
+      `gh api -H "Accept: application/vnd.github+json" ` +
+        `"/repos/${repo}/actions/runs/${runId}/logs" > "${zip}"`,
+    ]);
+    if (dl.exitCode !== 0) {
+      throw new Error(
+        `log archive download failed (gh exit ${dl.exitCode}): ${dl.stderr ?? ""}`,
+      );
+    }
+  }
+
+  const unz = await runtime.subprocess.run("unzip", ["-q", zip, "-d", dir]);
+  if (unz.exitCode !== 0) {
+    throw new Error(
+      `log archive empty/unreadable (unzip exit ${unz.exitCode})`,
+    );
+  }
+  return dir;
+}
+
+/**
+ * scan-logs command handler.
+ *
+ * @param {import("@forwardimpact/libcli").InvocationContext} ctx
+ * @returns {Promise<{ok: boolean, code: number, error?: string}>}
+ */
+export async function runScanLogsCommand(ctx) {
+  const runtime = ctx.deps.runtime;
+  const options = ctx.options;
+  const secrets = parseSecrets(options.secret);
+
+  let dir;
+  try {
+    dir = await resolveLogsDir({ options, runtime });
+  } catch (err) {
+    // Fail closed: an unresolvable archive must not pass as "no leak".
+    runtime.proc.stderr.write(`FAIL: scan-logs: ${err.message}\n`);
+    return { ok: false, code: 1, error: err.message };
+  }
+
+  const failures = await scanDirectory({ dir, secrets, runtime });
+  for (const label of failures) {
+    runtime.proc.stderr.write(`FAIL: ${label} literal in run logs\n`);
+  }
+  return { ok: failures.length === 0, code: failures.length ? 1 : 0 };
+}

--- a/libraries/libharness/test/scan-logs.test.js
+++ b/libraries/libharness/test/scan-logs.test.js
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for `fit-harness scan-logs`.
+ *
+ * `scanDirectory` and `parseSecrets` are pure and tested directly against a
+ * libmock fs; `runScanLogsCommand` is tested for the fail-closed path when the
+ * archive cannot be extracted (unzip exits non-zero) — a fail-open there would
+ * silently disarm the leak gate.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createTestRuntime, createMockFs } from "@forwardimpact/libmock";
+
+import {
+  scanDirectory,
+  parseSecrets,
+  runScanLogsCommand,
+} from "../src/commands/scan-logs.js";
+
+describe("parseSecrets", () => {
+  test("splits on the first = only (literals may contain =)", () => {
+    const parsed = parseSecrets([
+      "persona-jwt=eyJ.header=.sig==",
+      "empty=",
+      "bare",
+    ]);
+    assert.deepEqual(parsed, [
+      { label: "persona-jwt", literal: "eyJ.header=.sig==" },
+      { label: "empty", literal: "" },
+      { label: "bare", literal: "" },
+    ]);
+  });
+
+  test("tolerates a bare string or undefined", () => {
+    assert.deepEqual(parseSecrets("a=b"), [{ label: "a", literal: "b" }]);
+    assert.deepEqual(parseSecrets(undefined), []);
+  });
+});
+
+describe("scanDirectory", () => {
+  function runtimeWithLogs(files) {
+    const fs = createMockFs();
+    for (const [path, content] of Object.entries(files)) {
+      // Register the file by writing it; nested dirs are inferred by readdir.
+      fs.writeFileSync(path, content);
+    }
+    return createTestRuntime({ fs });
+  }
+
+  test("hit: records the label whose literal appears in a nested file", async () => {
+    const runtime = runtimeWithLogs({
+      "/logs/build/1_step.txt": "starting build\nTOKEN=super-secret-jwt done",
+      "/logs/build/2_step.txt": "nothing here",
+    });
+    const failures = await scanDirectory({
+      dir: "/logs",
+      secrets: [
+        { label: "persona-jwt", literal: "super-secret-jwt" },
+        { label: "other", literal: "not-present" },
+      ],
+      runtime,
+    });
+    assert.deepEqual(failures, ["persona-jwt"]);
+  });
+
+  test("clean: no literal present → empty", async () => {
+    const runtime = runtimeWithLogs({
+      "/logs/a.txt": "all masked ***",
+    });
+    const failures = await scanDirectory({
+      dir: "/logs",
+      secrets: [{ label: "jwt-secret", literal: "abc123" }],
+      runtime,
+    });
+    assert.deepEqual(failures, []);
+  });
+
+  test("empty literals are skipped (a never-set secret cannot leak)", async () => {
+    const runtime = runtimeWithLogs({ "/logs/a.txt": "" });
+    const failures = await scanDirectory({
+      dir: "/logs",
+      secrets: [{ label: "persona-jwt", literal: "" }],
+      runtime,
+    });
+    assert.deepEqual(failures, []);
+  });
+});
+
+describe("runScanLogsCommand", () => {
+  test("fails closed when the archive cannot be extracted", async () => {
+    const runtime = createTestRuntime({
+      subprocess: {
+        // unzip a nonexistent archive → non-zero exit.
+        run: async () => ({ exitCode: 9, stdout: "", stderr: "cannot find" }),
+        spawn: () => ({ exitCode: Promise.resolve(0) }),
+      },
+    });
+    const result = await runScanLogsCommand({
+      deps: { runtime },
+      options: { archive: "/nope/missing.zip", secret: ["a=b"] },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 1);
+    assert.match(result.error, /unreadable|unzip/);
+  });
+
+  test("requires --archive or --run-id + --repo (fails closed)", async () => {
+    const runtime = createTestRuntime({
+      subprocess: {
+        run: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        spawn: () => ({ exitCode: Promise.resolve(0) }),
+      },
+    });
+    const result = await runScanLogsCommand({
+      deps: { runtime },
+      options: { secret: ["a=b"] },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 1);
+  });
+});

--- a/libraries/libharness/test/scan-logs.test.js
+++ b/libraries/libharness/test/scan-logs.test.js
@@ -9,7 +9,11 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { createTestRuntime, createMockFs } from "@forwardimpact/libmock";
+import {
+  createTestRuntime,
+  createMockFs,
+  createMockProcess,
+} from "@forwardimpact/libmock";
 
 import {
   scanDirectory,
@@ -87,6 +91,57 @@ describe("scanDirectory", () => {
 });
 
 describe("runScanLogsCommand", () => {
+  // Build a runtime whose `unzip` "extracts" the given fixture files into the
+  // `-d <dir>` target in the mock fs, so the whole command (resolve → extract
+  // → scan → exit code) runs end-to-end without a real archive or binary.
+  function runtimeExtracting(files) {
+    const fs = createMockFs();
+    const proc = createMockProcess();
+    const subprocess = {
+      run: async (cmd, args = []) => {
+        if (cmd === "unzip") {
+          const dir = args[args.indexOf("-d") + 1];
+          for (const [name, content] of Object.entries(files)) {
+            fs.writeFileSync(`${dir}/${name}`, content);
+          }
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+      spawn: () => ({ exitCode: Promise.resolve(0) }),
+    };
+    return createTestRuntime({ fs, proc, subprocess });
+  }
+
+  test("hit: a resolved archive containing a literal exits non-zero", async () => {
+    const runtime = runtimeExtracting({
+      "1_build.txt": "starting\nAuthorization: Bearer super-secret-jwt\ndone",
+    });
+    const result = await runScanLogsCommand({
+      deps: { runtime },
+      options: {
+        archive: "/tmp/run-logs.zip",
+        secret: ["persona-jwt=super-secret-jwt", "unused=not-present"],
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 1);
+  });
+
+  test("clean: a resolved archive with no literal exits zero", async () => {
+    const runtime = runtimeExtracting({
+      "1_build.txt": "all values masked as ***\n",
+    });
+    const result = await runScanLogsCommand({
+      deps: { runtime },
+      options: {
+        archive: "/tmp/run-logs.zip",
+        secret: ["persona-jwt=super-secret-jwt"],
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.code, 0);
+  });
+
   test("fails closed when the archive cannot be extracted", async () => {
     const runtime = createTestRuntime({
       subprocess: {

--- a/libraries/libterrain/bin/fit-terrain.js
+++ b/libraries/libterrain/bin/fit-terrain.js
@@ -30,6 +30,7 @@ import {
   printCacheReport,
   printGenerateStats,
 } from "../src/cli-helpers.js";
+import { runSubstrateUp } from "../src/commands/substrate-up.js";
 
 // Overlay the runtime so the prompt/template loaders read inlined assets when
 // this is a compiled binary; a no-op in source/npx execution.
@@ -127,6 +128,27 @@ const definition = {
         "bunx fit-terrain inspect entities",
         "bunx fit-terrain inspect cache-lookup",
         "bunx fit-terrain inspect validate",
+      ],
+    },
+    {
+      name: "substrate up",
+      description:
+        "Bring up a local Supabase stack generically (start + discover); emit its URL/anon key. No migrations or seed — those stay with the consumer.",
+      options: {
+        cwd: {
+          type: "string",
+          description:
+            "Checkout to start Supabase from (default: current directory)",
+        },
+        "emit-env": {
+          type: "string",
+          description:
+            "Append SUPABASE_URL= / SUPABASE_ANON_KEY= lines to this path (e.g. $GITHUB_ENV)",
+        },
+      },
+      examples: [
+        "bunx fit-terrain substrate up",
+        'bunx fit-terrain substrate up --cwd . --emit-env "$GITHUB_ENV"',
       ],
     },
   ],
@@ -380,6 +402,25 @@ async function main() {
   if (!parsed) return;
 
   const { values, positionals } = parsed;
+
+  // `substrate up` is a generic Supabase bring-up, not a pipeline verb — it
+  // builds no synthetic-data pipeline, so it dispatches before resolveVerb.
+  if (positionals[0] === "substrate") {
+    if (positionals[1] !== "up") {
+      cli.usageError(
+        `Unknown substrate subcommand "${positionals[1] ?? ""}". Run "fit-terrain --help".`,
+      );
+      return;
+    }
+    const ok = await runSubstrateUp({
+      cwd: values.cwd,
+      emitEnv: values["emit-env"],
+      runtime,
+    });
+    if (ok !== 0) runtime.proc.exitCode = 1;
+    return;
+  }
+
   const resolved = resolveVerb(positionals);
   if (!resolved) return;
 

--- a/libraries/libterrain/src/commands/substrate-up.js
+++ b/libraries/libterrain/src/commands/substrate-up.js
@@ -1,0 +1,153 @@
+/**
+ * `fit-terrain substrate up` — generic Supabase bring-up.
+ *
+ * Opinionated on Supabase by design: it starts the local stack from an
+ * explicit `--cwd`, discovers the API URL and anon key via `supabase status
+ * --output json`, and (with `--emit-env`) appends `SUPABASE_URL=` /
+ * `SUPABASE_ANON_KEY=` lines to a target file. It knows nothing about
+ * migrations, seed data, or any product schema — those stay with the
+ * consumer's own command. This keeps the verb portable to any
+ * Supabase-backed checkout (e.g. a different-domain app), not just repos
+ * running the full Forward Impact stack.
+ *
+ * The spawner is inlined and cwd-explicit — it does not resolve a package
+ * root — so a consumer running from its own checkout brings up the stack
+ * defined by that checkout's `supabase/` directory. It is injectable for
+ * tests so the bring-up logic is exercised without a real `supabase` binary.
+ */
+
+import { formatSuccess } from "@forwardimpact/libcli";
+
+const SUPABASE_INSTALL_URL =
+  "https://supabase.com/docs/guides/local-development";
+
+function missingCliError() {
+  return new Error(
+    "Could not find the `supabase` CLI on PATH. Install it via Homebrew " +
+      "(`brew install supabase/tap/supabase`), npm " +
+      "(`npm install -g supabase`), or bun (`bun install -g supabase` — " +
+      "ensure the bun global bin directory is on PATH). " +
+      `See ${SUPABASE_INSTALL_URL}.`,
+  );
+}
+
+/**
+ * Build a thin, cwd-explicit Supabase spawner. Unlike fit-map's wrapper it
+ * takes `cwd` verbatim (no package-root resolution) so it targets the
+ * consumer's own checkout. Resolution order mirrors fit-map's: bare
+ * `supabase` on PATH, then `npx --no-install -- supabase`.
+ *
+ * @param {object} opts
+ * @param {import('@forwardimpact/libutil/runtime').Runtime} opts.runtime
+ * @param {string} opts.cwd - Working directory for every invocation.
+ * @returns {{ run: (args: string[]) => Promise<void>, capture: (args: string[]) => Promise<string> }}
+ */
+export function createSupabaseSpawner({ runtime, cwd }) {
+  if (!runtime?.subprocess) {
+    throw new Error("createSupabaseSpawner requires runtime.subprocess");
+  }
+  let resolvedPromise = null;
+
+  async function doResolve() {
+    const bare = await runtime.subprocess.run("supabase", ["--version"], {
+      cwd,
+    });
+    if (bare.exitCode === 0) return { cmd: "supabase", prefix: [] };
+    const viaNpx = await runtime.subprocess.run(
+      "npx",
+      ["--no-install", "--", "supabase", "--version"],
+      { cwd },
+    );
+    if (viaNpx.exitCode === 0) {
+      return { cmd: "npx", prefix: ["--no-install", "--", "supabase"] };
+    }
+    return null;
+  }
+
+  function resolve() {
+    if (!resolvedPromise) resolvedPromise = doResolve();
+    return resolvedPromise;
+  }
+
+  async function run(args) {
+    const desc = await resolve();
+    if (!desc) throw missingCliError();
+    // Inherit stdio so `supabase start` progress streams to the operator.
+    const child = runtime.subprocess.spawn(
+      desc.cmd,
+      [...desc.prefix, ...args],
+      {
+        cwd,
+        stdio: "inherit",
+      },
+    );
+    const code = await child.exitCode;
+    if (code !== 0) {
+      throw new Error(`supabase ${args.join(" ")} exited ${code}`);
+    }
+  }
+
+  async function capture(args) {
+    const desc = await resolve();
+    if (!desc) throw missingCliError();
+    const r = await runtime.subprocess.run(
+      desc.cmd,
+      [...desc.prefix, ...args],
+      {
+        cwd,
+      },
+    );
+    if (r.exitCode !== 0) {
+      throw new Error(`supabase ${args.join(" ")} exited ${r.exitCode}`);
+    }
+    return r.stdout;
+  }
+
+  return { run, capture };
+}
+
+/**
+ * Bring up a local Supabase stack and, when requested, emit its discovery
+ * vector as `KEY=value` lines.
+ *
+ * @param {object} params
+ * @param {string} [params.cwd] - Checkout to start Supabase from (default:
+ *   `runtime.proc.cwd()`).
+ * @param {string} [params.emitEnv] - Path to append `SUPABASE_URL=` /
+ *   `SUPABASE_ANON_KEY=` to (e.g. `$GITHUB_ENV`). Omit to skip the emit.
+ * @param {import('@forwardimpact/libutil/runtime').Runtime} params.runtime
+ * @param {(opts: object) => {run: Function, capture: Function}} [params.createSpawner]
+ *   Injected for tests; defaults to the real cwd-explicit spawner.
+ * @returns {Promise<number>}
+ */
+export async function runSubstrateUp({
+  cwd,
+  emitEnv,
+  runtime,
+  createSpawner = createSupabaseSpawner,
+} = {}) {
+  const targetCwd = cwd ?? runtime.proc.cwd();
+  const supabase = createSpawner({ runtime, cwd: targetCwd });
+
+  await supabase.run(["start"]);
+
+  const json = await supabase.capture(["status", "--output", "json"]);
+  const status = JSON.parse(json);
+  if (!status.API_URL) throw new Error("supabase status: no API_URL");
+  if (!status.ANON_KEY) throw new Error("supabase status: no ANON_KEY");
+
+  // Make the live values visible to any same-process consumer (mirrors
+  // fit-map's url-discovery phase); `--emit-env` carries them across steps.
+  runtime.proc.env.SUPABASE_URL = status.API_URL;
+  runtime.proc.env.SUPABASE_ANON_KEY = status.ANON_KEY;
+
+  if (emitEnv) {
+    await runtime.fs.appendFile(
+      emitEnv,
+      `SUPABASE_URL=${status.API_URL}\nSUPABASE_ANON_KEY=${status.ANON_KEY}\n`,
+    );
+  }
+
+  runtime.proc.stdout.write(formatSuccess("Substrate up") + "\n");
+  return 0;
+}

--- a/libraries/libterrain/test/substrate-up.test.js
+++ b/libraries/libterrain/test/substrate-up.test.js
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for `fit-terrain substrate up` (generic Supabase bring-up).
+ *
+ * The Supabase spawner is injected so the bring-up + emit logic is exercised
+ * without a real `supabase` binary: a fake spawner records `start` and returns
+ * a scripted `status --output json`. Assertions cover the two emitted
+ * `KEY=value` lines, the explicit cwd threaded to the spawner, and the
+ * fail-closed paths when status omits a field.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createTestRuntime } from "@forwardimpact/libmock";
+
+import {
+  runSubstrateUp,
+  createSupabaseSpawner,
+} from "../src/commands/substrate-up.js";
+
+/**
+ * A fake spawner factory: records the cwd it was built with and every `run`
+ * call, and returns `statusJson` from `capture`.
+ */
+function fakeSpawner(statusJson, sink) {
+  return ({ cwd }) => {
+    sink.cwd = cwd;
+    return {
+      run: async (args) => {
+        sink.runs.push(args);
+      },
+      capture: async (args) => {
+        sink.captures.push(args);
+        return statusJson;
+      },
+    };
+  };
+}
+
+describe("fit-terrain substrate up", () => {
+  test("emit-env writes SUPABASE_URL and SUPABASE_ANON_KEY", async () => {
+    const runtime = createTestRuntime();
+    const sink = { runs: [], captures: [] };
+    const code = await runSubstrateUp({
+      cwd: "/checkout",
+      emitEnv: "/tmp/gh-env",
+      runtime,
+      createSpawner: fakeSpawner(
+        JSON.stringify({
+          API_URL: "http://127.0.0.1:54321",
+          ANON_KEY: "anon-x",
+        }),
+        sink,
+      ),
+    });
+
+    assert.equal(code, 0);
+    assert.deepEqual(sink.runs[0], ["start"]);
+    assert.equal(sink.cwd, "/checkout");
+    const written = await runtime.fs.readFile("/tmp/gh-env", "utf8");
+    assert.equal(
+      written,
+      "SUPABASE_URL=http://127.0.0.1:54321\nSUPABASE_ANON_KEY=anon-x\n",
+    );
+  });
+
+  test("without emit-env, brings up but writes nothing", async () => {
+    const runtime = createTestRuntime();
+    const sink = { runs: [], captures: [] };
+    const code = await runSubstrateUp({
+      cwd: "/checkout",
+      runtime,
+      createSpawner: fakeSpawner(
+        JSON.stringify({ API_URL: "http://u", ANON_KEY: "k" }),
+        sink,
+      ),
+    });
+
+    assert.equal(code, 0);
+    assert.deepEqual(sink.runs[0], ["start"]);
+    assert.equal(runtime.proc.env.SUPABASE_URL, "http://u");
+    assert.equal(runtime.proc.env.SUPABASE_ANON_KEY, "k");
+  });
+
+  test("fails closed when status lacks API_URL", async () => {
+    const runtime = createTestRuntime();
+    const sink = { runs: [], captures: [] };
+    await assert.rejects(
+      () =>
+        runSubstrateUp({
+          cwd: "/checkout",
+          emitEnv: "/tmp/gh-env",
+          runtime,
+          createSpawner: fakeSpawner(JSON.stringify({ ANON_KEY: "k" }), sink),
+        }),
+      /no API_URL/,
+    );
+  });
+
+  test("spawner resolves bare supabase and threads cwd", async () => {
+    const calls = [];
+    const runtime = createTestRuntime({
+      subprocess: {
+        run: async (cmd, args, opts) => {
+          calls.push({ cmd, args, opts, kind: "run" });
+          return { exitCode: 0, stdout: "{}", stderr: "" };
+        },
+        spawn: (cmd, args, opts) => {
+          calls.push({ cmd, args, opts, kind: "spawn" });
+          return { exitCode: Promise.resolve(0) };
+        },
+      },
+    });
+    const spawner = createSupabaseSpawner({ runtime, cwd: "/checkout" });
+    await spawner.run(["start"]);
+
+    // First call probes bare `supabase --version` from the explicit cwd.
+    assert.equal(calls[0].cmd, "supabase");
+    assert.deepEqual(calls[0].args, ["--version"]);
+    assert.equal(calls[0].opts.cwd, "/checkout");
+    // Then `start` runs via spawn with inherited stdio from the same cwd.
+    const spawnCall = calls.find((c) => c.kind === "spawn");
+    assert.equal(spawnCall.cmd, "supabase");
+    assert.deepEqual(spawnCall.args, ["start"]);
+    assert.equal(spawnCall.opts.cwd, "/checkout");
+    assert.equal(spawnCall.opts.stdio, "inherit");
+  });
+});

--- a/products/kata/actions/kata-interview/README.md
+++ b/products/kata/actions/kata-interview/README.md
@@ -1,0 +1,150 @@
+# Kata Interview
+
+Run a JTBD switching interview in a single step. An isolated agent, briefed
+only with a persona, meets a product cold at a public website and tries to get
+a chosen Job To Be Done done; a supervisor runs the
+[`kata-interview` skill](https://www.npmjs.com/package/@forwardimpact/kata-skills)
+to build the persona, hand off the job in two Asks, and file findings as
+issues.
+
+This action owns the **generic** interview infrastructure: killswitch, GitHub
+App authentication, checkout, environment bootstrap, synthetic-data build, the
+supervised run via
+[fit-harness](https://www.npmjs.com/package/@forwardimpact/libharness), cost
+reporting, wiki-memory sync, and run-log secret scanning. The **app-specific**
+choices are pluggable inputs, so any repository — not just one running the full
+Forward Impact stack — can wrap it:
+
+- **`website-url`** — the entry point handed to the persona agent.
+- **`substrate-setup-command`** — brings up a Supabase substrate and emits its
+  URL/anon key. Empty runs a file-only interview.
+- **`persona-select-command`** — seals a persona identity and stashes a JWT for
+  the post-run scan. Empty builds the persona from the synthetic story with
+  anonymous access.
+
+## Usage
+
+```yaml
+name: "Kata: Interview"
+on:
+  workflow_dispatch:
+    inputs:
+      product:
+        required: false
+        type: string
+      job:
+        required: false
+        type: string
+
+concurrency:
+  group: kata-interview
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  interview:
+    runs-on: ubuntu-latest
+    # A composite action cannot declare concurrency or a job timeout — keep
+    # both on this wrapper. Stay strictly under 60 so a stalled run cannot
+    # outlive its 1-hour App token.
+    timeout-minutes: 50
+    steps:
+      - uses: forwardimpact/kata-interview@v1
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          website-url: https://example.com
+          product: ${{ inputs.product }}
+          job: ${{ inputs.job }}
+          # File-only interview: no substrate-setup-command / persona command.
+```
+
+A substrate-backed interview supplies the two domain commands and the substrate
+secrets:
+
+```yaml
+      - uses: forwardimpact/kata-interview@v1
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          website-url: https://example.com
+          substrate-setup-command: >-
+            npx fit-terrain substrate up --cwd . --emit-env "$GITHUB_ENV"
+          jwt-secret: ${{ secrets.SUPABASE_JWT_SECRET }}
+          service-role-key: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+```
+
+## Prerequisites
+
+- A GitHub App installed on your repository, with `Actions: Read` so the log
+  scan can download the run archive.
+- Repository secrets: `KATA_APP_ID`, `KATA_APP_PRIVATE_KEY`,
+  `ANTHROPIC_API_KEY` (plus substrate secrets on the substrate path).
+- The `kata-interview` skill and agent profiles installed (via
+  `npx skills add forwardimpact/kata-skills`).
+
+## Inputs
+
+### Authentication
+
+| Input               | Required | Default           | Description                      |
+| ------------------- | -------- | ----------------- | -------------------------------- |
+| `app-id`            | Yes      | —                 | GitHub App ID                    |
+| `app-private-key`   | Yes      | —                 | GitHub App private key           |
+| `anthropic-api-key` | Yes      | —                 | Anthropic API key                |
+| `app-slug`          | No       | `kata-agent-team` | GitHub App slug for git identity |
+
+### Interview target
+
+| Input         | Required | Default | Description                                            |
+| ------------- | -------- | ------- | ------------------------------------------------------ |
+| `website-url` | Yes      | —       | Public entry point handed to the persona agent (Ask 2) |
+| `product`     | No       | —       | Product to interview about (empty = supervisor picks)  |
+| `job`         | No       | —       | JTBD goal to test (empty = supervisor picks)           |
+| `task-amend`  | No       | —       | Text appended to the task prompt for steering          |
+
+### Pluggable domain steps
+
+| Input                     | Required | Default | Description                                                                                                  |
+| ------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| `substrate-setup-command` | No       | `""`    | Brings up the substrate and emits `SUPABASE_URL`/`SUPABASE_ANON_KEY` to `$GITHUB_ENV`. Non-empty ⇒ substrate path. Runs with `AGENT_CWD` set. |
+| `persona-select-command`  | No       | `""`    | Seals a persona into `$AGENT_CWD` and stashes a bare JWT at `$RUNNER_TEMP/.persona-jwt`. Empty ⇒ story-derived / anonymous. |
+
+### Substrate secrets
+
+Forwarded to the setup and persona commands only when the substrate path is
+active (`substrate-setup-command` non-empty).
+
+| Input              | Required | Default | Description               |
+| ------------------ | -------- | ------- | ------------------------- |
+| `jwt-secret`       | No       | `""`    | Supabase JWT secret       |
+| `service-role-key` | No       | `""`    | Supabase service-role key |
+
+### Shared knobs
+
+| Input                      | Required | Default              | Description                             |
+| -------------------------- | -------- | -------------------- | --------------------------------------- |
+| `max-turns`                | No       | `200`                | Max turns per runner (0 = unlimited)    |
+| `allowed-tools`            | No       | `Bash,Read,...`      | Agent tool allowlist                    |
+| `supervisor-allowed-tools` | No       | `Bash,Read,...`      | Supervisor tool allowlist               |
+| `killswitch`               | No       | `""`                 | Truthy value fails the run fast         |
+
+## Outputs
+
+| Output       | Description                                                     |
+| ------------ | --------------------------------------------------------------- |
+| `trace-file` | Absolute path of the raw NDJSON trace file from the run         |
+| `trace-dir`  | Absolute path of the temp directory holding all trace files     |
+
+## Notes
+
+- A composite action cannot declare `concurrency`, a job `timeout-minutes`, or
+  read `secrets.*`. Keep concurrency and the (sub-60-minute) timeout on the
+  wrapper workflow, and pass secrets as inputs.
+- On the substrate path, the run's own logs are scanned for the persona JWT and
+  the substrate secrets after the interview; a hit fails the run, and an
+  unreadable archive fails closed.

--- a/products/kata/actions/kata-interview/action.yml
+++ b/products/kata/actions/kata-interview/action.yml
@@ -1,0 +1,255 @@
+name: Kata Interview
+description: >
+  Run a JTBD switching interview against a product at a public website. Owns the
+  generic interview infrastructure — killswitch, token, checkout, bootstrap,
+  synthetic-data build, the supervised interview run, cost reporting, wiki push,
+  and run-log secret scanning. The app-specific choices (entry point, substrate
+  bring-up, persona selection) are pluggable inputs so any consumer can wrap it.
+
+inputs:
+  # --- Authentication ---
+  app-id:
+    description: GitHub App ID for token generation and git identity
+    required: true
+  app-private-key:
+    description: GitHub App private key for token generation
+    required: true
+  anthropic-api-key:
+    description: Anthropic API key for the Claude Agent SDK
+    required: true
+  app-slug:
+    description: GitHub App slug for git identity
+    required: false
+    default: "kata-agent-team"
+  # --- Interview target ---
+  website-url:
+    description: Public entry point handed to the persona agent in Ask 2
+    required: true
+  product:
+    description: Product to interview about (empty = supervisor chooses)
+    required: false
+  job:
+    description: Specific JTBD goal to test (empty = supervisor chooses)
+    required: false
+  task-amend:
+    description: Additional text appended to the task prompt for steering
+    required: false
+  # --- Pluggable domain steps ---
+  substrate-setup-command:
+    description: >
+      Shell command that brings up the substrate and emits
+      SUPABASE_URL / SUPABASE_ANON_KEY to $GITHUB_ENV. Non-empty selects the
+      substrate path (bring-up + post-run log scan); empty runs a file-only
+      interview. Runs with AGENT_CWD set to the staged workspace.
+    required: false
+    default: ""
+  persona-select-command:
+    description: >
+      Command the supervisor runs to seal a persona into $AGENT_CWD and stash a
+      bare JWT for the post-run scan. Empty = persona built from the synthetic
+      story / anonymous access.
+    required: false
+    default: ""
+  # --- Substrate secrets (forwarded only on the substrate path) ---
+  jwt-secret:
+    description: Supabase JWT secret, forwarded to the setup/persona commands
+    required: false
+    default: ""
+  service-role-key:
+    description: Supabase service-role key, forwarded to the setup/persona commands
+    required: false
+    default: ""
+  # --- Shared knobs ---
+  max-turns:
+    description: Maximum turns per runner invocation (0 = unlimited)
+    required: false
+    default: "200"
+  allowed-tools:
+    description: Comma-separated tool allowlist for the agent
+    required: false
+    default: "Bash,Read,Glob,Grep,Write,Edit,WebFetch,WebSearch"
+  supervisor-allowed-tools:
+    description: Comma-separated tool allowlist for the supervisor
+    required: false
+    default: "Bash,Read,Glob,Grep,Write,Edit,Skill,TodoWrite"
+  killswitch:
+    description: >
+      Operator killswitch. When set to a truthy value (anything other than
+      empty/0/false/no/off) the run fails fast before any token minting,
+      checkout, or agent work.
+    required: false
+    default: ""
+
+outputs:
+  trace-file:
+    description: >
+      Absolute path of the raw NDJSON trace file from the interview run.
+      Passed through from the internal fit-harness action.
+    value: ${{ steps.interview.outputs.trace-file }}
+  trace-dir:
+    description: >
+      Absolute path of the temp directory holding all trace files for this run.
+      Passed through from the internal fit-harness action.
+    value: ${{ steps.interview.outputs.trace-dir }}
+
+runs:
+  using: composite
+  steps:
+    # Killswitch first: fail before any token minting, checkout, or agent work
+    # so one repository variable halts every kata-* workflow at once.
+    - name: Kata killswitch
+      shell: bash
+      env:
+        KATA_KILLSWITCH: ${{ inputs.killswitch }}
+      run: |
+        case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+          ""|0|false|no|off) ;;
+          *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH})." >&2; exit 1 ;;
+        esac
+
+    - name: Generate installation token
+      id: ci-app
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.app-private-key }}
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        fetch-depth: 0
+        token: ${{ steps.ci-app.outputs.token }}
+
+    # fit-bootstrap installs the pre-compiled CLIs the run uses onto PATH.
+    # fit-terrain now also provides the generic substrate bring-up, so fit-map
+    # is NOT installed here — a consumer's FI substrate command runs it via bunx
+    # as its own documented exception.
+    - uses: forwardimpact/bootstrap@c852d29b38edbb2e6c037bf3952aac339e9fe8b8 # v1.0.12
+      with:
+        token: ${{ steps.ci-app.outputs.token }}
+        app-slug: ${{ inputs.app-slug }}
+        app-id: ${{ inputs.app-id }}
+        clis: fit-terrain fit-trace fit-harness fit-wiki
+
+    - name: Prepare interview workspace
+      id: workspace
+      shell: bash
+      run: |
+        agent_dir=$(mktemp -d)
+
+        # Build synthetic data so the supervisor can stage the right subset into
+        # the agent CWD per the chosen product. The skill's staging table
+        # decides what gets copied.
+        fit-terrain build
+
+        # Install the Supabase CLI globally — npm's global install is blocked by
+        # supabase's postinstall script, so we use bun.
+        bun install -g supabase
+
+        echo "dir=$agent_dir" >> "$GITHUB_OUTPUT"
+
+    # Substrate bring-up is a consumer-supplied command, gated on it being
+    # non-empty — not a hardcoded product name. It must emit
+    # SUPABASE_URL / SUPABASE_ANON_KEY to $GITHUB_ENV for the run below.
+    - name: Substrate setup
+      id: substrate-setup
+      if: inputs.substrate-setup-command != ''
+      shell: bash
+      env:
+        AGENT_CWD: ${{ steps.workspace.outputs.dir }}
+        JWT_SECRET: ${{ inputs.jwt-secret }}
+        SUPABASE_SERVICE_ROLE_KEY: ${{ inputs.service-role-key }}
+      run: ${{ inputs.substrate-setup-command }}
+
+    - name: Compose task amendment
+      id: amend
+      shell: bash
+      env:
+        PRODUCT: ${{ inputs.product }}
+        JOB: ${{ inputs.job }}
+        USER_AMEND: ${{ inputs.task-amend }}
+      run: |
+        {
+          echo 'amend<<AMEND_EOF'
+          [ -n "$PRODUCT" ] && echo "Product: $PRODUCT"
+          [ -n "$JOB" ] && echo "Job: $JOB"
+          [ -n "$USER_AMEND" ] && echo "$USER_AMEND"
+          echo 'AMEND_EOF'
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Run interview
+      id: interview
+      uses: forwardimpact/harness@b7409ad9a1df4ff75eca8fe68041b5384f75bd7e # v1.0.3
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+        CLAUDE_CODE_USE_BEDROCK: "0"
+        IS_SANDBOX: "1"
+        # Entry point the supervisor reads in Ask 2, and the persona-select
+        # command it runs when the substrate path is active.
+        WEBSITE_URL: ${{ inputs.website-url }}
+        AGENT_CWD: ${{ steps.workspace.outputs.dir }}
+        PERSONA_SELECT_COMMAND: ${{ inputs.substrate-setup-command != '' && inputs.persona-select-command || '' }}
+        # Substrate secrets reach the persona-select command only on the
+        # substrate path; empty otherwise.
+        JWT_SECRET: ${{ inputs.substrate-setup-command != '' && inputs.jwt-secret || '' }}
+        SUPABASE_SERVICE_ROLE_KEY: ${{ inputs.substrate-setup-command != '' && inputs.service-role-key || '' }}
+      with:
+        mode: "supervise"
+        task-text: |
+          Run the `kata-interview` skill.
+
+          If a `Product:` or `Job:` line is appended below, honour it;
+          otherwise the skill picks. Any other appended text is steering
+          — pass it through.
+        supervisor-cwd: "."
+        agent-cwd: ${{ steps.workspace.outputs.dir }}
+        lead-profile: "product-manager"
+        max-turns: ${{ inputs.max-turns }}
+        allowed-tools: ${{ inputs.allowed-tools }}
+        supervisor-allowed-tools: ${{ inputs.supervisor-allowed-tools }}
+        task-amend: ${{ steps.amend.outputs.amend }}
+
+    # fit-trace cost tolerates a missing trace, so no file guard is needed.
+    - name: Report run cost
+      if: always()
+      shell: bash
+      env:
+        TRACE_FILE: ${{ steps.interview.outputs.trace-file }}
+      run: fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Push wiki changes
+      if: always()
+      uses: forwardimpact/wiki@v1
+      with:
+        command: push
+        app-id: ${{ inputs.app-id }}
+        app-private-key: ${{ inputs.app-private-key }}
+
+    # Scan the run's own logs for secret literals on the substrate path. The
+    # persona-JWT stash is written by the persona-select command inside the
+    # harness step; the missing-file guard covers an unset command. fit-harness
+    # scan-logs owns the archive download and fails closed.
+    - name: Scan logs for sensitive values
+      if: always() && inputs.substrate-setup-command != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+        JWT_SECRET: ${{ inputs.jwt-secret }}
+        SERVICE_ROLE_KEY: ${{ inputs.service-role-key }}
+      run: |
+        stash="$RUNNER_TEMP/.persona-jwt"
+        secrets=()
+        if [ -f "$stash" ]; then
+          persona_jwt=$(cat "$stash")
+          echo "::add-mask::$persona_jwt"
+          secrets+=(--secret "persona-jwt=$persona_jwt")
+        else
+          echo "No persona-JWT stash at $stash — persona-select command did not run."
+        fi
+        [ -n "$JWT_SECRET" ] && secrets+=(--secret "jwt-secret=$JWT_SECRET")
+        [ -n "$SERVICE_ROLE_KEY" ] && secrets+=(--secret "service-role-key=$SERVICE_ROLE_KEY")
+
+        fit-harness scan-logs \
+          --run-id "${{ github.run_id }}" \
+          --repo "${{ github.repository }}" \
+          "${secrets[@]}"

--- a/products/map/bin/dispatch-auth.js
+++ b/products/map/bin/dispatch-auth.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+/**
+ * Auth subcommand dispatch — extracted from `bin/fit-map.js` so the CLI
+ * entry point stays under biome's `nursery/noExcessiveLinesPerFile` cap
+ * (`biome.json`: `maxLines: 530`), mirroring `dispatch-substrate.js`.
+ * Extraction reclaims the headroom the `substrate stage --emit-env` option
+ * needs.
+ *
+ * Callers pass `{ config, mapClient, cli, runtime }` so this module stays
+ * dep-free at import time. `runtime` is the injected collaborator bag
+ * threaded from `bin/fit-map.js` (the sole construction site).
+ */
+
+/**
+ * @param {string} subcommand
+ * @param {Array<string>} _rest
+ * @param {Record<string, string|undefined>} values
+ * @param {{ config: object, mapClient: () => Promise<object>, cli: { usageError: (msg: string) => void }, runtime: import('@forwardimpact/libutil/runtime').Runtime }} deps
+ * @returns {Promise<number>}
+ */
+export async function dispatchAuth(subcommand, _rest, values, deps) {
+  const { config, mapClient, cli, runtime } = deps;
+  switch (subcommand) {
+    case "issue": {
+      const supabase = await mapClient();
+      const { runAuthIssueCommand } = await import(
+        "../src/commands/auth-issue.js"
+      );
+      await runAuthIssueCommand({
+        supabase,
+        config,
+        options: { email: values.email, ttl: values.ttl },
+        runtime,
+      });
+      return 0;
+    }
+    default:
+      cli.usageError(`unknown auth subcommand: ${subcommand || "(none)"}`);
+      return 1;
+  }
+}

--- a/products/map/bin/dispatch-substrate.js
+++ b/products/map/bin/dispatch-substrate.js
@@ -30,7 +30,12 @@ export async function dispatchSubstrate(subcommand, _rest, values, deps) {
       const { runStageCommand } = await import(
         "../src/commands/substrate-stage.js"
       );
-      return runStageCommand({ config, target: values.cwd, runtime });
+      return runStageCommand({
+        config,
+        target: values.cwd,
+        emitEnv: values["emit-env"],
+        runtime,
+      });
     }
     case "roster": {
       const supabase = await mapClient();

--- a/products/map/bin/fit-map.js
+++ b/products/map/bin/fit-map.js
@@ -16,6 +16,7 @@ import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createProductConfig } from "@forwardimpact/libconfig";
 import { findDataDir } from "../src/lib/data-dir.js";
 import { dispatchSubstrate as _dispatchSubstrate } from "./dispatch-substrate.js";
+import { dispatchAuth as _dispatchAuth } from "./dispatch-auth.js";
 import {
   createCli,
   SummaryRenderer,
@@ -96,6 +97,11 @@ const definition = {
         cwd: {
           type: "string",
           description: "Target dir for the init bootstrap (default: cwd)",
+        },
+        "emit-env": {
+          type: "string",
+          description:
+            "Append SUPABASE_URL= / SUPABASE_ANON_KEY= lines to this path after url-discovery (e.g. $GITHUB_ENV)",
         },
       },
     },
@@ -500,24 +506,12 @@ async function dispatchGetdx(subcommand, rest, values) {
 }
 
 async function dispatchAuth(subcommand, _rest, values) {
-  switch (subcommand) {
-    case "issue": {
-      const supabase = await mapClient();
-      const { runAuthIssueCommand } = await import(
-        "../src/commands/auth-issue.js"
-      );
-      await runAuthIssueCommand({
-        supabase,
-        config,
-        options: { email: values.email, ttl: values.ttl },
-        runtime,
-      });
-      return 0;
-    }
-    default:
-      cli.usageError(`unknown auth subcommand: ${subcommand || "(none)"}`);
-      return 1;
-  }
+  return _dispatchAuth(subcommand, _rest, values, {
+    config,
+    mapClient,
+    cli,
+    runtime,
+  });
 }
 
 async function dispatchSubstrate(subcommand, _rest, values) {

--- a/products/map/src/commands/substrate-stage.js
+++ b/products/map/src/commands/substrate-stage.js
@@ -31,12 +31,15 @@ import { formatSuccess } from "@forwardimpact/libcli";
  * @param {object} params.config - libconfig product config for "map".
  * @param {string} [params.target] - Target dir for the init bootstrap
  *   (default: `runtime.proc.cwd()`).
+ * @param {string} [params.emitEnv] - Path to append `SUPABASE_URL=` /
+ *   `SUPABASE_ANON_KEY=` to after the `url-discovery` phase (e.g.
+ *   `$GITHUB_ENV`). Omit to skip the emit; all phases are unchanged.
  * @param {import('@forwardimpact/libutil/runtime').Runtime} params.runtime - Injected collaborators.
  * @param {object} [deps]
  * @returns {Promise<number>}
  */
 export async function runStageCommand(
-  { config, target, runtime },
+  { config, target, emitEnv, runtime },
   {
     loadInit = () => import("./init.js").then((m) => m.runInit),
     loadCopyActivity = () =>
@@ -93,6 +96,15 @@ export async function runStageCommand(
     // the live local-stack values.
     runtime.proc.env.SUPABASE_URL = status.API_URL;
     runtime.proc.env.SUPABASE_ANON_KEY = status.ANON_KEY;
+    // Carry the same two lines across CI steps when asked. Same emit shape
+    // as `fit-terrain substrate up --emit-env`, so a consumer can swap the
+    // FI stage for the generic bring-up without changing the action.
+    if (emitEnv) {
+      await runtime.fs.appendFile(
+        emitEnv,
+        `SUPABASE_URL=${status.API_URL}\nSUPABASE_ANON_KEY=${status.ANON_KEY}\n`,
+      );
+    }
   });
 
   await runPhase("migrate", () => cli.run(["db", "reset"]));

--- a/products/map/test/substrate-stage.test.js
+++ b/products/map/test/substrate-stage.test.js
@@ -1,0 +1,72 @@
+/**
+ * Unit test for `fit-map substrate stage --emit-env`.
+ *
+ * Every phase collaborator is stubbed (init, copy-activity, seed, provision,
+ * smoke, config reload) and a fake Supabase CLI returns a scripted
+ * `status --output json`, so the test isolates the `url-discovery` phase and
+ * asserts that `--emit-env` appends the two `KEY=value` lines — the same emit
+ * shape as `fit-terrain substrate up`. All other phases stay untouched.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createTestRuntime } from "@forwardimpact/libmock";
+
+import { runStageCommand } from "../src/commands/substrate-stage.js";
+
+function stubDeps(statusJson) {
+  const noop = async () => {};
+  return {
+    loadInit: () => async () => {},
+    loadCopyActivity: () => async () => {},
+    createSupabaseCli: () => ({
+      run: async () => {},
+      capture: async () => statusJson,
+    }),
+    findDataDir: async () => "/data/synthetic",
+    createMapClient: () => ({}),
+    loadSeed: () => noop,
+    loadProvision: () => noop,
+    loadSmoke: () => noop,
+    reloadConfig: () => ({}),
+  };
+}
+
+describe("fit-map substrate stage --emit-env", () => {
+  test("appends SUPABASE_URL and SUPABASE_ANON_KEY after url-discovery", async () => {
+    const runtime = createTestRuntime();
+    const code = await runStageCommand(
+      {
+        config: {},
+        target: "/agent-cwd",
+        emitEnv: "/tmp/gh-env",
+        runtime,
+      },
+      stubDeps(
+        JSON.stringify({
+          API_URL: "http://127.0.0.1:54321",
+          ANON_KEY: "anon-x",
+        }),
+      ),
+    );
+
+    assert.equal(code, 0);
+    const written = await runtime.fs.readFile("/tmp/gh-env", "utf8");
+    assert.equal(
+      written,
+      "SUPABASE_URL=http://127.0.0.1:54321\nSUPABASE_ANON_KEY=anon-x\n",
+    );
+  });
+
+  test("without emit-env, writes nothing but still discovers", async () => {
+    const runtime = createTestRuntime();
+    const code = await runStageCommand(
+      { config: {}, target: "/agent-cwd", runtime },
+      stubDeps(JSON.stringify({ API_URL: "http://u", ANON_KEY: "k" })),
+    );
+
+    assert.equal(code, 0);
+    assert.equal(runtime.proc.env.SUPABASE_URL, "http://u");
+    assert.equal(runtime.proc.env.SUPABASE_ANON_KEY, "k");
+  });
+});

--- a/references/bionova-apps/design-a.md
+++ b/references/bionova-apps/design-a.md
@@ -297,3 +297,49 @@ prose cache; today they reach only HTML output, never SQL.
 The `polaris-seed` output block in `data/synthetic/story.dsl` already lists the
 six prose entities (the only DSL change this spec makes); the parser accepts
 them and the renderer silently ignores them until specs B land.
+
+## Interviewing Polaris
+
+Polaris proves Forward Impact's method for an external team, so it should be
+interviewable the same way this monorepo interviews its own products — with the
+published `forwardimpact/kata-interview` composite action, not a forked
+workflow. The action owns the generic infrastructure (token, checkout,
+bootstrap, `fit-terrain build`, the supervised run, cost, wiki push, log scan);
+Polaris supplies only its own entry point and substrate command.
+
+`.github/workflows/interview.yml` in `bionova-apps`:
+
+```yaml
+jobs:
+  interview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 50 # composite actions cannot set a job timeout
+    steps:
+      - uses: forwardimpact/kata-interview@<sha> # pin like every sibling action
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          website-url: https://polaris.bionova.example
+          # Generic Supabase bring-up, then Polaris' own migration + embed seed.
+          # No fit-map and no map schema — bring-up + emit is all the action needs.
+          substrate-setup-command: >-
+            npx fit-terrain substrate up --cwd . --emit-env "$GITHUB_ENV"
+            && supabase db push
+            && ./data/synthetic/setup.sh
+          jwt-secret: ${{ secrets.SUPABASE_JWT_SECRET }}
+          service-role-key: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+```
+
+Patient interviews omit `persona-select-command` entirely — Polaris is
+patient-facing with anonymous access, so the supervisor builds the persona from
+the vendored `story.dsl` and issues no JWT. A staff-facing interview would pass
+a Polaris persona command satisfying the same `.env` / `.substrate.json` / stash
+contract the action documents.
+
+The substrate command brings Supabase up from the repo checkout (`--cwd .`,
+using Polaris' own `supabase/` config), while the interview itself stages its
+working files into the temp `agent-cwd` the action creates — so this needs no
+`fit-map`, no map schema, and no Polaris application code running in the runner.
+Prerequisite A (`fit-terrain` runs outside the monorepo) is the same dependency
+the seed pipeline already relies on.


### PR DESCRIPTION
Implements [spec 2170](specs/2170-reusable-interview-action/spec.md) per [plan-a](specs/2170-reusable-interview-action/plan-a.md).

## What & why

The JTBD switching-interview capability lived as inline bash welded to monorepo specifics in one workflow, with its load-bearing logic (Supabase status parse, secret-literal log scan) untested. This extracts the generic capability into a **published composite action**, splits the load-bearing bash into **tested CLI verbs** along the generic-vs-FI seam, and makes the domain steps **pluggable** so an external team (e.g. the Polaris reference) can interview its own product without forking the workflow.

## Changes

**New CLI verbs (tested):**
- `fit-terrain substrate up` — generic Supabase bring-up (`start` → discover → `--emit-env`) with its own thin, cwd-explicit spawner. No migration/seed knowledge. Nothing moves out of `products/map` (a move would close a `libterrain → map` cycle).
- `fit-map substrate stage --emit-env` — emits `SUPABASE_URL`/`SUPABASE_ANON_KEY` after the existing `url-discovery` phase; all other phases unchanged. (Extracted `dispatch-auth.js` to keep `fit-map.js` under the line cap.)
- `fit-harness scan-logs` — scans a run's log archive for secret literals, fails closed on an unreadable archive, exits non-zero on any hit. `--secret label=literal` splits on the first `=`.

**Reusable action + thin wrapper:**
- New composite action `products/kata/actions/kata-interview/` (`action.yml` + `README.md`) owning the generic infra; app-specific choices (`website-url`, `substrate-setup-command`, `persona-select-command`, secrets) are inputs. Substrate steps gate on a non-empty `substrate-setup-command` — no hardcoded product name.
- `.github/workflows/kata-interview.yml` is now a thin wrapper supplying the FI substrate + persona commands. Substrate-backed products are selected by list membership (`contains`), not a `product == 'landmark'` predicate. Inline `python3` parse and log-scan bash removed. `concurrency` + sub-60-minute job timeout stay on the wrapper.
- Wired into `publish-actions.yml` (one path filter + one matrix entry) and registered in the `sibling-composite-actions` enum source (`.github/CLAUDE.md`) and its consumers.

**Skill parameterization:**
- `kata-interview` SKILL.md Step 3a runs the injected `PERSONA_SELECT_COMMAND` instead of calling `fit-map`; Step 5 reads the entry point from `WEBSITE_URL`. `job-handoff.md` uses a `<website-url>` placeholder. No hardcoded entry point remains.

**Reference:**
- `references/bionova-apps/design-a.md` documents interviewing Polaris via the published action with a `fit-terrain substrate up`–based substrate command and anonymous access.

## Verification

- Full `check` suite green; all 5550 tests pass. New unit tests: `substrate-up` (4), `substrate-stage` (2), `scan-logs` (9, incl. end-to-end hit→exit 1 / clean→exit 0), rewritten shape test (6).
- All 8 spec success criteria verified (action interface + `trace-file` output; no inline `python3`/`supabase status`; both `--emit-env` verbs; scan-logs hit/clean/fail-closed; substrate-command gate with no `landmark` literal; no hardcoded URL in the skill; wrapper `timeout-minutes < 60`; Polaris reference).
- Clean 5-reviewer diff panel — zero blocker/high; both Medium findings (scan-logs end-to-end coverage, sibling enum registration) addressed.

## Operational note

The sibling `forwardimpact/kata-interview` repo must exist and be seeded before the first publish — `split-and-push` rejects a non-fast-forward (per the plan's Risks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgBdXACCc85ZgcSdjVb75H

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgBdXACCc85ZgcSdjVb75H)_