### PR TITLE
design(2180): generic substrate contract — standard schemas to libskill, identity verbs to fit-terrain

### DIFF
--- a/specs/2180-terrain-substrate-contract/design-a.md
+++ b/specs/2180-terrain-substrate-contract/design-a.md
@@ -2,8 +2,8 @@
 
 Restates spec 2180: move the standard's data contract (levels module + JSON
 schemas) from `map` into `libskill`, and move the substrate identity verbs
-(provision, pick, issue) from `fit-map` into `fit-terrain`, rewritten against
-a documented **Substrate Contract** of consumer-defined views. One clean
+(provision, pick, roster, issue) from `fit-map` into `fit-terrain`, rewritten
+against a documented **Substrate Contract** of consumer-defined views. One clean
 break: no re-export shims, no deprecated wrappers, no dual paths. Vendor
 schema, transforms, seed, read queries, and the Landmark smoke stay in `map`.
 
@@ -12,12 +12,13 @@ schema, transforms, seed, read queries, and the Landmark smoke stay in `map`.
 | Component | Location | Purpose |
 | --- | --- | --- |
 | Standard contract | `libraries/libskill/` (`./levels`, `./schema/json/*` exports) | Canonical home of the levels type/enum module and the thirteen JSON schemas; `libskill` stops importing `map` |
-| Substrate verbs | `libraries/libterrain/` (`fit-terrain substrate init\|check\|provision\|pick\|issue`) | Generic identity capability driven by the contract; plus existing `up` from spec 2170 |
+| Substrate verbs | `libraries/libterrain/` (`fit-terrain substrate init\|check\|provision\|pick\|roster\|issue`) | Generic identity capability driven by the contract; plus existing `up` from spec 2170 |
 | Substrate client | `libraries/libterrain/` | Supabase client factory bound to the `substrate` Postgres schema, built from documented env vars |
 | Contract guide | `websites/fit/docs/` (library guide) | Normative documentation: relations, columns, auth model, env vars, degradation semantics |
 | Map contract views | `products/map/supabase/migrations/` | New migration defining `substrate.people/evidence/discovery` over `activity.*`; `config.toml` exposes `substrate` |
-| Map remainder | `products/map/` | Exports pruned; `substrate pick`/`substrate issue`/`people provision` deleted; `substrate stage` imports provision from `libterrain` |
+| Map remainder | `products/map/` | Exports pruned; `substrate pick`/`issue`/`roster` + `people provision` deleted; `substrate stage`, the Landmark smoke, and `auth issue` consume the moved capabilities from `libterrain` |
 | Workflow wiring | `.github/workflows/kata-interview.yml` | `persona-select-command` switches to `fit-terrain substrate pick`/`issue` |
+| Skill wiring | `.claude/skills/fit-terrain/`, `.claude/skills/fit-map/` | fit-terrain skill documents the substrate verbs and links the contract guide; fit-map skill drops the moved verbs |
 | Reference wiring | `references/bionova-apps/` | Polaris documents `up → init → migrate/seed → check → provision → pick → issue` |
 
 ## Architecture
@@ -63,9 +64,11 @@ new edge (product depending on library).
 
 - **Auth model** — Supabase auth with email identities; product RLS keys on
   `auth.email()`; provisioning and picking use the service-role key.
-- **Env vars** — `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (all verbs),
-  `SUPABASE_JWT_SECRET` (`issue` only). The FI wrapper's persona command maps
-  the action's `JWT_SECRET` input onto `SUPABASE_JWT_SECRET`.
+- **Env vars** — `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (every
+  stack-facing verb; `init` is an offline scaffold and needs neither),
+  `JWT_SECRET` (`issue` only — the name the shared libconfig resolver and
+  the kata-interview action already use, so no mapping step exists
+  anywhere).
 - **Degradation** — declared, not silent: `check` reports optional relations
   as absent (info, not failure); `pick` without `substrate.evidence` drops the
   evidence invariants and reports which invariants applied in its payload;
@@ -79,12 +82,14 @@ new edge (product depending on library).
 | `substrate init` | `--cwd <dir>` | Write one timestamped starter migration into `<cwd>/supabase/migrations/`: `CREATE SCHEMA substrate`, grants, and commented example views the consumer edits to map its own tables |
 | `substrate check` | none beyond env | Column-explicit probe of each contract relation via the API; one diagnostic per missing/malformed relation; non-zero only when a **required** relation fails |
 | `substrate provision` | none beyond env | Reconcile `auth.users` against `substrate.people` emails: create missing, restore banned, decommission removed (current `people provision` semantics, requeried against the contract) |
-| `substrate pick` | `--format json\|text`, `--memory <path>`, `--memory-window <n>` | Current pick semantics against contract relations: structural invariants (has manager, manages ≥1; evidence invariants when `substrate.evidence` exists), diversified against `--memory` when supplied (stateless otherwise); enrichment from terrain's own `story.dsl` + `prose-cache.json` |
-| `substrate issue` | `--email <e> --cwd <p> --token-env <NAME>` `[--ttl <d>] [--stash <path>]` | Mint JWT via shared secret; write `<NAME>=<jwt>` to `.env`, discovery key/values + `persona_email`/`manager_email`/`generated_at` to `.substrate.json`, bare JWT to `--stash`; atomic, mode 0600 — byte-identical file contract to spec 2170 |
+| `substrate pick` | `--format json\|text`, `--memory <path>`, `--memory-window <n>` | Current pick semantics against contract relations: structural invariants (has manager, manages ≥1; evidence invariants when `substrate.evidence` exists), diversified against `--memory` when supplied — reading the window and appending the pick on success, so cross-run diversification carries over (stateless when omitted); `--memory-window` generalizes the previously hardcoded window of 5. Enrichment reads the synthetic story artifacts (`story.dsl`, `prose-cache.json`) resolved from the working directory's data root; absent artifacts yield the structural persona fields un-enriched |
+| `substrate roster` | `--format json\|text` | List every invariant-satisfying persona (operator surface over the same persona query as `pick`) |
+| `substrate issue` | `--email <e> --cwd <p> --token-env <NAME>` `[--ttl <d>] [--stash <path>]` | Mint JWT via shared secret; write `<NAME>=<jwt>` to `.env`, discovery key/values + `persona_email`/`manager_email`/`generated_at` to `.substrate.json`, bare JWT to `--stash`; atomic, mode 0600 — same file set, fields, and modes as spec 2170 |
 
 `--token-env` is required — there is no default token name, so no product
 literal can survive in the library. The FI wrapper passes
-`--token-env PRODUCT_LANDMARK_TOKEN` and `--memory wiki/kata-interview/picks.csv`.
+`--token-env PRODUCT_LANDMARK_TOKEN` and
+`--memory wiki/kata-interview/picks.csv`.
 
 ## Data flow — interview persona path (FI wiring)
 
@@ -114,19 +119,22 @@ Polaris `--token-env`. No `fit-map`, no map schema.
 | Verb parameterization | `--token-env` required, `--memory` opt-in | Defaults preserving current FI values | Any default bakes a product or repo literal into the library; the FI wrapper is the right home for FI values |
 | supabase-js in terrain | Promote to regular dependency | Keep `optionalDependencies` | Four of six substrate verbs need it; an install-time miss surfacing at persona-issue time in CI is the worst failure point |
 | Provision reuse in stage | `stage` imports the provision function from `libterrain` | Keep a private copy in map; shell out to `fit-terrain` | A copy re-creates the drift this spec removes; shelling out loses the in-process env (`SUPABASE_URL`) stage sets during url-discovery |
+| Map-side survivors (Landmark smoke, `auth issue`) | Import the moved persona query and auth-user lookup from `libterrain`'s substrate module | Private copies in map | Copies re-create the drift; `map → libterrain` already exists for provision, so the seam costs nothing new |
+| Roster verb home | Moves to `fit-terrain substrate roster` | Stay in map importing terrain's query | The verb is contract-generic operator surface over the same query as `pick`; leaving it behind splits one capability across two CLIs |
+| JWT secret env name | Keep `JWT_SECRET` | Introduce `SUPABASE_JWT_SECRET` | The shared libconfig resolver and the kata-interview action already speak `JWT_SECRET`; a second name for the same secret adds a mapping step everywhere |
 | Schema-dir resolution in terrain | Resolve from `libskill` (hard dep), drop the not-installed fallback | Keep graceful `null` skip | The fallback existed because `map` was optional for non-FI consumers; `libskill` is a required dependency, so the miss can only mean a broken install — fail loudly |
 
-## Moved code and new dependencies
+## Dependency changes
 
-- Into `libterrain`: persona query (rewritten against `substrate.*`), persona
-  enricher, pick memory, auth-user lookup, provision, issue — with their
-  tests. `libterrain` gains `@forwardimpact/libsecret` (JWT mint) and
-  promotes `@supabase/supabase-js`; drops `@forwardimpact/map`.
-- Out of `map`: `levels.js`, `schema/json/*`, the three verb commands and
-  their libs/tests. `map` gains `@forwardimpact/libterrain`, keeps
-  `@forwardimpact/libskill`.
-- `libskill`: gains `src/levels.js` + `schema/json/`; drops
-  `@forwardimpact/map`; internal imports become relative.
+- `libterrain`: gains `@forwardimpact/libskill` (schema-dir resolution) and
+  `@forwardimpact/libsecret` (JWT mint); promotes `@supabase/supabase-js`
+  from optional to regular; drops `@forwardimpact/map`. Hosts the persona
+  query (rewritten against `substrate.*`), persona enricher, pick memory,
+  and auth-user lookup, exported for map's surviving consumers.
+- `map`: gains `@forwardimpact/libterrain`; keeps `@forwardimpact/libskill`;
+  its levels and JSON-schema surface leaves the package.
+- `libskill`: hosts the levels module and JSON schemas; drops
+  `@forwardimpact/map`.
 
 ## Test strategy
 
@@ -139,7 +147,8 @@ Polaris `--token-env`. No `fit-map`, no map schema.
   `--token-env` threading, stash, non-human rejection), `init` (migration
   file lands under the target).
 - **map** — stage test keeps asserting the provision phase runs (now via the
-  `libterrain` import); contract-view migration asserted by the `check`
-  shape test; removed verbs asserted absent from the CLI definition.
+  `libterrain` import); smoke and `auth issue` tests pass against the
+  `libterrain`-owned query/lookup; contract-view migration asserted by the
+  `check` shape test; removed verbs asserted absent from the CLI definition.
 - **workflow shape test** — `persona-select-command` names `fit-terrain`, not
   `fit-map`.

--- a/specs/2180-terrain-substrate-contract/design-a.md
+++ b/specs/2180-terrain-substrate-contract/design-a.md
@@ -1,0 +1,145 @@
+# Design 2180: Generic substrate contract
+
+Restates spec 2180: move the standard's data contract (levels module + JSON
+schemas) from `map` into `libskill`, and move the substrate identity verbs
+(provision, pick, issue) from `fit-map` into `fit-terrain`, rewritten against
+a documented **Substrate Contract** of consumer-defined views. One clean
+break: no re-export shims, no deprecated wrappers, no dual paths. Vendor
+schema, transforms, seed, read queries, and the Landmark smoke stay in `map`.
+
+## Components
+
+| Component | Location | Purpose |
+| --- | --- | --- |
+| Standard contract | `libraries/libskill/` (`./levels`, `./schema/json/*` exports) | Canonical home of the levels type/enum module and the thirteen JSON schemas; `libskill` stops importing `map` |
+| Substrate verbs | `libraries/libterrain/` (`fit-terrain substrate init\|check\|provision\|pick\|issue`) | Generic identity capability driven by the contract; plus existing `up` from spec 2170 |
+| Substrate client | `libraries/libterrain/` | Supabase client factory bound to the `substrate` Postgres schema, built from documented env vars |
+| Contract guide | `websites/fit/docs/` (library guide) | Normative documentation: relations, columns, auth model, env vars, degradation semantics |
+| Map contract views | `products/map/supabase/migrations/` | New migration defining `substrate.people/evidence/discovery` over `activity.*`; `config.toml` exposes `substrate` |
+| Map remainder | `products/map/` | Exports pruned; `substrate pick`/`substrate issue`/`people provision` deleted; `substrate stage` imports provision from `libterrain` |
+| Workflow wiring | `.github/workflows/kata-interview.yml` | `persona-select-command` switches to `fit-terrain substrate pick`/`issue` |
+| Reference wiring | `references/bionova-apps/` | Polaris documents `up → init → migrate/seed → check → provision → pick → issue` |
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph libraries
+        skill["libskill<br/>levels + schema/json"]
+        terrain["libterrain<br/>pipeline + substrate verbs"]
+    end
+    subgraph products
+        map["map<br/>vendor schema, ELT, seed,<br/>queries, smoke, stage"]
+        pathway["pathway / summit / landmark"]
+    end
+    terrain --> skill
+    map --> skill
+    map --> terrain
+    pathway --> skill
+    subgraph consumer stack
+        views["substrate.* views<br/>(consumer migrations)"]
+        vendor["vendor tables<br/>(activity.* / Polaris clinical)"]
+        views --> vendor
+    end
+    terrain -. "queries only substrate.*" .-> views
+```
+
+The dependency arrows are the deliverable: after the change `rg
+'@forwardimpact/map' libraries/` is empty, and `map → libterrain` is the only
+new edge (product depending on library).
+
+## Substrate Contract (normative)
+
+- **Namespace** — a Postgres schema `substrate`, listed in the consumer's
+  Supabase `api.schemas`. Terrain's client sets `db.schema = "substrate"` and
+  never names another schema.
+- **Relations** — implemented as views (or tables) by the consumer:
+
+| Relation | Required | Columns |
+| --- | --- | --- |
+| `substrate.people` | yes | `email` (unique), `name`, `kind` (`human` rows are personas), `manager_email`, `team_id`, `team_name`, `discipline`, `level`, `track` |
+| `substrate.evidence` | optional | `email` — one row per authored evidence item |
+| `substrate.discovery` | optional | `key`, `value` — navigation ids copied into `.substrate.json` |
+
+- **Auth model** — Supabase auth with email identities; product RLS keys on
+  `auth.email()`; provisioning and picking use the service-role key.
+- **Env vars** — `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (all verbs),
+  `SUPABASE_JWT_SECRET` (`issue` only). The FI wrapper's persona command maps
+  the action's `JWT_SECRET` input onto `SUPABASE_JWT_SECRET`.
+- **Degradation** — declared, not silent: `check` reports optional relations
+  as absent (info, not failure); `pick` without `substrate.evidence` drops the
+  evidence invariants and reports which invariants applied in its payload;
+  `issue` without `substrate.discovery` writes an identity-only
+  `.substrate.json`.
+
+## CLI verb interfaces
+
+| Verb | Signature | Behaviour |
+| --- | --- | --- |
+| `substrate init` | `--cwd <dir>` | Write one timestamped starter migration into `<cwd>/supabase/migrations/`: `CREATE SCHEMA substrate`, grants, and commented example views the consumer edits to map its own tables |
+| `substrate check` | none beyond env | Column-explicit probe of each contract relation via the API; one diagnostic per missing/malformed relation; non-zero only when a **required** relation fails |
+| `substrate provision` | none beyond env | Reconcile `auth.users` against `substrate.people` emails: create missing, restore banned, decommission removed (current `people provision` semantics, requeried against the contract) |
+| `substrate pick` | `--format json\|text`, `--memory <path>`, `--memory-window <n>` | Current pick semantics against contract relations: structural invariants (has manager, manages ≥1; evidence invariants when `substrate.evidence` exists), diversified against `--memory` when supplied (stateless otherwise); enrichment from terrain's own `story.dsl` + `prose-cache.json` |
+| `substrate issue` | `--email <e> --cwd <p> --token-env <NAME>` `[--ttl <d>] [--stash <path>]` | Mint JWT via shared secret; write `<NAME>=<jwt>` to `.env`, discovery key/values + `persona_email`/`manager_email`/`generated_at` to `.substrate.json`, bare JWT to `--stash`; atomic, mode 0600 — byte-identical file contract to spec 2170 |
+
+`--token-env` is required — there is no default token name, so no product
+literal can survive in the library. The FI wrapper passes
+`--token-env PRODUCT_LANDMARK_TOKEN` and `--memory wiki/kata-interview/picks.csv`.
+
+## Data flow — interview persona path (FI wiring)
+
+```text
+substrate-setup-command:  bunx fit-map substrate stage --cwd $AGENT_CWD --emit-env $GITHUB_ENV
+   stage phases: init → copy-activity → stack → url-discovery → migrate
+                 → seed → provision (imported from libterrain) → smoke
+persona-select-command:   fit-terrain substrate pick --format json --memory wiki/kata-interview/picks.csv
+                          fit-terrain substrate issue --email <picked> --cwd $AGENT_CWD
+                            --token-env PRODUCT_LANDMARK_TOKEN --stash $RUNNER_TEMP/.persona-jwt
+```
+
+Polaris wiring: `fit-terrain substrate up --emit-env` → its own
+`supabase db push` (starter migration from `init`, edited, plus clinical
+schema) → its own seed → `check` → `provision` → `pick`/`issue` with a
+Polaris `--token-env`. No `fit-map`, no map schema.
+
+## Key Decisions
+
+| Decision | Chosen | Rejected | Why |
+| --- | --- | --- | --- |
+| Schema home | `libskill` hosts levels + JSON schemas | New `libstandard` package below `libskill` | `libskill` is already "the standard made queryable"; a data-only package adds a publish unit for no consumer benefit |
+| Migration strategy | Clean break: map exports removed, all imports repoint, verbs deleted | Re-export shims + deprecated wrappers | Spec mandate; shims keep the old graph alive and every future reader pays for it; internal consumers are all in-repo, external ones take a version bump |
+| Contract form | Fixed-name views in a dedicated `substrate` schema | Configurable relation names; terrain-owned tables | One documented shape is the product ("opinionated, documented"); a dedicated schema gives one `db.schema` client and zero collision with consumer namespaces; terrain-owned tables would put vendor semantics back in the library |
+| Contract vocabulary | `discipline`/`level`/`track` mandated on `substrate.people` | Generic role columns with passthrough | Persona payload and interview skill already speak this vocabulary; mapping foreign role models onto three columns is cheaper than parameterizing every downstream reader |
+| Optional relations | `evidence`/`discovery` optional with declared degradation | All relations required | Forcing a consumer without evidence semantics to fabricate rows weakens the invariants' meaning; degradation is declared in `check` output and pick payload, not silent |
+| Verb parameterization | `--token-env` required, `--memory` opt-in | Defaults preserving current FI values | Any default bakes a product or repo literal into the library; the FI wrapper is the right home for FI values |
+| supabase-js in terrain | Promote to regular dependency | Keep `optionalDependencies` | Four of six substrate verbs need it; an install-time miss surfacing at persona-issue time in CI is the worst failure point |
+| Provision reuse in stage | `stage` imports the provision function from `libterrain` | Keep a private copy in map; shell out to `fit-terrain` | A copy re-creates the drift this spec removes; shelling out loses the in-process env (`SUPABASE_URL`) stage sets during url-discovery |
+| Schema-dir resolution in terrain | Resolve from `libskill` (hard dep), drop the not-installed fallback | Keep graceful `null` skip | The fallback existed because `map` was optional for non-FI consumers; `libskill` is a required dependency, so the miss can only mean a broken install — fail loudly |
+
+## Moved code and new dependencies
+
+- Into `libterrain`: persona query (rewritten against `substrate.*`), persona
+  enricher, pick memory, auth-user lookup, provision, issue — with their
+  tests. `libterrain` gains `@forwardimpact/libsecret` (JWT mint) and
+  promotes `@supabase/supabase-js`; drops `@forwardimpact/map`.
+- Out of `map`: `levels.js`, `schema/json/*`, the three verb commands and
+  their libs/tests. `map` gains `@forwardimpact/libterrain`, keeps
+  `@forwardimpact/libskill`.
+- `libskill`: gains `src/levels.js` + `schema/json/`; drops
+  `@forwardimpact/map`; internal imports become relative.
+
+## Test strategy
+
+- **libskill** — import smoke for `./levels` and `./schema/json/*`; existing
+  derivation tests keep passing with relative imports.
+- **terrain verbs** — unit tests with a stubbed Supabase client: `check`
+  (required-missing fails, optional-missing passes with diagnostic),
+  `provision` (create/restore/decommission), `pick` (invariants with and
+  without `substrate.evidence`, memory on/off), `issue` (file set,
+  `--token-env` threading, stash, non-human rejection), `init` (migration
+  file lands under the target).
+- **map** — stage test keeps asserting the provision phase runs (now via the
+  `libterrain` import); contract-view migration asserted by the `check`
+  shape test; removed verbs asserted absent from the CLI definition.
+- **workflow shape test** — `persona-select-command` names `fit-terrain`, not
+  `fit-map`.

--- a/specs/2180-terrain-substrate-contract/spec.md
+++ b/specs/2180-terrain-substrate-contract/spec.md
@@ -3,9 +3,10 @@
 **Classification:** Internal. The change re-layers libraries (`libskill`,
 `libterrain`) and `products/map`, updates one workflow wrapper and the
 `references/bionova-apps/` staging area, and documents a new external
-contract. It serves the **Platform Builders** persona indirectly by making
-the substrate identity capability consumable outside the Forward Impact
-stack; no shipped end-user product surface changes behaviour.
+contract. It serves the **Platform Builders** persona (JTBD: *Build
+Agent-Capable Systems*) indirectly by making the substrate identity
+capability consumable outside the Forward Impact stack; no shipped
+end-user product surface changes behaviour.
 
 ## Problem
 
@@ -17,7 +18,7 @@ the substrate identity capability is welded to `fit-map`:
   product inverts the layering every other unit follows.
 - **`libskill` and `map` form a package-level dependency cycle.**
   `libskill` runtime-imports enums and helpers from
-  `@forwardimpact/map/levels` in six modules, while `map` imports
+  `@forwardimpact/map/levels` in thirteen modules, while `map` imports
   `deriveSkillMatrix` from `libskill`. The standard's data contract (the
   levels type/enum module and thirteen JSON schemas) lives in the product,
   above the library that derives from it.
@@ -25,11 +26,12 @@ the substrate identity capability is welded to `fit-map`:
   bring-up generic (`fit-terrain substrate up`) and made the interview
   workflow's persona selection pluggable, but the only implementation of
   the persona contract — provision `auth.users` from the roster, pick an
-  invariant-satisfying persona, issue a JWT plus substrate files — is
-  `fit-map`, and its queries read map's vendor tables (`getdx_*`,
-  `github_*`, `evidence`) directly. Landmark specifics are hardcoded: the
-  issued token's env var name (`PRODUCT_LANDMARK_TOKEN`) and the pick
-  memory path (`wiki/kata-interview/picks.csv`).
+  invariant-satisfying persona, list the qualifying roster, issue a JWT
+  plus substrate files — is `fit-map`, and its queries read map's vendor
+  tables (`getdx_*`, `github_*`, `evidence`) directly. Landmark specifics
+  are hardcoded: the issued token's env var name
+  (`PRODUCT_LANDMARK_TOKEN`) and the pick memory path
+  (`wiki/kata-interview/picks.csv`).
 
 ### Who is affected
 
@@ -57,9 +59,12 @@ The levels type/enum module and the thirteen JSON schemas move from
 engineering standard made queryable". `libskill` exports them
 (`./levels`, `./schema/json/*`); `map`'s package exports drop both paths
 and the files leave the product. Every internal import repoints —
-`products/pathway` (~39 files), `products/summit`, `products/landmark`,
-root `tests/`, `libskill`'s own modules, and `libterrain`'s schema-dir
-resolution. `libskill` drops its `map` dependency (breaking the cycle);
+`products/pathway` (39 files), `products/summit`, `products/landmark`,
+root `tests/`, `libskill`'s own modules, `libterrain`'s schema-dir
+resolution, and `map`'s own remaining source (its root module re-exports
+the levels module and its validation layer imports it — those consumers
+repoint like every other, so `map`'s root export surface changes too).
+`libskill` drops its `map` dependency (breaking the cycle);
 `libterrain` drops its `map` dependency (fixing the inverted edge). After
 the move, no package under `libraries/` depends on `@forwardimpact/map`.
 
@@ -81,9 +86,9 @@ The contract is opinionated and documented as an external guide:
 | `substrate.discovery` | no | `key`, `value` — navigation ids handed to the persona agent |
 | Auth model | yes | Supabase auth, email identities, RLS keyed on `auth.email()`; service-role key for provisioning |
 
-Consumers implement the relations as views over their own schema in their
-own migrations: `map` maps `activity.*` onto them; Polaris maps its
-clinical schema. `discipline`/`level`/`track` are mandated columns — the
+Consumers implement the relations (as views or tables) over their own
+schema: `map` maps `activity.*` onto them; Polaris maps its clinical
+schema. `discipline`/`level`/`track` are mandated columns — the
 engineering-standard vocabulary is a stated opinion of the contract, and a
 different-domain consumer maps its role model onto those columns. Absent
 optional relations degrade declaredly: no `evidence` drops the
@@ -97,8 +102,9 @@ New and moved `fit-terrain substrate` verbs:
 | `init` | new | Scaffold starter SQL (schema + example contract views) into the consumer's migrations directory for editing |
 | `check` | new | Validate a live stack against the contract; one diagnostic per missing or malformed relation, severity split required/optional |
 | `provision` | `fit-map people provision` | Reconcile `auth.users` against `substrate.people` |
-| `pick` | `fit-map substrate pick` | Return one invariant-satisfying persona, diversified against pick memory when a memory path option is supplied (no memory otherwise); persona enrichment reads terrain's own synthetic story artifacts |
-| `issue` | `fit-map substrate issue` | Mint a persona JWT and atomically write the `.env` / `.substrate.json` / stash set; the `.env` variable name comes from a `--token-env` option |
+| `pick` | `fit-map substrate pick` | Return one invariant-satisfying persona, diversified against pick memory when a memory path option is supplied (appending the pick on success; no memory otherwise); persona enrichment reads terrain's own synthetic story artifacts |
+| `roster` | `fit-map substrate roster` | List every invariant-satisfying persona (operator surface over the same query as `pick`) |
+| `issue` | `fit-map substrate issue` | Mint a persona JWT and atomically write the `.env` / `.substrate.json` / stash set; the `.env` variable name is caller-supplied with no default |
 
 The `.env`/`.substrate.json`/stash output contract from spec 2170 is
 unchanged — the `kata-interview` skill's persona step depends on it; only
@@ -106,20 +112,26 @@ the command producing it changes.
 
 ### 3. fit-map after the move
 
-- `fit-map substrate pick`, `fit-map substrate issue`, and
-  `fit-map people provision` are **removed**, not deprecated.
-- `fit-map substrate stage` keeps its pipeline; its provision phase imports
-  the capability from `libterrain` (`map` gains a `libterrain` dependency —
-  product depending on library, the correct direction).
+- `fit-map substrate pick`, `fit-map substrate issue`,
+  `fit-map substrate roster`, and `fit-map people provision` are
+  **removed**, not deprecated.
+- `fit-map substrate stage` keeps its pipeline; its provision phase runs
+  the capability now owned by `libterrain` (`map` gains a `libterrain`
+  dependency — product depending on library, the correct direction).
+- The Landmark smoke and `fit-map auth issue` stay in `map` and keep their
+  behaviour by consuming the moved persona-query and auth-user-lookup
+  capabilities from `libterrain` — no private copies survive.
 - `map` adds a migration defining the contract views over `activity.*` and
-  exposes `substrate` through its Supabase API config. The Landmark smoke
-  stays in `map`.
+  exposes `substrate` through its Supabase API config.
 
 ### 4. Workflow and reference wiring
 
 - The `kata-interview` wrapper workflow's `persona-select-command` switches
   to `fit-terrain substrate pick` / `issue` (already on PATH in the
-  action); `bunx fit-map` remains only in `substrate-setup-command`.
+  action), preserving today's behaviour: pick memory at
+  `wiki/kata-interview/picks.csv` and the issued token named
+  `PRODUCT_LANDMARK_TOKEN`. `bunx fit-map` remains only in
+  `substrate-setup-command`.
 - The Polaris reference documents the full loop: `up` → `init` + its own
   migrations → its own seed → `check` → `provision` → `pick` → `issue`.
 - The Substrate Contract ships as an external guide; the `fit-terrain` and
@@ -131,12 +143,13 @@ the command producing it changes.
 
 - `libraries/libskill/` — hosts the levels module and JSON schemas; drops
   its `@forwardimpact/map` dependency.
-- `libraries/libterrain/` — `substrate init|check|provision|pick|issue`
+- `libraries/libterrain/` — `substrate init|check|provision|pick|roster|issue`
   verbs with tests; drops its `@forwardimpact/map` dependency; gains the
   dependencies the moved verbs need.
-- `products/map/` — package exports pruned; three verbs removed; contract
-  view migration; API schema exposure; stage provision phase repointed to
-  `libterrain`; the moved source and tests leave the product.
+- `products/map/` — package exports pruned; four verbs removed; contract
+  view migration; API schema exposure; stage, smoke, and `auth issue`
+  repointed to the `libterrain` capabilities; the moved source and tests
+  leave the product.
 - `products/pathway/`, `products/summit/`, `products/landmark/`, root
   `tests/` — mechanical import repoints to `@forwardimpact/libskill`.
 - `.github/workflows/kata-interview.yml` — `persona-select-command`
@@ -150,6 +163,9 @@ the command producing it changes.
 
 - Renaming or generalizing map's vendor tables (`getdx_*`, `github_*`,
   `evidence`) — the activity schema is unchanged.
+- Map's `./schema/rdf/*` export — the RDF vocabulary is map's product
+  surface, not part of the standard data contract libraries consume; it
+  stays in `map`.
 - Moving the transforms, seed, read queries (`activity/queries/*`), or the
   production ELT out of `map`.
 - Changing the `kata-interview` composite action's input/output interface,
@@ -171,39 +187,49 @@ substrate up`, the pluggable `substrate-setup-command` /
 1. No library depends on the map product. Verify:
    `rg '@forwardimpact/map' libraries/` returns nothing.
 
-2. `libskill` hosts the standard contract: `@forwardimpact/libskill/levels`
-   and `@forwardimpact/libskill/schema/json/*` resolve, and `map`'s package
-   exports contain neither `./levels` nor `./schema/json/*`, with the
-   corresponding files gone from `products/map/`. Verify: package export
-   maps plus an import smoke in `libskill`'s tests.
+2. `libskill` hosts the standard contract and `map` no longer exports it.
+   Verify: a `libskill` test imports `@forwardimpact/libskill/levels` and
+   resolves `@forwardimpact/libskill/schema/json/standard.schema.json`;
+   `rg '"\./levels"|"\./schema/json' products/map/package.json` returns
+   nothing; `products/map/src/levels.js` and `products/map/schema/json/`
+   do not exist.
 
 3. Every internal import repoints. Verify:
-   `rg "@forwardimpact/map/levels|@forwardimpact/map/schema" --glob '!specs/**'`
+   `rg "@forwardimpact/map/levels|@forwardimpact/map/schema/json" --glob '!specs/**'`
    over the repo returns nothing.
 
-4. `fit-terrain substrate init|check|provision|pick|issue` exist with unit
-   tests, and the verbs query only contract relations. Verify: tests pass
-   and `rg 'getdx_|github_' libraries/libterrain/src/` returns nothing.
+4. `fit-terrain substrate init|check|provision|pick|roster|issue` exist
+   with unit tests, and the verbs query only contract relations. Verify:
+   tests pass;
+   `rg 'getdx_|github_' libraries/libterrain/src/ libraries/libterrain/bin/`
+   returns nothing; a unit test asserts the verbs' Supabase client is
+   bound to the `substrate` schema (covering the `evidence` name shared
+   with the vendor table).
 
 5. No Landmark or monorepo literal survives in the moved verbs. Verify:
-   `rg 'PRODUCT_LANDMARK_TOKEN|kata-interview' libraries/libterrain/src/`
-   returns nothing; `--token-env` and the pick memory option are exercised
-   by unit tests.
+   `rg 'PRODUCT_LANDMARK_TOKEN|kata-interview' libraries/libterrain/src/ libraries/libterrain/bin/`
+   returns nothing; the caller-supplied token name and pick memory path are
+   exercised by unit tests.
 
 6. `fit-map` no longer carries the moved verbs. Verify: the `fit-map` CLI
-   definition lists neither `substrate pick`, `substrate issue`, nor
-   `people provision`; `fit-map substrate stage` retains all phases and its
-   tests pass.
+   definition lists none of `substrate pick`, `substrate issue`,
+   `substrate roster`, `people provision`; `fit-map substrate stage`
+   retains all phases and its tests pass; the smoke and `auth issue` tests
+   pass against the `libterrain`-owned capabilities.
 
 7. `map` implements the contract. Verify: a migration under
    `products/map/supabase/migrations/` defines `substrate.people` (and the
    optional relations) over `activity.*`; the Supabase API config exposes
-   `substrate`; a unit test with a stubbed client asserts
-   `fit-terrain substrate check` passes against the contract shape.
+   `substrate`; a test asserts `fit-terrain substrate check` passes
+   against the relation shapes that migration defines.
 
-8. The wrapper workflow's persona step uses terrain. Verify:
-   `rg 'fit-map' .github/workflows/kata-interview.yml` matches only the
-   `substrate-setup-command` line.
+8. The wrapper workflow's persona step uses terrain and preserves current
+   behaviour. Verify: the workflow shape test asserts
+   `persona-select-command` invokes `fit-terrain substrate pick` and
+   `issue`, carries the `wiki/kata-interview/picks.csv` memory path and
+   the `PRODUCT_LANDMARK_TOKEN` token name, and contains no `fit-map`
+   invocation ( `substrate-setup-command` remains the only `fit-map`
+   command line in the workflow).
 
 9. The Substrate Contract is documented for external consumers: relations,
    required columns, auth assumptions, required env vars, and degradation

--- a/specs/2180-terrain-substrate-contract/spec.md
+++ b/specs/2180-terrain-substrate-contract/spec.md
@@ -1,0 +1,215 @@
+# Spec 2180: Generic substrate contract — standard schemas to libskill, identity verbs to fit-terrain
+
+**Classification:** Internal. The change re-layers libraries (`libskill`,
+`libterrain`) and `products/map`, updates one workflow wrapper and the
+`references/bionova-apps/` staging area, and documents a new external
+contract. It serves the **Platform Builders** persona indirectly by making
+the substrate identity capability consumable outside the Forward Impact
+stack; no shipped end-user product surface changes behaviour.
+
+## Problem
+
+Two library-to-product dependency edges invert the monorepo's layering, and
+the substrate identity capability is welded to `fit-map`:
+
+- **`libterrain` depends on the `map` product** solely to resolve the
+  pathway JSON-schema directory for rendering. A library depending on a
+  product inverts the layering every other unit follows.
+- **`libskill` and `map` form a package-level dependency cycle.**
+  `libskill` runtime-imports enums and helpers from
+  `@forwardimpact/map/levels` in six modules, while `map` imports
+  `deriveSkillMatrix` from `libskill`. The standard's data contract (the
+  levels type/enum module and thirteen JSON schemas) lives in the product,
+  above the library that derives from it.
+- **The substrate identity flow is fit-map-only.** Spec 2170 made substrate
+  bring-up generic (`fit-terrain substrate up`) and made the interview
+  workflow's persona selection pluggable, but the only implementation of
+  the persona contract — provision `auth.users` from the roster, pick an
+  invariant-satisfying persona, issue a JWT plus substrate files — is
+  `fit-map`, and its queries read map's vendor tables (`getdx_*`,
+  `github_*`, `evidence`) directly. Landmark specifics are hardcoded: the
+  issued token's env var name (`PRODUCT_LANDMARK_TOKEN`) and the pick
+  memory path (`wiki/kata-interview/picks.csv`).
+
+### Who is affected
+
+- **Platform Builders / the BioNova Polaris reference** — the interview
+  loop's persona identity capability is unusable without adopting the map
+  schema wholesale; Polaris can bring a stack up but cannot provision,
+  pick, or issue.
+- **Monorepo contributors** — the cycle and the inverted edges make the
+  layering unreliable as a reasoning tool and block future invariants of
+  the form "libraries never depend on products".
+- **The Kata team** — the published `kata-interview` action's persona step
+  still requires `bunx fit-map`, an exception the action's README has to
+  explain.
+
+## Proposal
+
+Two moves, shipped as **one explicit clean break** — no re-export shims, no
+deprecated wrappers, no dual code paths. The repository afterward reads as
+if it had always been layered this way.
+
+### 1. The standard's data contract moves to libskill
+
+The levels type/enum module and the thirteen JSON schemas move from
+`products/map` into `libraries/libskill`, which already owns "the
+engineering standard made queryable". `libskill` exports them
+(`./levels`, `./schema/json/*`); `map`'s package exports drop both paths
+and the files leave the product. Every internal import repoints —
+`products/pathway` (~39 files), `products/summit`, `products/landmark`,
+root `tests/`, `libskill`'s own modules, and `libterrain`'s schema-dir
+resolution. `libskill` drops its `map` dependency (breaking the cycle);
+`libterrain` drops its `map` dependency (fixing the inverted edge). After
+the move, no package under `libraries/` depends on `@forwardimpact/map`.
+
+### 2. Substrate identity verbs move to fit-terrain, behind a documented contract
+
+`fit-terrain` becomes the generic substrate capability: bring up a stack
+(spec 2170), validate it, provision identities, pick a persona, issue
+credentials. It does this by **assuming** a consumer-defined interface —
+the **Substrate Contract** — instead of owning any vendor schema. Vendor
+tables, transforms, seed, and read queries all stay in `map`.
+
+The contract is opinionated and documented as an external guide:
+
+| Element | Required | Content |
+| --- | --- | --- |
+| Postgres schema `substrate`, exposed through the consumer's Supabase API | yes | Namespace for the contract relations |
+| `substrate.people` | yes | `email` (unique), `name`, `kind`, `manager_email`, `team_id`, `team_name`, `discipline`, `level`, `track` |
+| `substrate.evidence` | no | `email` — one row per authored evidence item |
+| `substrate.discovery` | no | `key`, `value` — navigation ids handed to the persona agent |
+| Auth model | yes | Supabase auth, email identities, RLS keyed on `auth.email()`; service-role key for provisioning |
+
+Consumers implement the relations as views over their own schema in their
+own migrations: `map` maps `activity.*` onto them; Polaris maps its
+clinical schema. `discipline`/`level`/`track` are mandated columns — the
+engineering-standard vocabulary is a stated opinion of the contract, and a
+different-domain consumer maps its role model onto those columns. Absent
+optional relations degrade declaredly: no `evidence` drops the
+evidence-based pick invariants; no `discovery` yields an identity-only
+substrate file.
+
+New and moved `fit-terrain substrate` verbs:
+
+| Verb | Origin | Behaviour |
+| --- | --- | --- |
+| `init` | new | Scaffold starter SQL (schema + example contract views) into the consumer's migrations directory for editing |
+| `check` | new | Validate a live stack against the contract; one diagnostic per missing or malformed relation, severity split required/optional |
+| `provision` | `fit-map people provision` | Reconcile `auth.users` against `substrate.people` |
+| `pick` | `fit-map substrate pick` | Return one invariant-satisfying persona, diversified against pick memory when a memory path option is supplied (no memory otherwise); persona enrichment reads terrain's own synthetic story artifacts |
+| `issue` | `fit-map substrate issue` | Mint a persona JWT and atomically write the `.env` / `.substrate.json` / stash set; the `.env` variable name comes from a `--token-env` option |
+
+The `.env`/`.substrate.json`/stash output contract from spec 2170 is
+unchanged — the `kata-interview` skill's persona step depends on it; only
+the command producing it changes.
+
+### 3. fit-map after the move
+
+- `fit-map substrate pick`, `fit-map substrate issue`, and
+  `fit-map people provision` are **removed**, not deprecated.
+- `fit-map substrate stage` keeps its pipeline; its provision phase imports
+  the capability from `libterrain` (`map` gains a `libterrain` dependency —
+  product depending on library, the correct direction).
+- `map` adds a migration defining the contract views over `activity.*` and
+  exposes `substrate` through its Supabase API config. The Landmark smoke
+  stays in `map`.
+
+### 4. Workflow and reference wiring
+
+- The `kata-interview` wrapper workflow's `persona-select-command` switches
+  to `fit-terrain substrate pick` / `issue` (already on PATH in the
+  action); `bunx fit-map` remains only in `substrate-setup-command`.
+- The Polaris reference documents the full loop: `up` → `init` + its own
+  migrations → its own seed → `check` → `provision` → `pick` → `issue`.
+- The Substrate Contract ships as an external guide; the `fit-terrain` and
+  `fit-map` skills and docs update to match.
+
+## Scope
+
+### Included
+
+- `libraries/libskill/` — hosts the levels module and JSON schemas; drops
+  its `@forwardimpact/map` dependency.
+- `libraries/libterrain/` — `substrate init|check|provision|pick|issue`
+  verbs with tests; drops its `@forwardimpact/map` dependency; gains the
+  dependencies the moved verbs need.
+- `products/map/` — package exports pruned; three verbs removed; contract
+  view migration; API schema exposure; stage provision phase repointed to
+  `libterrain`; the moved source and tests leave the product.
+- `products/pathway/`, `products/summit/`, `products/landmark/`, root
+  `tests/` — mechanical import repoints to `@forwardimpact/libskill`.
+- `.github/workflows/kata-interview.yml` — `persona-select-command`
+  switches to `fit-terrain`.
+- `.claude/skills/fit-terrain/`, `.claude/skills/fit-map/`,
+  `websites/fit/docs/` — Substrate Contract guide and skill/doc updates.
+- `references/bionova-apps/` — Polaris substrate wiring documented against
+  the new verbs.
+
+### Excluded
+
+- Renaming or generalizing map's vendor tables (`getdx_*`, `github_*`,
+  `evidence`) — the activity schema is unchanged.
+- Moving the transforms, seed, read queries (`activity/queries/*`), or the
+  production ELT out of `map`.
+- Changing the `kata-interview` composite action's input/output interface,
+  the harness `supervise` contract, or the interview loop itself.
+- Managed Supabase, and any Polaris application code (spec 1160 work in a
+  separate repo).
+- Any compatibility shims, re-exports, deprecated aliases, or transitional
+  fallbacks — external consumers of the removed `map` exports take a
+  breaking version bump.
+
+## Prerequisites
+
+None blocking. Builds directly on spec 2170 (merged): `fit-terrain
+substrate up`, the pluggable `substrate-setup-command` /
+`persona-select-command` seam, and `fit-harness scan-logs` all exist.
+
+## Success Criteria
+
+1. No library depends on the map product. Verify:
+   `rg '@forwardimpact/map' libraries/` returns nothing.
+
+2. `libskill` hosts the standard contract: `@forwardimpact/libskill/levels`
+   and `@forwardimpact/libskill/schema/json/*` resolve, and `map`'s package
+   exports contain neither `./levels` nor `./schema/json/*`, with the
+   corresponding files gone from `products/map/`. Verify: package export
+   maps plus an import smoke in `libskill`'s tests.
+
+3. Every internal import repoints. Verify:
+   `rg "@forwardimpact/map/levels|@forwardimpact/map/schema" --glob '!specs/**'`
+   over the repo returns nothing.
+
+4. `fit-terrain substrate init|check|provision|pick|issue` exist with unit
+   tests, and the verbs query only contract relations. Verify: tests pass
+   and `rg 'getdx_|github_' libraries/libterrain/src/` returns nothing.
+
+5. No Landmark or monorepo literal survives in the moved verbs. Verify:
+   `rg 'PRODUCT_LANDMARK_TOKEN|kata-interview' libraries/libterrain/src/`
+   returns nothing; `--token-env` and the pick memory option are exercised
+   by unit tests.
+
+6. `fit-map` no longer carries the moved verbs. Verify: the `fit-map` CLI
+   definition lists neither `substrate pick`, `substrate issue`, nor
+   `people provision`; `fit-map substrate stage` retains all phases and its
+   tests pass.
+
+7. `map` implements the contract. Verify: a migration under
+   `products/map/supabase/migrations/` defines `substrate.people` (and the
+   optional relations) over `activity.*`; the Supabase API config exposes
+   `substrate`; a unit test with a stubbed client asserts
+   `fit-terrain substrate check` passes against the contract shape.
+
+8. The wrapper workflow's persona step uses terrain. Verify:
+   `rg 'fit-map' .github/workflows/kata-interview.yml` matches only the
+   `substrate-setup-command` line.
+
+9. The Substrate Contract is documented for external consumers: relations,
+   required columns, auth assumptions, required env vars, and degradation
+   semantics for absent optional relations. Verify: the guide exists under
+   `websites/fit/docs/` and the `fit-terrain` skill links it.
+
+10. The Polaris reference wires the new verbs. Verify:
+    `references/bionova-apps/` names `init`, `check`, `provision`, `pick`,
+    and `issue`, with no `fit-map` in the Polaris flow.


### PR DESCRIPTION
## Summary

Lockstep spec + design for **spec 2180** (one combined PR per the lockstep co-execution protocol; no separate spec PR). Follow-on to spec 2170's reusable interview action, executing the convergence its design deferred.

**What (spec.md):** one explicit clean break, no shims or fallbacks:

1. **Standard contract → libskill.** The levels type/enum module and the thirteen JSON schemas move from `products/map` into `libraries/libskill`. This breaks the existing `libskill ↔ map` package cycle (13 libskill modules runtime-import `map/levels`; map imports `deriveSkillMatrix` back) and the inverted `libterrain → map` edge (schema-dir resolution). Map's `./levels` and `./schema/json/*` exports are removed — every internal consumer repoints (pathway 39 files, summit, landmark, root tests, map's own source). After the change, `rg '@forwardimpact/map' libraries/` is empty.
2. **Substrate identity verbs → fit-terrain.** `provision`, `pick`, `roster`, `issue` move from `fit-map` to `fit-terrain substrate`, rewritten against a documented **Substrate Contract**: a `substrate` Postgres schema of consumer-defined relations (`people` required with mandated `discipline`/`level`/`track`; `evidence`/`discovery` optional with declared degradation). New `substrate init` scaffolds starter SQL; `substrate check` validates a live stack. Vendor tables, transforms, seed, read queries, and the Landmark smoke stay in `map`; map implements the contract as views over `activity.*`.

**Which/where (design-a.md):** components, contract normative section, verb interfaces, FI + Polaris data flows, and twelve key decisions with rejected alternatives — including keeping `JWT_SECRET` as the single secret name, `--token-env` required with no default so no product literal survives in the library, and map-side survivors (smoke, `auth issue`) importing the moved query/lookup from libterrain rather than keeping private copies.

**Why:** makes the substrate capability consumable by the BioNova Polaris reference (and any Supabase-backed consumer) without adopting the map schema, and restores the libraries-never-depend-on-products layering.

## Review

Lockstep panel batch (9 reviewers: spec product ×3, spec technical ×3, design ×3) completed before this PR was opened — zero blockers; all consensus and verified singleton blocker/high/medium findings addressed in the second commit (evidence counts corrected, `substrate roster` disposition added, map-survivor seams stated, verify commands hardened, behaviour-preservation criterion added for the workflow switch).

`wiki/STATUS.md` row: `2180 design draft`. Per the lockstep protocol the row skips `spec approved`; a single design-class approval signal covers both artifacts.

> Note: this branch also carries the session's earlier research context; the reviewable content is `specs/2180-terrain-substrate-contract/{spec.md,design-a.md}`.

https://claude.ai/code/session_01U8CBqqkx5etFirMifY4mYd

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8CBqqkx5etFirMifY4mYd)_