### PR TITLE
plan(2180): generic substrate contract — six-part execution plan

### DIFF
--- a/specs/2180-terrain-substrate-contract/plan-a-01.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-01.md
@@ -1,0 +1,131 @@
+# Plan 2180-a part 01 — Standard contract moves to libskill
+
+Move the levels module and the thirteen JSON schemas into `libskill`, repoint
+every consumer, and fix `libterrain`'s schema-dir resolution — after this part
+`rg '@forwardimpact/map' libraries/` is empty (SC1–SC3).
+
+## Step 1 — Move the levels module
+
+Host `levels.js` and its test in `libskill`.
+
+- Moved: `products/map/src/levels.js` → `libraries/libskill/src/levels.js`
+- Moved: `products/map/test/levels.test.js` →
+  `libraries/libskill/test/levels.test.js` (import repoints to
+  `../src/levels.js`)
+- Modified: `libraries/libskill/package.json`
+
+`libskill` `exports` gains `"./levels": "./src/levels.js"`.
+
+Verify: `bun test libraries/libskill/test/levels.test.js` passes.
+
+## Step 2 — Move the JSON schemas
+
+Host the thirteen `*.schema.json` files in `libskill`; `map` keeps
+`schema/rdf/` only.
+
+- Moved: `products/map/schema/json/` → `libraries/libskill/schema/json/`
+  (13 files)
+- Modified: `libraries/libskill/package.json`, `products/map/package.json`
+
+`libskill`: `exports` gains `"./schema/json/*": "./schema/json/*"`; `files`
+gains `"schema/json/*.json"`. `map`: `exports` drops `"./levels"` and
+`"./schema/json/*"` (keeps `"./schema/rdf/*"`); prune `schema/json` from
+`files` if listed.
+
+Verify: `node -e 'import("@forwardimpact/libskill/schema/json/standard.schema.json", {with:{type:"json"}})'`
+resolves; `rg '"\./levels"|"\./schema/json' products/map/package.json` is
+empty; add the two resolution assertions to
+`libraries/libskill/test/levels.test.js` (SC2).
+
+## Step 3 — Repoint libskill internals and drop its map dependency
+
+Break the package cycle.
+
+- Modified: `libraries/libskill/src/{agent,derivation,derivation-responsibilities,derivation-validation,interview,interview-helpers,interview-selection,interview-specialized,matching,matching-development,modifiers,progression}.js`,
+  `libraries/libskill/src/policies/{filters,orderings,predicates}.js`,
+  `libraries/libskill/test/modifiers.test.js`,
+  `libraries/libskill/package.json`
+
+`@forwardimpact/map/levels` → `./levels.js` (relative; test uses
+`../src/levels.js`). `dependencies` drops `@forwardimpact/map`.
+
+Verify: `rg '@forwardimpact/map' libraries/libskill/` is empty;
+`bun test libraries/libskill` passes.
+
+## Step 4 — Repoint map internals
+
+`map` consumes the standard contract from `libskill` like every other product.
+
+- Modified: `products/map/src/index.js` (drop `export * from "./levels.js"` —
+  the root export surface shrinks by design),
+  `products/map/src/{modifiers,validation}.js`,
+  `products/map/src/validation/{agent,behaviour,common,discipline,driver,level,questions,skill,track}.js`
+  (`./levels.js` → `@forwardimpact/libskill/levels`),
+  `products/map/src/schema-validation.js`
+
+`schema-validation.js` `createSchemaValidator` replaces the relative
+`../schema/json` join with package resolution:
+
+```js
+const schemaDir = dirname(
+  fileURLToPath(
+    import.meta.resolve("@forwardimpact/libskill/schema/json/defs.schema.json"),
+  ),
+);
+```
+
+Verify: `bun test products/map` passes; `products/map/src/levels.js` and
+`products/map/schema/json/` do not exist (SC2).
+
+## Step 5 — Repoint products and root tests
+
+Mechanical import swap `@forwardimpact/map/levels` →
+`@forwardimpact/libskill/levels` (all four products already declare
+`@forwardimpact/libskill`).
+
+- Modified: `products/pathway/src/**` (39 files per
+  `rg -l '@forwardimpact/map/levels' products/pathway`),
+  `products/summit/src/aggregation/{coverage,depth,growth}.js`,
+  `products/landmark/src/lib/evidence-helpers.js`,
+  `products/landmark/src/commands/practiced.js`,
+  `tests/{model-fixtures.js,model-profile-base.test.js,model-types.test.js,model-types-capability.test.js}`
+
+`@forwardimpact/map/validation` and `@forwardimpact/map/activity/*` imports
+stay — only the levels/schema surface moves.
+
+Verify: `rg "@forwardimpact/map/levels|@forwardimpact/map/schema/json" --glob '!specs/**' --glob '!references/**'`
+is empty (SC3); `bun test tests/ products/` passes.
+
+## Step 6 — libterrain resolves the schema dir from libskill
+
+Drop the inverted `libterrain → map` edge and the graceful-null fallback.
+
+- Modified: `libraries/libterrain/bin/fit-terrain.js`,
+  `libraries/libterrain/package.json`,
+  `libraries/libsyntheticprose/src/engine/pathway.js` (doc comment only)
+
+`defaultSchemaDir()` resolves
+`@forwardimpact/libskill/schema/json/standard.schema.json` and **throws** on
+resolution failure instead of returning `null` — `libskill` is a required
+dependency, so a miss is a broken install (design § Key Decisions). Update the
+`--schema-dir` help text to name `@forwardimpact/libskill`. `package.json`:
+drop `@forwardimpact/map`, add `@forwardimpact/libskill`.
+
+Verify: `rg '@forwardimpact/map' libraries/` is empty (SC1);
+`bun test libraries/libterrain` passes; `bunx fit-terrain validate` renders
+pathway output in the monorepo.
+
+## Step 7 — Repo-wide checks
+
+Verify: `bun run invariants` (workspace-imports guard) and `bun test` pass;
+`bun run context:fix` shows no catalog drift.
+
+Libraries used: libskill (new export surface), libterrain (schema-dir
+resolution).
+
+## Risks
+
+- `import.meta.resolve` must be called with `this === import.meta` under Bun
+  (see the existing note in `bin/fit-terrain.js:207-209`) — keep the call at
+  module scope or in a plain function in the same module, not passed as a
+  bare reference.

--- a/specs/2180-terrain-substrate-contract/plan-a-01.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-01.md
@@ -32,19 +32,20 @@ gains `"schema/json/*.json"`. `map`: `exports` drops `"./levels"` and
 `"./schema/json/*"` (keeps `"./schema/rdf/*"`); prune `schema/json` from
 `files` if listed.
 
-Verify: `node -e 'import("@forwardimpact/libskill/schema/json/standard.schema.json", {with:{type:"json"}})'`
-resolves; `rg '"\./levels"|"\./schema/json' products/map/package.json` is
-empty; add the two resolution assertions to
-`libraries/libskill/test/levels.test.js` (SC2).
+Verify:
+`node -e 'import("@forwardimpact/libskill/schema/json/standard.schema.json", {with:{type:"json"}})'`
+resolves; `rg '"\./levels"|"\./schema/json' products/map/package.json` is empty;
+add the two resolution assertions to `libraries/libskill/test/levels.test.js`
+(SC2).
 
 ## Step 3 — Repoint libskill internals and drop its map dependency
 
 Break the package cycle.
 
-- Modified: `libraries/libskill/src/{agent,derivation,derivation-responsibilities,derivation-validation,interview,interview-helpers,interview-selection,interview-specialized,matching,matching-development,modifiers,progression}.js`,
+- Modified:
+  `libraries/libskill/src/{agent,derivation,derivation-responsibilities,derivation-validation,interview,interview-helpers,interview-selection,interview-specialized,matching,matching-development,modifiers,progression}.js`,
   `libraries/libskill/src/policies/{filters,orderings,predicates}.js`,
-  `libraries/libskill/test/modifiers.test.js`,
-  `libraries/libskill/package.json`
+  `libraries/libskill/test/modifiers.test.js`, `libraries/libskill/package.json`
 
 `@forwardimpact/map/levels` → `./levels.js` (relative; test uses
 `../src/levels.js`). `dependencies` drops `@forwardimpact/map`.
@@ -102,11 +103,12 @@ is where dev and build serve libskill's src
 `/map/lib/levels.js` stops existing after the move. No test covers
 importmaps; get this wrong and the published site 404s silently.
 
-Verify: `rg "@forwardimpact/map/levels|@forwardimpact/map/schema/json" --glob '!specs/**'`
-is empty (SC3 — the spec's exact command; `references/` is updated by
-part 06 and must also be clean); `rg '/map/lib/levels' products/pathway/src`
-is empty; `bun test tests/ products/` passes and a pathway `dev`/`build`
-smoke loads a page that imports levels.
+Verify:
+`rg "@forwardimpact/map/levels|@forwardimpact/map/schema/json" --glob '!specs/**'`
+is empty (SC3 — the spec's exact command; `references/` is updated by part 06
+and must also be clean); `rg '/map/lib/levels' products/pathway/src` is empty;
+`bun test tests/ products/` passes and a pathway `dev`/`build` smoke loads a
+page that imports levels.
 
 ## Step 6 — libterrain resolves the schema dir from libskill
 

--- a/specs/2180-terrain-substrate-contract/plan-a-01.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-01.md
@@ -93,8 +93,20 @@ Mechanical import swap `@forwardimpact/map/levels` →
 `@forwardimpact/map/validation` and `@forwardimpact/map/activity/*` imports
 stay — only the levels/schema surface moves.
 
-Verify: `rg "@forwardimpact/map/levels|@forwardimpact/map/schema/json" --glob '!specs/**' --glob '!references/**'`
-is empty (SC3); `bun test tests/ products/` passes.
+Pathway's three browser importmaps are **not** a mechanical specifier swap:
+in `products/pathway/src/{index,slides,handout}.html` the
+`"@forwardimpact/map/levels": "/map/lib/levels.js"` entry becomes
+`"@forwardimpact/libskill/levels": "/model/lib/levels.js"` — `/model/lib/`
+is where dev and build serve libskill's src
+(`products/pathway/src/commands/dev.js:130`, `build.js:142`), and
+`/map/lib/levels.js` stops existing after the move. No test covers
+importmaps; get this wrong and the published site 404s silently.
+
+Verify: `rg "@forwardimpact/map/levels|@forwardimpact/map/schema/json" --glob '!specs/**'`
+is empty (SC3 — the spec's exact command; `references/` is updated by
+part 06 and must also be clean); `rg '/map/lib/levels' products/pathway/src`
+is empty; `bun test tests/ products/` passes and a pathway `dev`/`build`
+smoke loads a page that imports levels.
 
 ## Step 6 — libterrain resolves the schema dir from libskill
 
@@ -115,7 +127,25 @@ Verify: `rg '@forwardimpact/map' libraries/` is empty (SC1);
 `bun test libraries/libterrain` passes; `bunx fit-terrain validate` renders
 pathway output in the monorepo.
 
-## Step 7 — Repo-wide checks
+## Step 7 — CI and website publish follow the schema move
+
+The published schema URLs and the CI cache keys reference the old path.
+
+- Modified: `.github/workflows/website.yml` (line 50:
+  `cp products/map/schema/json/*.json dist/schema/json/` →
+  `cp libraries/libskill/schema/json/*.json dist/schema/json/`; the `dist/`
+  target and the published `https://www.forwardimpact.team/schema/json/…`
+  `$id` URLs are unchanged)
+- Modified: `.github/workflows/check-test.yml` (lines 74 and 80: both
+  `hashFiles(…)` cache keys swap `products/map/schema/json/**` for
+  `libraries/libskill/schema/json/**` — a stale path silently hashes to
+  nothing and the synthetic/pathway caches stop invalidating)
+- Modified: `websites/CLAUDE.md` (§ around line 126: the sentence describing
+  where the published schemas are copied from names the new source)
+
+Verify: `rg 'products/map/schema' .github/ websites/` is empty.
+
+## Step 8 — Repo-wide checks
 
 Verify: `bun run invariants` (workspace-imports guard) and `bun test` pass;
 `bun run context:fix` shows no catalog drift.

--- a/specs/2180-terrain-substrate-contract/plan-a-02.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-02.md
@@ -1,0 +1,161 @@
+# Plan 2180-a part 02 — libterrain substrate verbs
+
+Build the generic substrate identity capability in `libterrain`: a
+schema-bound client, the contract description, the persona query rewritten
+against `substrate.*`, and the six CLI verbs with unit tests (SC4, SC5).
+`map`'s copies stay untouched until part 03.
+
+## Step 1 — Contract description and client factory
+
+One module states the contract; one factory is the only client construction
+site.
+
+- Created: `libraries/libterrain/src/substrate/contract.js`
+- Created: `libraries/libterrain/src/substrate/client.js`
+
+`contract.js` exports:
+
+```js
+export const SUBSTRATE_CONTRACT = {
+  schema: "substrate",
+  relations: {
+    people: {
+      required: true,
+      columns: ["email", "name", "kind", "manager_email",
+                "team_id", "team_name", "discipline", "level", "track"],
+    },
+    evidence: { required: false, columns: ["email"] },
+    discovery: { required: false, columns: ["key", "value"] },
+  },
+};
+```
+
+`client.js` exports `createSubstrateClient({ config })` →
+`createClient(config.supabaseUrl(), config.supabaseServiceRoleKey(), { db: { schema: "substrate" } })`.
+No other module calls `createClient`.
+
+Verify: new `test/substrate-client.test.js` asserts (via an injected
+`createClient` spy) the factory passes `db.schema = "substrate"` — the SC4
+schema-binding test covering the `evidence` name shared with map's vendor
+table.
+
+## Step 2 — Persona query against the contract
+
+Port `findInvariantSatisfyingPersonas` from
+`products/map/src/commands/substrate-persona-query.js`, requeried against
+contract relations only.
+
+- Created: `libraries/libterrain/src/substrate/persona-query.js`
+
+| Aspect | Behaviour |
+| --- | --- |
+| Inputs | `substrate.people` (`kind = 'human'` rows are personas), `substrate.evidence`, `substrate.discovery` |
+| Structural invariants (always) | `manager_email` non-null; manages ≥ 1 direct (derived from people rows) |
+| Evidence invariants (when `substrate.evidence` present) | authors ≥ 1 evidence row; manages ≥ 1 direct who authors ≥ 1 |
+| Optional-relation detection | a query error with code `PGRST205`/`42P01` (relation absent) marks the relation absent; any other error propagates |
+| Discovery | fold `substrate.discovery` key/value rows into one object (e.g. `{snapshot_id, item_id}`); absent or empty relation → `discovery: null` |
+| Row shape | `email, name, discipline, level, track, parent_email, team_id, team_name, parent, teammates (≤3, truncation flag), manages_count, evidence_count, practice_directs_count` — `github_username`, `getdx_team_id`, `snapshot_id`, `item_id` drop from the row |
+| Return | `{ personas, discovery, applied_invariants, diagnostic? }` — `applied_invariants` names which invariant set ran, for the pick payload's declared degradation |
+| Diagnostics | port `diagnoseBindingConstraint` unchanged; empty-people diagnostic stays |
+
+Verify: `test/substrate-persona-query.test.js` covers invariants with and
+without `substrate.evidence`, the binding-constraint diagnostic, and discovery
+folding/absence, against a new `test/substrate-stubs.js` fixture keyed on the
+three contract relations (modeled on map's `_substrate-stubs.js`).
+
+## Step 3 — Enricher, pick memory, auth users
+
+Port the three support modules.
+
+- Created: `libraries/libterrain/src/substrate/persona-enricher.js` (from
+  `products/map/src/lib/persona-enricher.js`)
+- Created: `libraries/libterrain/src/substrate/pick-memory.js` (from
+  `products/map/src/lib/pick-memory.js`, logic unchanged; header comment loses
+  the `wiki/kata-interview` path — the path is caller-supplied)
+- Created: `libraries/libterrain/src/substrate/auth-users.js` (merges
+  `products/map/src/lib/auth-helpers.js` `findAuthUser` and
+  `products/map/src/commands/people-provision.js` `runProvisionCommand` →
+  `runProvision`, requeried: roster emails come from `substrate.people`)
+
+Enricher change: `enrichPersonaRow(row, ast)` keys on the contract's
+`row.team_id` and calls `findTeamById(ast, row.team_id)` directly — the
+`gdx_team_` prefix handling deletes; vendor-id mapping is the consumer view's
+job (part 03). `loadStory` ports unchanged (upward resolution of
+`data/synthetic/story.dsl` from cwd; absent → `null`, un-enriched rows).
+
+Verify: `test/substrate-enricher.test.js` (team resolution by bare `team_id`,
+absent AST → null fields) and `test/substrate-provision.test.js`
+(create/restore/decommission against a stubbed `auth.admin`, roster read from
+`substrate.people`) pass.
+
+## Step 4 — The six verb commands
+
+One module per verb, signatures from design § CLI verb interfaces.
+
+- Created: `libraries/libterrain/src/commands/substrate-init.js`
+- Created: `libraries/libterrain/src/commands/substrate-check.js`
+- Created: `libraries/libterrain/src/commands/substrate-provision.js`
+- Created: `libraries/libterrain/src/commands/substrate-pick.js`
+- Created: `libraries/libterrain/src/commands/substrate-roster.js`
+- Created: `libraries/libterrain/src/commands/substrate-issue.js`
+
+| Verb | Implementation notes |
+| --- | --- |
+| `init --cwd <dir>` | Offline. Writes `<cwd>/supabase/migrations/<ts>_substrate_contract.sql` (`ts` from `runtime.clock`): `CREATE SCHEMA substrate`, service-role grants, one commented example view per contract relation generated from `SUBSTRATE_CONTRACT` columns |
+| `check` | Column-explicit `select(<columns>).limit(1)` per relation via the client; one diagnostic per missing/malformed relation; required failure → exit 1, optional absence → info diagnostic, exit 0 |
+| `provision` | Thin wrapper over `runProvision` |
+| `pick --format json\|text --memory <path> --memory-window <n>` | Port of map's `runPickCommand`: memory only when `--memory` supplied (read window, append on success; stateless otherwise); window default 5 via `--memory-window`; enrichment via `loadStory`; payload gains `selection_metadata.applied_invariants` from the query |
+| `roster --format json\|text` | Port of map's `runRosterCommand` over the same query; table headers unchanged |
+| `issue --email <e> --cwd <p> --token-env <NAME> [--ttl <d>] [--stash <path>]` | Port of map's `runSubstrateIssueCommand`: `--token-env` **required, no default**; `.env` line is `<NAME>=<jwt>`; `.substrate.json` carries the discovery key/values (spread, not nested) + `persona_email`, `manager_email` (persona's own email — port the invariant-(a) comment), `generated_at`; no discovery → identity-only file; same tmp-write/rename atomicity, mode 0600, stash behaviour; `kind !== "human"` rejection message names `substrate.people`, not `fit-map auth issue` |
+
+No `PRODUCT_LANDMARK_TOKEN` or `kata-interview` literal survives (SC5). The
+pick-memory `run_id` column keeps its `env.GITHUB_RUN_ID ?? ""` source — CI
+run metadata, not a product literal, and it degrades to empty outside GitHub.
+
+Verify:
+`rg 'PRODUCT_LANDMARK_TOKEN|kata-interview|getdx_|github_' libraries/libterrain/src/ libraries/libterrain/bin/`
+is empty (SC4, SC5); `test/substrate-init.test.js`,
+`test/substrate-check.test.js`, `test/substrate-pick.test.js` (memory on/off,
+window, token-env-free), `test/substrate-issue.test.js` (file set,
+`--token-env` threading and required-ness, stash, non-human rejection,
+identity-only degradation) pass.
+
+## Step 5 — CLI wiring and package surface
+
+Dispatch the verbs and export the capabilities map will consume.
+
+- Modified: `libraries/libterrain/bin/fit-terrain.js`,
+  `libraries/libterrain/package.json`
+- Created: `libraries/libterrain/src/substrate/index.js`
+
+`bin/fit-terrain.js`: the existing `positionals[0] === "substrate"` branch
+becomes a subcommand table (`up|init|check|provision|pick|roster|issue`);
+stack-facing verbs build `createScriptConfig("terrain")` and
+`createSubstrateClient({ config })`; `issue` reads `config.supabaseJwtSecret()`
+(the `JWT_SECRET` env var — design § Key Decisions). Add the six command
+definitions (options + examples) to `definition.commands`.
+
+`package.json`: `exports` gains
+`"./substrate": "./src/substrate/index.js"` (re-exports
+`findInvariantSatisfyingPersonas`, `findAuthUser`, `runProvision`,
+`createSubstrateClient`, `SUBSTRATE_CONTRACT`); `@supabase/supabase-js` moves
+from `optionalDependencies` to `dependencies`; add `@forwardimpact/libsecret`.
+
+Verify: `bunx fit-terrain --help` lists the seven substrate verbs;
+`bun test libraries/libterrain` passes; `bun run invariants` passes.
+
+Libraries used: libsecret (`mintSupabaseJwt`, `parseDuration`), libconfig
+(`createScriptConfig`), libcli (`formatTable`, `formatError`,
+`formatSuccess`), libsyntheticgen (enricher helpers), libutil
+(`isoTimestamp`, runtime), libmock (tests).
+
+## Risks
+
+- `pick`'s enrichment resolves `story.dsl`/`prose-cache.json` upward from
+  `cwd` with a depth cap of 5 (ported `findUpward` call) — in the interview
+  action the process cwd is the checkout root, so the cap is safe, but do not
+  "simplify" to project-root resolution: an external consumer has no
+  monorepo-shaped root.
+- `check` must not use `select("*")` — PostgREST accepts unknown relations
+  lazily on some error paths; the column-explicit select is what turns a
+  malformed view into a diagnostic naming the missing column.

--- a/specs/2180-terrain-substrate-contract/plan-a-02.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-02.md
@@ -82,6 +82,10 @@ Enricher change: `enrichPersonaRow(row, ast)` keys on the contract's
 `gdx_team_` prefix handling deletes; vendor-id mapping is the consumer view's
 job (part 03). `loadStory` ports unchanged (upward resolution of
 `data/synthetic/story.dsl` from cwd; absent → `null`, un-enriched rows).
+Declared deviation from design § CLI verb interfaces: the pick path reads
+**only** `story.dsl` — `prose-cache.json` is not read by the enricher today
+and this plan adds no such read; the design's mention describes the synthetic
+story artifact family, not a second resolution.
 
 Verify: `test/substrate-enricher.test.js` (team resolution by bare `team_id`,
 absent AST → null fields) and `test/substrate-provision.test.js`
@@ -102,11 +106,11 @@ One module per verb, signatures from design § CLI verb interfaces.
 | Verb | Implementation notes |
 | --- | --- |
 | `init --cwd <dir>` | Offline. Writes `<cwd>/supabase/migrations/<ts>_substrate_contract.sql` (`ts` from `runtime.clock`): `CREATE SCHEMA substrate`, service-role grants, one commented example view per contract relation generated from `SUBSTRATE_CONTRACT` columns |
-| `check` | Column-explicit `select(<columns>).limit(1)` per relation via the client; one diagnostic per missing/malformed relation; required failure → exit 1, optional absence → info diagnostic, exit 0 |
+| `check` | Column-explicit `select(<columns>).limit(1)` per relation via the client; one diagnostic per missing/malformed relation; required missing **or malformed** → exit 1; optional missing or malformed → info diagnostic, exit 0 (severity follows the relation's required flag, not the failure kind) |
 | `provision` | Thin wrapper over `runProvision` |
 | `pick --format json\|text --memory <path> --memory-window <n>` | Port of map's `runPickCommand`: memory only when `--memory` supplied (read window, append on success; stateless otherwise); window default 5 via `--memory-window`; enrichment via `loadStory`; payload gains `selection_metadata.applied_invariants` from the query |
 | `roster --format json\|text` | Port of map's `runRosterCommand` over the same query; table headers unchanged |
-| `issue --email <e> --cwd <p> --token-env <NAME> [--ttl <d>] [--stash <path>]` | Port of map's `runSubstrateIssueCommand`: `--token-env` **required, no default**; `.env` line is `<NAME>=<jwt>`; `.substrate.json` carries the discovery key/values (spread, not nested) + `persona_email`, `manager_email` (persona's own email — port the invariant-(a) comment), `generated_at`; no discovery → identity-only file; same tmp-write/rename atomicity, mode 0600, stash behaviour; `kind !== "human"` rejection message names `substrate.people`, not `fit-map auth issue` |
+| `issue --email <e> --cwd <p> --token-env <NAME> [--ttl <d>] [--stash <path>]` | Port of map's `runSubstrateIssueCommand`: `--token-env` **required, no default**; `.env` line is `<NAME>=<jwt>`; `.substrate.json` carries the discovery key/values (spread, not nested) + `persona_email`, `manager_email` (persona's own email — port the invariant-(a) comment), `generated_at`; discovery values come from the persona-query module's exported discovery loader (the `substrate.discovery` fold) — map's `resolveDiscoveryVector` has no successor, `issue` calls that shared helper itself; loader returns `null` → identity-only file; same tmp-write/rename atomicity, mode 0600, stash behaviour; `kind !== "human"` rejection message names `substrate.people`, not `fit-map auth issue` |
 
 No `PRODUCT_LANDMARK_TOKEN` or `kata-interview` literal survives (SC5). The
 pick-memory `run_id` column keeps its `env.GITHUB_RUN_ID ?? ""` source — CI
@@ -151,9 +155,9 @@ Libraries used: libsecret (`mintSupabaseJwt`, `parseDuration`), libconfig
 
 ## Risks
 
-- `pick`'s enrichment resolves `story.dsl`/`prose-cache.json` upward from
-  `cwd` with a depth cap of 5 (ported `findUpward` call) — in the interview
-  action the process cwd is the checkout root, so the cap is safe, but do not
+- `pick`'s enrichment resolves `data/synthetic/story.dsl` upward from `cwd`
+  with a depth cap of 5 (ported `findUpward` call) — in the interview action
+  the process cwd is the checkout root, so the cap is safe, but do not
   "simplify" to project-root resolution: an external consumer has no
   monorepo-shaped root.
 - `check` must not use `select("*")` — PostgREST accepts unknown relations

--- a/specs/2180-terrain-substrate-contract/plan-a-02.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-02.md
@@ -120,9 +120,9 @@ Verify:
 `rg 'PRODUCT_LANDMARK_TOKEN|kata-interview|getdx_|github_' libraries/libterrain/src/ libraries/libterrain/bin/`
 is empty (SC4, SC5); `test/substrate-init.test.js`,
 `test/substrate-check.test.js`, `test/substrate-pick.test.js` (memory on/off,
-window, token-env-free), `test/substrate-issue.test.js` (file set,
-`--token-env` threading and required-ness, stash, non-human rejection,
-identity-only degradation) pass.
+window, token-env-free), `test/substrate-issue.test.js` (file set, `--token-env`
+threading and required-ness, stash, non-human rejection, identity-only
+degradation) pass.
 
 ## Step 5 — CLI wiring and package surface
 

--- a/specs/2180-terrain-substrate-contract/plan-a-03.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-03.md
@@ -69,15 +69,15 @@ probe passes against a stub built from the migration's column lists (SC7).
   `products/map/bin/dispatch-substrate.js` (only the `stage` case and a
   `stage`-only `known` set survive)
 
-Verify: `fit-map --help` lists none of the four verbs; a new assertion in an
-existing CLI-definition test (or `products/map/test/cli-definition.test.js`)
-pins their absence (SC6).
+Verify: `fit-map --help` lists none of the four verbs; a **new**
+`products/map/test/cli-definition.test.js` (no CLI-definition test exists
+today) pins their absence (SC6).
 
 ## Step 3 — Stage provisions through libterrain
 
 - Modified: `products/map/src/commands/substrate-stage.js`,
-  `products/map/src/lib/client.js` (no change needed — `createMapClient`
-  already takes `schema`), `products/map/package.json`
+  `products/map/package.json` (`createMapClient` already takes a `schema`
+  option — `src/lib/client.js` is untouched)
 
 `loadProvision` default becomes
 `() => import("@forwardimpact/libterrain/substrate").then((m) => m.runProvision)`.

--- a/specs/2180-terrain-substrate-contract/plan-a-03.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-03.md
@@ -1,0 +1,132 @@
+# Plan 2180-a part 03 — map after the move
+
+The clean break: `map` implements the contract as views over `activity.*`,
+deletes the four moved verbs and their support modules, and repoints stage,
+smoke, and `auth issue` to the `libterrain` capabilities (SC6, SC7).
+
+## Step 1 — Contract-view migration and API exposure
+
+`map` maps `activity.*` onto the contract relations.
+
+- Created: `products/map/supabase/migrations/20260708000000_substrate_contract.sql`
+- Modified: `products/map/supabase/config.toml`
+
+Migration content (shape; implementer finalizes SQL):
+
+```sql
+create schema substrate;
+grant usage on schema substrate to service_role;
+
+create view substrate.people as
+select p.email, p.name, p.kind, p.manager_email,
+       replace(p.getdx_team_id, 'gdx_team_', '') as team_id,
+       t.name as team_name,
+       p.discipline, p.level, p.track
+from activity.organization_people p
+left join activity.getdx_teams t on t.getdx_team_id = p.getdx_team_id;
+
+create view substrate.evidence as
+select ga.email
+from activity.evidence e
+join activity.github_artifacts ga on ga.artifact_id = e.artifact_id;
+
+create view substrate.discovery as
+with latest as (select snapshot_id from activity.getdx_snapshots
+                order by scheduled_for desc limit 1)
+select 'snapshot_id' as key, latest.snapshot_id as value from latest
+union all
+select 'item_id', sc.item_id
+from latest
+join lateral (select item_id from activity.getdx_snapshot_team_scores
+              where snapshot_id = latest.snapshot_id limit 1) sc on true;
+
+grant select on all tables in schema substrate to service_role;
+```
+
+`team_id` strips the `gdx_team_` vendor prefix — the DSL team id the terrain
+enricher keys on; the vendor coupling lives here, not in the library. Grants
+go to `service_role` only — `substrate` stays out of anon/authenticated
+reach, matching the contract's auth model. `config.toml`:
+`schemas = ["public", "activity", "substrate"]`.
+
+Verify: `supabase db reset` applies cleanly; new
+`products/map/test/activity/substrate-contract-views.test.js` parses the
+migration and asserts every relation/column named by `libterrain`'s
+`SUBSTRATE_CONTRACT` is defined, and that `fit-terrain substrate check`'s
+probe passes against a stub built from the migration's column lists (SC7).
+
+## Step 2 — Delete the moved verbs and support modules
+
+- Deleted: `products/map/src/commands/{substrate-pick,substrate-roster,substrate-issue,substrate-persona-query,people-provision}.js`,
+  `products/map/src/lib/{persona-enricher,pick-memory,auth-helpers}.js`
+- Deleted: `products/map/test/activity/{substrate-pick.integration,substrate-roster,substrate-issue.integration,substrate-persona-query,people-provision.integration}.test.js`,
+  `products/map/test/lib/{persona-enricher,pick-memory.integration}.test.js`,
+  `products/map/test/activity/_substrate-stubs.js` (superseded by
+  `libterrain/test/substrate-stubs.js`)
+- Modified: `products/map/bin/fit-map.js` (CLI definition drops the
+  `substrate roster|pick|issue` commands; `people` args become
+  `<validate|push> [file]` and the provision dispatch case deletes),
+  `products/map/bin/dispatch-substrate.js` (only the `stage` case and a
+  `stage`-only `known` set survive)
+
+Verify: `fit-map --help` lists none of the four verbs; a new assertion in an
+existing CLI-definition test (or `products/map/test/cli-definition.test.js`)
+pins their absence (SC6).
+
+## Step 3 — Stage provisions through libterrain
+
+- Modified: `products/map/src/commands/substrate-stage.js`,
+  `products/map/src/lib/client.js` (no change needed — `createMapClient`
+  already takes `schema`), `products/map/package.json`
+
+`loadProvision` default becomes
+`() => import("@forwardimpact/libterrain/substrate").then((m) => m.runProvision)`.
+Stage builds a second client
+`createMapClient({ config: stageConfig, schema: "substrate" })` after
+url-discovery and passes it to the provision phase and the smoke; the
+activity-schema client keeps serving seed. `package.json` gains
+`@forwardimpact/libterrain`.
+
+Verify: `products/map/test/substrate-stage.test.js` and
+`test/activity/substrate-stage*.test.js` pass, still asserting the provision
+phase runs and that phase failures carry `[substrate stage: provision]`.
+
+## Step 4 — Smoke and auth issue consume the moved capabilities
+
+No private copy of the persona query or auth-user lookup survives.
+
+- Modified: `products/map/src/commands/substrate-smoke.js` (import
+  `findInvariantSatisfyingPersonas` from `@forwardimpact/libterrain/substrate`;
+  it now receives the substrate-schema client; `assertPersonaIsHuman` queries
+  `substrate.people`; `assertDiscoveryResolves` reads the query's folded
+  `discovery` object — FI strictness on discovery stays here)
+- Modified: `products/map/src/commands/auth-issue.js` (import `findAuthUser`
+  from `@forwardimpact/libterrain/substrate`; the `organization_people`
+  roster read stays — it is map's vendor query on map's operator surface)
+
+Verify: `products/map/test/activity/substrate-smoke.test.js` (rebuilt on
+contract-relation stubs) and `test/activity/auth-issue.test.js` pass.
+
+## Step 5 — Repo-wide checks
+
+Verify:
+`rg 'getdx_|github_' libraries/libterrain/src/ libraries/libterrain/bin/`
+still empty; `bun test products/map` and `bun run invariants` pass;
+`fit-map substrate stage` help text and the skill remain accurate about the
+retained pipeline (prose updates land in part 05).
+
+Libraries used: libterrain (`./substrate`: `runProvision`,
+`findInvariantSatisfyingPersonas`, `findAuthUser`, `SUBSTRATE_CONTRACT`),
+libconfig, libsecret (smoke/auth issue JWT mint — unchanged).
+
+## Risks
+
+- View column drift is the contract's failure mode: the
+  `substrate-contract-views.test.js` comparison against `SUBSTRATE_CONTRACT`
+  is what keeps map's migration and the library's probe from drifting apart —
+  do not hand-copy the column list into the test.
+- `rls-scope.test.js`, `migration-rls.test.js`, and
+  `service-role-still-used.test.js` assert schema/RLS posture; the new
+  `substrate` schema (service-role-only grants, no RLS of its own — views run
+  with owner rights) must be reflected there rather than allow-listed
+  blindly.

--- a/specs/2180-terrain-substrate-contract/plan-a-03.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-03.md
@@ -8,7 +8,8 @@ smoke, and `auth issue` to the `libterrain` capabilities (SC6, SC7).
 
 `map` maps `activity.*` onto the contract relations.
 
-- Created: `products/map/supabase/migrations/20260708000000_substrate_contract.sql`
+- Created:
+  `products/map/supabase/migrations/20260708000000_substrate_contract.sql`
 - Modified: `products/map/supabase/config.toml`
 
 Migration content (shape; implementer finalizes SQL):
@@ -57,9 +58,11 @@ probe passes against a stub built from the migration's column lists (SC7).
 
 ## Step 2 — Delete the moved verbs and support modules
 
-- Deleted: `products/map/src/commands/{substrate-pick,substrate-roster,substrate-issue,substrate-persona-query,people-provision}.js`,
+- Deleted:
+  `products/map/src/commands/{substrate-pick,substrate-roster,substrate-issue,substrate-persona-query,people-provision}.js`,
   `products/map/src/lib/{persona-enricher,pick-memory,auth-helpers}.js`
-- Deleted: `products/map/test/activity/{substrate-pick.integration,substrate-roster,substrate-issue.integration,substrate-persona-query,people-provision.integration}.test.js`,
+- Deleted:
+  `products/map/test/activity/{substrate-pick.integration,substrate-roster,substrate-issue.integration,substrate-persona-query,people-provision.integration}.test.js`,
   `products/map/test/lib/{persona-enricher,pick-memory.integration}.test.js`,
   `products/map/test/activity/_substrate-stubs.js` (superseded by
   `libterrain/test/substrate-stubs.js`)

--- a/specs/2180-terrain-substrate-contract/plan-a-04.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-04.md
@@ -18,12 +18,15 @@ persona=$(fit-terrain substrate pick --format json \
   --token-env PRODUCT_LANDMARK_TOKEN --stash "$RUNNER_TEMP/.persona-jwt"
 ```
 
-(single-quoted YAML expression string like today; `fit-terrain` is on PATH in
-the action, no `bunx`). `substrate-setup-command` is untouched — `bunx
-fit-map substrate stage` stays the sole `fit-map` line, and the comment above
-the step updates to say so. Note: the old command extracted `.email` from a
-payload whose email lives at `.personas[0].email`; the new extraction is the
-correct path, not a behaviour change.
+The block above is the logical shape, not verbatim YAML: like today's line 61
+it collapses to a single line inside the `${{ … && '…' || '' }}` expression,
+where every embedded single quote — including the `jq` filter's — doubles to
+`''` (so the filter reads `jq -r ''.personas[0].email''`). `fit-terrain` is
+on PATH in the action, no `bunx`. `substrate-setup-command` is untouched —
+`bunx fit-map substrate stage` stays the sole `fit-map` line, and the comment
+above the step updates to say so. Note: the old command extracted `.email`
+from a payload whose email lives at `.personas[0].email`; the new extraction
+is the correct path, not a behaviour change.
 
 Verify: `yq '.jobs.interview.steps[0].with' .github/workflows/kata-interview.yml`
 shows the new command; workflow shape test below passes.
@@ -47,6 +50,10 @@ Libraries used: none.
 
 ## Risks
 
-- This part must not land before part 03: the workflow's pick queries
-  `substrate.*`, which exists only once map's contract-view migration ships
-  in the release the interview runner installs.
+- The gate for merging this part is the **release cut**, not part 03's merge:
+  the interview runner installs `fit-terrain` as a pre-built binary via the
+  bootstrap action and runs the published `bunx fit-map` — both must come
+  from the release train carrying parts 01–03 (`libskill`, `libterrain`,
+  `map`), or every landmark interview fails with an unknown-subcommand or
+  missing-`substrate.*` error. Merge this part only after that release
+  ships.

--- a/specs/2180-terrain-substrate-contract/plan-a-04.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-04.md
@@ -28,8 +28,9 @@ above the step updates to say so. Note: the old command extracted `.email`
 from a payload whose email lives at `.personas[0].email`; the new extraction
 is the correct path, not a behaviour change.
 
-Verify: `yq '.jobs.interview.steps[0].with' .github/workflows/kata-interview.yml`
-shows the new command; workflow shape test below passes.
+Verify:
+`yq '.jobs.interview.steps[0].with' .github/workflows/kata-interview.yml` shows
+the new command; workflow shape test below passes.
 
 ## Step 2 — Shape-test assertions
 

--- a/specs/2180-terrain-substrate-contract/plan-a-04.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-04.md
@@ -1,0 +1,52 @@
+# Plan 2180-a part 04 — Interview workflow wiring
+
+Switch the wrapper workflow's persona step to `fit-terrain`, carrying the FI
+values as explicit options, and pin the shape in the workflow test (SC8).
+
+## Step 1 — persona-select-command switches to fit-terrain
+
+- Modified: `.github/workflows/kata-interview.yml`
+
+The `persona-select-command` ternary's command string becomes:
+
+```sh
+persona=$(fit-terrain substrate pick --format json \
+  --memory "wiki/kata-interview/picks.csv") \
+&& printf '%s\n' "$persona" \
+&& email=$(printf '%s' "$persona" | jq -r '.personas[0].email') \
+&& fit-terrain substrate issue --email "$email" --cwd "$AGENT_CWD" \
+  --token-env PRODUCT_LANDMARK_TOKEN --stash "$RUNNER_TEMP/.persona-jwt"
+```
+
+(single-quoted YAML expression string like today; `fit-terrain` is on PATH in
+the action, no `bunx`). `substrate-setup-command` is untouched — `bunx
+fit-map substrate stage` stays the sole `fit-map` line, and the comment above
+the step updates to say so. Note: the old command extracted `.email` from a
+payload whose email lives at `.personas[0].email`; the new extraction is the
+correct path, not a behaviour change.
+
+Verify: `yq '.jobs.interview.steps[0].with' .github/workflows/kata-interview.yml`
+shows the new command; workflow shape test below passes.
+
+## Step 2 — Shape-test assertions
+
+- Modified: `.github/workflows/test/kata-interview-shape.test.js`
+
+New `describe` block on the wrapper's `with:` map asserting
+`persona-select-command`:
+
+- matches `/fit-terrain substrate pick/` and `/fit-terrain substrate issue/`
+- carries `--memory "wiki/kata-interview/picks.csv"` and
+  `--token-env PRODUCT_LANDMARK_TOKEN`
+- does not match `/fit-map/`; and across the whole `with:` map, `fit-map`
+  appears only in `substrate-setup-command`
+
+Verify: `bun test .github/workflows/test/kata-interview-shape.test.js` passes.
+
+Libraries used: none.
+
+## Risks
+
+- This part must not land before part 03: the workflow's pick queries
+  `substrate.*`, which exists only once map's contract-view migration ships
+  in the release the interview runner installs.

--- a/specs/2180-terrain-substrate-contract/plan-a-05.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-05.md
@@ -48,9 +48,8 @@ SKILL.md gains a substrate section: what the contract is (one paragraph), the
 seven verbs with one-line purposes, the env vars, and the degradation
 one-liners; `## Documentation` gains
 `[Substrate Contract](https://www.forwardimpact.team/docs/libraries/substrate-contract/index.md)`.
-The CLI `documentation` array adds the same entry in the same order
-(linking rule in `libraries/CLAUDE.md`). `references/cli.md` lists the new
-verbs.
+The CLI `documentation` array adds the same entry in the same order (linking
+rule in `libraries/CLAUDE.md`). `references/cli.md` lists the new verbs.
 
 Verify: skill list and CLI array carry identical entries in identical order;
 `bun run invariants` (skill-genericity) passes.
@@ -66,8 +65,9 @@ now runs via the shared library) and the smoke, deletes the roster/pick/issue
 and `people provision` verb documentation, and points persona selection at
 `npx fit-terrain substrate` plus the contract guide URL.
 
-Verify: `rg 'substrate (pick|issue|roster)|people provision' .claude/skills/fit-map/`
-is empty.
+Verify:
+`rg 'substrate (pick|issue|roster)|people provision' .claude/skills/fit-map/` is
+empty.
 
 ## Step 4 — Provisioning guide and every doc commanding the moved verbs
 
@@ -102,8 +102,9 @@ CLIs' arrays match their skills' `## Documentation` lists.
   source-location column/prose, if it names the map package — the published
   `/schema/json/…` URLs are unchanged)
 
-Verify: `rg -n 'schema/json' .claude/skills/fit-map/ websites/fit/docs/reference/`
-shows no line locating the JSON schemas in the map product.
+Verify:
+`rg -n 'schema/json' .claude/skills/fit-map/ websites/fit/docs/reference/` shows
+no line locating the JSON schemas in the map product.
 
 Libraries used: none.
 

--- a/specs/2180-terrain-substrate-contract/plan-a-05.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-05.md
@@ -69,20 +69,41 @@ and `people provision` verb documentation, and points persona selection at
 Verify: `rg 'substrate (pick|issue|roster)|people provision' .claude/skills/fit-map/`
 is empty.
 
-## Step 4 — Provisioning guide follows the verb
+## Step 4 — Provisioning guide and every doc commanding the moved verbs
 
 - Modified: `websites/fit/docs/products/provisioning-engineers/index.md`,
+  `websites/fit/docs/products/signing-in-to-landmark/index.md`,
+  `websites/fit/docs/products/issuing-service-account-tokens/index.md`,
+  `websites/fit/docs/getting-started/leaders/landmark/index.md`,
+  `websites/fit/docs/getting-started/leaders/map/index.md`,
+  `websites/fit/docs/getting-started/engineers/landmark/index.md`,
   `products/map/bin/fit-map.js`, `libraries/libterrain/bin/fit-terrain.js`,
   `.claude/skills/fit-map/SKILL.md`, `.claude/skills/fit-terrain/SKILL.md`
 
-The guide's command becomes `npx fit-terrain substrate provision` with the
-contract (not the map schema) as the stated prerequisite; its
-"Provision Engineer Auth Users" entry moves from `fit-map`'s
-`documentation` array + skill list to `fit-terrain`'s, keeping list/array
-parity on both sides.
+The provisioning guide's command becomes
+`npx fit-terrain substrate provision` with the contract (not the map schema)
+as the stated prerequisite; its "Provision Engineer Auth Users" entry moves
+from `fit-map`'s `documentation` array + skill list to `fit-terrain`'s,
+keeping list/array parity on both sides. The five other docs above each
+command `fit-map people provision` in passing — repoint every occurrence to
+the new verb.
 
-Verify: guide names no `fit-map` command; both CLIs' arrays match their
-skills' `## Documentation` lists.
+Verify: `rg -l 'people provision' websites/ .claude/skills/` is empty; both
+CLIs' arrays match their skills' `## Documentation` lists.
+
+## Step 5 — Schema-location mentions follow the part-01 move
+
+- Modified: `.claude/skills/fit-map/SKILL.md` (validation section lines
+  ~47–52: "each YAML against its JSON Schema (`schema/json/`)" and the
+  schema-change instruction now name the schemas' libskill home while
+  `schema/rdf/` stays map's),
+  `.claude/skills/fit-map/references/` (any file locating `schema/json` in
+  map), `websites/fit/docs/reference/yaml-schema/index.md` (the
+  source-location column/prose, if it names the map package — the published
+  `/schema/json/…` URLs are unchanged)
+
+Verify: `rg -n 'schema/json' .claude/skills/fit-map/ websites/fit/docs/reference/`
+shows no line locating the JSON schemas in the map product.
 
 Libraries used: none.
 

--- a/specs/2180-terrain-substrate-contract/plan-a-05.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-05.md
@@ -1,0 +1,94 @@
+# Plan 2180-a part 05 — Contract guide, skills, docs
+
+Document the Substrate Contract for external consumers and bring the
+`fit-terrain` / `fit-map` skills, CLI `documentation` arrays, and the
+provisioning guide in line with the moved verbs (SC9).
+
+## Step 1 — Substrate Contract guide
+
+The normative external document.
+
+- Created: `websites/fit/docs/libraries/substrate-contract/index.md`
+- Modified: `websites/fit/docs/libraries/index.md` (register
+  `<!-- part:card:substrate-contract -->` in its own grid section)
+
+Front matter and card conventions copied from
+`websites/fit/docs/libraries/prove-changes/generate-dataset/index.md`.
+Content (all normative tables from design § Substrate Contract):
+
+- the `substrate` schema requirement and Supabase API exposure
+- the three relations with required flags and column lists, including the
+  `discipline`/`level`/`track` opinion and how a different-domain consumer
+  maps its role model onto them
+- auth model (Supabase auth, email identities, RLS keyed on `auth.email()`,
+  service-role key for provisioning)
+- env vars: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (every stack-facing
+  verb), `JWT_SECRET` (`issue` only), and that `init` is offline
+- degradation semantics: `check` optional-absent = info; `pick` without
+  `evidence` drops the evidence invariants and reports `applied_invariants`;
+  `issue` without `discovery` writes an identity-only `.substrate.json`
+- the consumer walkthrough:
+  `up → init → edit views + own migrations → own seed → check → provision → pick → issue`
+  with `npx fit-terrain` command lines and a worked example of mapping a
+  non-engineering schema onto `substrate.people`
+
+Audience rules per `websites/` conventions: external reader, `npx` only, no
+monorepo paths.
+
+Verify: `bun run docs:build` (or the site's build task) renders the page and
+the index card; every internal link resolves.
+
+## Step 2 — fit-terrain skill and CLI documentation parity
+
+- Modified: `.claude/skills/fit-terrain/SKILL.md`,
+  `.claude/skills/fit-terrain/references/cli.md`,
+  `libraries/libterrain/bin/fit-terrain.js` (`documentation` array)
+
+SKILL.md gains a substrate section: what the contract is (one paragraph), the
+seven verbs with one-line purposes, the env vars, and the degradation
+one-liners; `## Documentation` gains
+`[Substrate Contract](https://www.forwardimpact.team/docs/libraries/substrate-contract/index.md)`.
+The CLI `documentation` array adds the same entry in the same order
+(linking rule in `libraries/CLAUDE.md`). `references/cli.md` lists the new
+verbs.
+
+Verify: skill list and CLI array carry identical entries in identical order;
+`bun run invariants` (skill-genericity) passes.
+
+## Step 3 — fit-map skill prunes the moved verbs
+
+- Modified: `.claude/skills/fit-map/SKILL.md` (and
+  `references/` files that name the moved verbs)
+
+Frontmatter description drops "picking, and issuing personas"; the substrate
+section keeps `substrate stage` (its phases, including the provision phase it
+now runs via the shared library) and the smoke, deletes the roster/pick/issue
+and `people provision` verb documentation, and points persona selection at
+`npx fit-terrain substrate` plus the contract guide URL.
+
+Verify: `rg 'substrate (pick|issue|roster)|people provision' .claude/skills/fit-map/`
+is empty.
+
+## Step 4 — Provisioning guide follows the verb
+
+- Modified: `websites/fit/docs/products/provisioning-engineers/index.md`,
+  `products/map/bin/fit-map.js`, `libraries/libterrain/bin/fit-terrain.js`,
+  `.claude/skills/fit-map/SKILL.md`, `.claude/skills/fit-terrain/SKILL.md`
+
+The guide's command becomes `npx fit-terrain substrate provision` with the
+contract (not the map schema) as the stated prerequisite; its
+"Provision Engineer Auth Users" entry moves from `fit-map`'s
+`documentation` array + skill list to `fit-terrain`'s, keeping list/array
+parity on both sides.
+
+Verify: guide names no `fit-map` command; both CLIs' arrays match their
+skills' `## Documentation` lists.
+
+Libraries used: none.
+
+## Risks
+
+- The guide is the contract's single home — the `fit-terrain` skill and the
+  map migration must reference it, not restate the relation tables, or the
+  next column change forks the spec (one-home-per-policy rule in
+  CLAUDE.md § Documentation Map).

--- a/specs/2180-terrain-substrate-contract/plan-a-06.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-06.md
@@ -1,0 +1,70 @@
+# Plan 2180-a part 06 — Polaris reference wiring
+
+Update the `references/bionova-apps/` living reference (spec 1160) so Polaris
+consumes the substrate capability through the new `fit-terrain` verbs, with no
+`fit-map` and no `@forwardimpact/map` anywhere in its flow (SC10). This is a
+reference-document edit inside this monorepo — no `bionova-apps` repository
+work.
+
+## Step 1 — Drop `@forwardimpact/map` from the Polaris dependency story
+
+Schema resolution now ships inside `libterrain` via its hard `libskill`
+dependency, so Polaris needs no direct `map` package at all.
+
+- Modified: `references/bionova-apps/spec.md` (§ Technology stack drops
+  "`@forwardimpact/map` from npm"; Prerequisite 1's `--schema-dir` sentence
+  re-grounds on `@forwardimpact/libskill`'s published `schema/json`)
+- Modified: `references/bionova-apps/design-a.md` (dependency table row
+  "`@forwardimpact/map` — dependency of `libterrain`" deletes; § Prerequisite
+  library changes A's schema-dir row re-grounds on `libskill`)
+- Modified: `references/bionova-apps/plan-a.md` (Prerequisites table and
+  "Libraries used" drop `@forwardimpact/map`)
+- Modified: `references/bionova-apps/plan-a-01.md` (devDependencies block
+  drops the `@forwardimpact/map` pin)
+- Modified: `references/bionova-apps/plan-a-03.md` (version-pin step drops
+  `npm view @forwardimpact/map version` and the `bun pm ls` grep for map)
+
+Verify: `rg '@forwardimpact/map|fit-map' references/bionova-apps/` is empty.
+
+## Step 2 — Document the full substrate identity loop
+
+Extend design § Interviewing Polaris from "a staff-facing interview would
+pass a Polaris persona command" to the concrete wiring against the contract.
+
+- Modified: `references/bionova-apps/design-a.md` § Interviewing Polaris
+
+Content to add:
+
+- **One-time scaffold, committed:** `npx fit-terrain substrate init --cwd .`
+  writes the starter migration; Polaris edits the example views to map its
+  clinical schema onto the contract — staff and researchers become
+  `substrate.people` rows with Polaris roles mapped onto the mandated
+  `discipline`/`level`/`track` columns; `substrate.evidence` and
+  `substrate.discovery` are declared optional-absent (or mapped later), with
+  the declared degradation that implies (structural-only pick invariants;
+  identity-only `.substrate.json`).
+- **Workflow wiring:** `substrate-setup-command` becomes
+  `npx fit-terrain substrate up --cwd . --emit-env "$GITHUB_ENV" && supabase db push && ./data/synthetic/setup.sh && npx fit-terrain substrate check && npx fit-terrain substrate provision`.
+- **Staff-facing persona step:** `persona-select-command` uses
+  `npx fit-terrain substrate pick --format json` and
+  `npx fit-terrain substrate issue --email <picked> --cwd "$AGENT_CWD" --token-env PRODUCT_POLARIS_TOKEN --stash "$RUNNER_TEMP/.persona-jwt"`
+  — the token env name is Polaris's own; `--memory` is optional and
+  Polaris-scoped if used. Patient interviews still omit the persona step
+  entirely.
+- Link the Substrate Contract guide
+  (`https://www.forwardimpact.team/docs/libraries/substrate-contract/index.md`)
+  as the normative reference — the design names only Polaris-specific
+  mapping, never restating the relation tables (references/CLAUDE.md § route
+  each change to the layer that owns it).
+
+Verify: `rg -l 'init|check|provision|pick|issue' references/bionova-apps/design-a.md`
+matches, and the six verb names all appear in § Interviewing Polaris (SC10).
+
+Libraries used: none.
+
+## Risks
+
+- The reference is a living template for a **separate repository** — nothing
+  in this part touches `wiki/STATUS.md` rows for spec 1160 or implies
+  re-running the bionova-apps build; reconciling the external repo itself is
+  the separate § Keeping a reference current pass, out of this spec's scope.

--- a/specs/2180-terrain-substrate-contract/plan-a-06.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-06.md
@@ -24,7 +24,9 @@ dependency, so Polaris needs no direct `map` package at all.
 - Modified: `references/bionova-apps/plan-a-03.md` (version-pin step drops
   `npm view @forwardimpact/map version` and the `bun pm ls` grep for map)
 
-Verify: `rg '@forwardimpact/map|fit-map' references/bionova-apps/` is empty.
+Verify: `rg '@forwardimpact/map' references/bionova-apps/` is empty. (The
+"no fit-map" prose in design § Interviewing Polaris is rewritten by Step 2 —
+the combined `fit-map`-free check runs there.)
 
 ## Step 2 — Document the full substrate identity loop
 
@@ -57,8 +59,14 @@ Content to add:
   mapping, never restating the relation tables (references/CLAUDE.md § route
   each change to the layer that owns it).
 
-Verify: `rg -l 'init|check|provision|pick|issue' references/bionova-apps/design-a.md`
-matches, and the six verb names all appear in § Interviewing Polaris (SC10).
+Step 2 also rewords the section's "No fit-map and no map schema" comments so
+they stay true without naming a tool the flow never touches.
+
+Verify: each of `fit-terrain substrate init|check|provision|pick|issue`
+appears as a command string in § Interviewing Polaris
+(`rg -o 'fit-terrain substrate (init|check|provision|pick|issue)' references/bionova-apps/design-a.md`
+yields all five), and `rg 'fit-map' references/bionova-apps/` is empty
+(SC10).
 
 Libraries used: none.
 

--- a/specs/2180-terrain-substrate-contract/plan-a-06.md
+++ b/specs/2180-terrain-substrate-contract/plan-a-06.md
@@ -62,11 +62,10 @@ Content to add:
 Step 2 also rewords the section's "No fit-map and no map schema" comments so
 they stay true without naming a tool the flow never touches.
 
-Verify: each of `fit-terrain substrate init|check|provision|pick|issue`
-appears as a command string in § Interviewing Polaris
+Verify: each of `fit-terrain substrate init|check|provision|pick|issue` appears
+as a command string in § Interviewing Polaris
 (`rg -o 'fit-terrain substrate (init|check|provision|pick|issue)' references/bionova-apps/design-a.md`
-yields all five), and `rg 'fit-map' references/bionova-apps/` is empty
-(SC10).
+yields all five), and `rg 'fit-map' references/bionova-apps/` is empty (SC10).
 
 Libraries used: none.
 

--- a/specs/2180-terrain-substrate-contract/plan-a.md
+++ b/specs/2180-terrain-substrate-contract/plan-a.md
@@ -1,0 +1,80 @@
+# Plan 2180-a — Generic substrate contract
+
+Execute spec [2180](spec.md) / design [a](design-a.md): move the standard's
+data contract (levels module + thirteen JSON schemas) from `map` into
+`libskill`, and move the substrate identity verbs into `fit-terrain` behind
+the documented Substrate Contract. One clean break — no shims, no re-exports,
+no dual paths.
+
+## Approach
+
+Land the layering fix first (part 01 breaks the `libskill ↔ map` cycle and the
+`libterrain → map` edge), then build the generic verbs in `libterrain`
+(part 02) while `map` still carries its own copies — the repo stays green
+between parts. Part 03 is the break: `map` gains the contract-view migration,
+loses the four verbs, and repoints its survivors (stage, smoke, `auth issue`)
+to the `libterrain` capabilities. Parts 04–06 rewire the consumers: the
+interview workflow, the external documentation and skills, and the Polaris
+reference. Every FI-specific literal (`PRODUCT_LANDMARK_TOKEN`,
+`wiki/kata-interview/picks.csv`) moves up into the wrapper workflow; the
+library takes them only as required options.
+
+## Part Index
+
+| Part | Title | Scope | Depends on |
+| --- | --- | --- | --- |
+| [01](plan-a-01.md) | Standard contract moves to libskill | `levels.js` + `schema/json/` move, all import repoints, `libterrain` schema-dir resolution, dependency edges | — |
+| [02](plan-a-02.md) | libterrain substrate verbs | `substrate` module (client, contract, persona query, enricher, pick memory, auth users), six verbs, CLI wiring, unit tests | 01 |
+| [03](plan-a-03.md) | map after the move | Contract-view migration + API exposure, four verbs deleted, stage/smoke/`auth issue` repointed, tests | 02 |
+| [04](plan-a-04.md) | Interview workflow wiring | `persona-select-command` switches to `fit-terrain`, shape-test assertions | 03 |
+| [05](plan-a-05.md) | Contract guide, skills, docs | Substrate Contract guide, `fit-terrain`/`fit-map` skill + CLI doc parity, provisioning guide repoint | 02 |
+| [06](plan-a-06.md) | Polaris reference wiring | `references/bionova-apps/` drops `@forwardimpact/map`, documents the full `up → init → check → provision → pick → issue` loop | 02 |
+
+Libraries used: libskill (levels module, `schema/json/*` — new home),
+libterrain (substrate verbs — new home), libsecret (`mintSupabaseJwt`,
+`parseDuration`), libconfig (`createScriptConfig` env resolution:
+`supabaseUrl`, `supabaseServiceRoleKey`, `supabaseJwtSecret`), libcli
+(`formatTable`, `formatError`, `formatSuccess`), libutil (runtime, `isoTimestamp`),
+libsyntheticgen (DSL persona enrichment), libmock (`createTestRuntime`).
+
+## Risks
+
+- **The current wrapper's `jq -r .email` reads a field the pick payload does
+  not carry at top level** (`substrate pick --format json` emits
+  `{personas:[…]}`). Part 04 extracts `.personas[0].email`. This corrects the
+  extraction while switching CLIs — reviewers should not read it as
+  behaviour drift; the payload shape itself is unchanged.
+- **`substrate.evidence` shares its name with map's vendor `activity.evidence`
+  table.** Any terrain query built from a client not bound to
+  `db.schema = "substrate"` would silently read the wrong relation through
+  the default search path. Part 02's client factory is the only construction
+  site and a unit test pins the schema binding (SC4).
+- **The contract persona row drops `github_username`** (not a contract
+  column). `kata-interview`'s persona template does not reference it, but the
+  implementer of part 02 must confirm no supervisor prompt or action consumes
+  it from the pick payload before deleting the field.
+- **Stage needs two clients after part 03**: the activity-schema client for
+  seed, and a substrate-schema client for provision and smoke. Passing the
+  activity client to the moved provision would fail with "relation people
+  not found" only at CI time.
+- **Publish coupling.** `libskill`, `libterrain`, and `map` must release
+  together: `map@0.15.x` consumers of `./levels` / `./schema/json/*` take a
+  breaking bump, and `map`'s new `libterrain` dependency must resolve to the
+  version carrying the substrate verbs. `kata-release-cut` owns the bump
+  levels; the constraint to record there is "one release train, map last".
+- **Map's discovery strictness moves, not disappears.** The library degrades
+  declaredly when `substrate.discovery` is empty or absent; the FI
+  requirement that discovery resolves is enforced by map's smoke
+  (`assertDiscoveryResolves`), which part 03 keeps.
+
+## Execution recommendation
+
+| Sequencing | Notes |
+| --- | --- |
+| 01 → 02 → 03 → 04 sequential | Each depends on the previous; repo green after every part |
+| 05 ∥ 06 parallel after 02 | Documentation of the verbs and the Polaris reference need only the library surface; they can land while 03/04 are in flight |
+
+Route parts 01–04 and 06 to `staff-engineer` via `kata-implement`; route
+part 05 to `technical-writer` (guide + skill prose, with the CLI
+`documentation`-array parity edits included so skill/CLI stay in one commit).
+Each part lands as one PR.

--- a/specs/2180-terrain-substrate-contract/plan-a.md
+++ b/specs/2180-terrain-substrate-contract/plan-a.md
@@ -30,11 +30,11 @@ library takes them only as required options.
 | [05](plan-a-05.md) | Contract guide, skills, docs | Substrate Contract guide, `fit-terrain`/`fit-map` skill + CLI doc parity, provisioning guide + verb-doc sweep | 03 |
 | [06](plan-a-06.md) | Polaris reference wiring | `references/bionova-apps/` drops `@forwardimpact/map`, documents the full `up → init → check → provision → pick → issue` loop | 02 |
 
-Libraries used: libskill (levels module, `schema/json/*` — new home),
-libterrain (substrate verbs — new home), libsecret (`mintSupabaseJwt`,
-`parseDuration`), libconfig (`createScriptConfig` env resolution:
-`supabaseUrl`, `supabaseServiceRoleKey`, `supabaseJwtSecret`), libcli
-(`formatTable`, `formatError`, `formatSuccess`), libutil (runtime, `isoTimestamp`),
+Libraries used: libskill (levels module, `schema/json/*` — new home), libterrain
+(substrate verbs — new home), libsecret (`mintSupabaseJwt`, `parseDuration`),
+libconfig (`createScriptConfig` env resolution: `supabaseUrl`,
+`supabaseServiceRoleKey`, `supabaseJwtSecret`), libcli (`formatTable`,
+`formatError`, `formatSuccess`), libutil (runtime, `isoTimestamp`),
 libsyntheticgen (DSL persona enrichment), libmock (`createTestRuntime`).
 
 ## Risks

--- a/specs/2180-terrain-substrate-contract/plan-a.md
+++ b/specs/2180-terrain-substrate-contract/plan-a.md
@@ -27,7 +27,7 @@ library takes them only as required options.
 | [02](plan-a-02.md) | libterrain substrate verbs | `substrate` module (client, contract, persona query, enricher, pick memory, auth users), six verbs, CLI wiring, unit tests | 01 |
 | [03](plan-a-03.md) | map after the move | Contract-view migration + API exposure, four verbs deleted, stage/smoke/`auth issue` repointed, tests | 02 |
 | [04](plan-a-04.md) | Interview workflow wiring | `persona-select-command` switches to `fit-terrain`, shape-test assertions | 03 |
-| [05](plan-a-05.md) | Contract guide, skills, docs | Substrate Contract guide, `fit-terrain`/`fit-map` skill + CLI doc parity, provisioning guide repoint | 02 |
+| [05](plan-a-05.md) | Contract guide, skills, docs | Substrate Contract guide, `fit-terrain`/`fit-map` skill + CLI doc parity, provisioning guide + verb-doc sweep | 03 |
 | [06](plan-a-06.md) | Polaris reference wiring | `references/bionova-apps/` drops `@forwardimpact/map`, documents the full `up → init → check → provision → pick → issue` loop | 02 |
 
 Libraries used: libskill (levels module, `schema/json/*` — new home),
@@ -71,8 +71,9 @@ libsyntheticgen (DSL persona enrichment), libmock (`createTestRuntime`).
 
 | Sequencing | Notes |
 | --- | --- |
-| 01 → 02 → 03 → 04 sequential | Each depends on the previous; repo green after every part |
-| 05 ∥ 06 parallel after 02 | Documentation of the verbs and the Polaris reference need only the library surface; they can land while 03/04 are in flight |
+| 01 → 02 → 03 → 04 sequential | Each depends on the previous; repo green after every part. Part 04 additionally waits for the release cut (see its risk) |
+| 06 parallel after 02 | The Polaris reference needs only the library surface and touches no map file |
+| 05 after 03 | Part 05 edits `products/map/bin/fit-map.js` and the fit-map skill that part 03 also touches, and must not document verbs as gone while the shipped CLI still has them |
 
 Route parts 01–04 and 06 to `staff-engineer` via `kata-implement`; route
 part 05 to `technical-writer` (guide + skill prose, with the CLI


### PR DESCRIPTION
Implementation plan for spec 2180 (design merged in #1910, commit `d557abf`).

## What this plan covers

Six independently executable parts translating `specs/2180-terrain-substrate-contract/design-a.md` into steps:

| Part | Scope |
| --- | --- |
| 01 | Levels module + 13 JSON schemas move to `libskill`; every import, importmap, CI cache key, and website-publish path repoints; `libterrain` schema-dir resolves from `libskill` — no library depends on `map` afterward (SC1–SC3) |
| 02 | `fit-terrain substrate init\|check\|provision\|pick\|roster\|issue` behind the Substrate Contract: schema-bound client, contract-relation persona query, enricher/pick-memory/auth-users ports, unit tests (SC4, SC5) |
| 03 | The clean break in `map`: contract-view migration over `activity.*` + API exposure, four verbs deleted, stage/smoke/`auth issue` consume the `libterrain` capabilities (SC6, SC7) |
| 04 | `kata-interview.yml` persona step switches to `fit-terrain` with explicit `--memory` / `--token-env`; shape-test assertions; gated on the release cut (SC8) |
| 05 | Substrate Contract guide + skill/CLI documentation parity + sweep of every doc commanding the moved verbs (SC9) |
| 06 | `references/bionova-apps/` (Polaris) drops `@forwardimpact/map` and documents the full `up → init → check → provision → pick → issue` loop (SC10) |

The Polaris reference update requested alongside this plan is part 06 — it is inside spec 2180's scope (success criterion 10), so it stays in this plan rather than a second one (one plan per spec).

## Review

Clean sub-agent panel (3 × engineering reviewers, kata-review protocol) ran on the draft at `7c6d984`: 0 blockers, 2 confirmed highs (pathway importmaps, doc sweep) and all consensus mediums addressed in `4ee0d49`; two false findings dismissed with rationale in the commit message.

Panel-clean SHA: `7c6d984` · Amendment SHA: `4ee0d49` (dual-SHA record per kata-plan § Post-panel coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcSX5W7CbNAAGxa1XprcSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcSX5W7CbNAAGxa1XprcSM)_