### PR TITLE
feat(kata): interview persona step picks and issues via fit-terrain (#2180)

### DIFF
--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -42,12 +42,16 @@ jobs:
     timeout-minutes: 50
     steps:
       # Thin wrapper over the reusable action. The only monorepo-specific
-      # knowledge lives here: which products are substrate-backed, and the FI
-      # substrate + persona commands. The action gates all substrate steps on
-      # `substrate-setup-command != ''` — so a file-only product passes an
-      # empty command and skips bring-up, persona selection, and the log scan.
-      # `bunx fit-map` is the sole remaining documented exception (fit-map
-      # ships in the map release, not the gear bundle on PATH).
+      # knowledge lives here: which products are substrate-backed, the FI
+      # substrate + persona commands, and the FI values the persona step
+      # carries explicitly (pick memory at wiki/kata-interview/picks.csv,
+      # issued token named PRODUCT_LANDMARK_TOKEN). The action gates all
+      # substrate steps on `substrate-setup-command != ''` — so a file-only
+      # product passes an empty command and skips bring-up, persona
+      # selection, and the log scan. `bunx fit-map` appears only in
+      # `substrate-setup-command` (fit-map ships in the map release, not the
+      # gear bundle on PATH); the persona step runs `fit-terrain`, which is
+      # on PATH in the action.
       - uses: ./products/kata/actions/kata-interview
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
@@ -58,7 +62,7 @@ jobs:
           job: ${{ inputs.job }}
           task-amend: ${{ inputs.task-amend }}
           substrate-setup-command: ${{ contains(fromJSON('["landmark"]'), inputs.product) && format('SUBSTRATE_FORCE_EMPTY_CORPUS={0} bunx fit-map substrate stage --cwd "$AGENT_CWD" --emit-env "$GITHUB_ENV"', inputs.empty-corpus-test) || '' }}
-          persona-select-command: ${{ contains(fromJSON('["landmark"]'), inputs.product) && 'persona=$(bunx fit-map substrate pick --format json) && printf ''%s\n'' "$persona" && email=$(printf ''%s'' "$persona" | jq -r .email) && bunx fit-map substrate issue --email "$email" --cwd "$AGENT_CWD" --stash "$RUNNER_TEMP/.persona-jwt"' || '' }}
+          persona-select-command: ${{ contains(fromJSON('["landmark"]'), inputs.product) && 'persona=$(fit-terrain substrate pick --format json --memory "wiki/kata-interview/picks.csv") && printf ''%s\n'' "$persona" && email=$(printf ''%s'' "$persona" | jq -r ''.personas[0].email'') && fit-terrain substrate issue --email "$email" --cwd "$AGENT_CWD" --token-env PRODUCT_LANDMARK_TOKEN --stash "$RUNNER_TEMP/.persona-jwt"' || '' }}
           jwt-secret: ${{ secrets.SUPABASE_JWT_SECRET }}
           service-role-key: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           killswitch: ${{ vars.KATA_KILLSWITCH }}

--- a/.github/workflows/test/kata-interview-shape.test.js
+++ b/.github/workflows/test/kata-interview-shape.test.js
@@ -105,3 +105,43 @@ describe("kata-interview.yml wrapper", () => {
     );
   });
 });
+
+describe("kata-interview.yml wrapper persona step", () => {
+  const step = wf.jobs.interview.steps.find(
+    (s) => s.uses === "./products/kata/actions/kata-interview",
+  );
+  const withMap = step.with;
+  const persona = String(withMap["persona-select-command"]);
+
+  it("picks and issues via fit-terrain substrate", () => {
+    assert.match(persona, /fit-terrain substrate pick/);
+    assert.match(persona, /fit-terrain substrate issue/);
+  });
+
+  it("extracts the picked email from the pick payload's personas array", () => {
+    assert.match(persona, /\.personas\[0\]\.email/);
+  });
+
+  it("carries the FI pick memory path and token name explicitly", () => {
+    assert.match(persona, /--memory "wiki\/kata-interview\/picks\.csv"/);
+    assert.match(persona, /--token-env PRODUCT_LANDMARK_TOKEN/);
+  });
+
+  it("contains no fit-map invocation", () => {
+    assert.doesNotMatch(persona, /fit-map/);
+  });
+
+  it("fit-map appears only in substrate-setup-command across the with: map", () => {
+    for (const [key, value] of Object.entries(withMap)) {
+      if (key === "substrate-setup-command") {
+        assert.match(String(value), /bunx fit-map substrate stage/);
+        continue;
+      }
+      assert.doesNotMatch(
+        String(value),
+        /fit-map/,
+        `unexpected fit-map invocation in ${key}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Part 04 of plan 2180-a — the interview workflow wiring deferred out of #1912.

Reverts the pre-merge deferral `6ba77a9f`, restoring the persona-step switch:

- `kata-interview.yml` `persona-select-command` moves from `bunx fit-map substrate pick/issue` to `fit-terrain substrate pick --memory "wiki/kata-interview/picks.csv"` + `fit-terrain substrate issue --token-env PRODUCT_LANDMARK_TOKEN`, with the corrected `.personas[0].email` extraction.
- Shape test pins the new command form (fit-terrain pick/issue present, `fit-map` only in `substrate-setup-command`). 11/11 pass.

**Merge gate (plan-a-04 § Risks):** the interview runner installs `fit-terrain` as a pre-built binary via the bootstrap action. The spec-2180 train (`libskill@6.2.0`, `libterrain@0.1.41`, `map@0.15.63` + 6 more) is live on npm, but the `gear@v0.1.15` binaries are still waiting on the `macos-signing` deployment approval, after which `FIT_GEAR_RELEASE` gets repinned. Merge only after that repin lands.

https://claude.ai/code/session_01Pbkjsvf8AAvixdhkGxZbCp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pbkjsvf8AAvixdhkGxZbCp)_