### PR TITLE
chore(bootstrap): install the five kata-used fit-* CLIs by default

### DIFF
--- a/.github/actions/bootstrap/fit-install.sh
+++ b/.github/actions/bootstrap/fit-install.sh
@@ -29,10 +29,12 @@ LIB_DIR="$PREFIX/lib"
 # Default dev/CI tool set, in install order — the third-party external tools
 # every job needs (scripts/bootstrap.sh runs `just`), `claude` (the Claude Code
 # native CLI the Agent SDK spawns — fit-harness/fit-benchmark point at it via
-# pathToClaudeCodeExecutable), plus coaligned, our own gear binary that the
-# instruction checks run. This set is ALWAYS installed; any named gear CLIs add
-# to it. The same list drives `--paths`.
-DEFAULT_TOOLS=(apm just gh rg gitleaks claude coaligned)
+# pathToClaudeCodeExecutable), plus our own gear binaries: coaligned, which the
+# instruction checks run, and the five fit-* CLIs the kata-* skills invoke.
+# This set is ALWAYS installed; any named gear CLIs add to it. The same list
+# drives `--paths`.
+DEFAULT_TOOLS=(apm just gh rg gitleaks claude coaligned
+  fit-wiki fit-xmr fit-trace fit-doc fit-terrain)
 
 # ── gear binary release coordinates ──────────────────────────────
 # Every installable gear binary (fit-trace, fit-wiki, fit-harness, …, plus


### PR DESCRIPTION
## Summary

- Add `fit-wiki`, `fit-xmr`, `fit-trace`, `fit-doc`, and `fit-terrain` to `DEFAULT_TOOLS` in `.github/actions/bootstrap/fit-install.sh`, so a bare run installs them alongside the external tools and `coaligned`.
- These are the five fit-* CLIs the kata-* skills invoke; previously they were only available via `bunx`/`npx` unless named explicitly, so environments bootstrapped without arguments lacked them on PATH.
- Verified: `--paths` emits the five new bin paths, explicit names still dedupe, unknown tools still fail hard, and a bare run downloads and SHA-verifies all five from the pinned `gear@v0.1.14` release.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01KvJPJ61etEWexTen7dEd3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvJPJ61etEWexTen7dEd3N)_