### PR TITLE
feat(kata): switch interview persona step to fit-terrain (#2180)

### DIFF
--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -46,8 +46,11 @@ jobs:
       # substrate + persona commands. The action gates all substrate steps on
       # `substrate-setup-command != ''` — so a file-only product passes an
       # empty command and skips bring-up, persona selection, and the log scan.
-      # `bunx fit-map` is the sole remaining documented exception (fit-map
-      # ships in the map release, not the gear bundle on PATH).
+      # Persona pick/issue run `fit-terrain` (on PATH via the gear bundle) and
+      # carry the FI-specific values — pick memory and the issued token name —
+      # as explicit options. `bunx fit-map substrate stage` is the sole
+      # remaining `fit-map` exception (fit-map ships in the map release, not
+      # the gear bundle on PATH).
       - uses: ./products/kata/actions/kata-interview
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
@@ -58,7 +61,7 @@ jobs:
           job: ${{ inputs.job }}
           task-amend: ${{ inputs.task-amend }}
           substrate-setup-command: ${{ contains(fromJSON('["landmark"]'), inputs.product) && format('SUBSTRATE_FORCE_EMPTY_CORPUS={0} bunx fit-map substrate stage --cwd "$AGENT_CWD" --emit-env "$GITHUB_ENV"', inputs.empty-corpus-test) || '' }}
-          persona-select-command: ${{ contains(fromJSON('["landmark"]'), inputs.product) && 'persona=$(bunx fit-map substrate pick --format json) && printf ''%s\n'' "$persona" && email=$(printf ''%s'' "$persona" | jq -r .email) && bunx fit-map substrate issue --email "$email" --cwd "$AGENT_CWD" --stash "$RUNNER_TEMP/.persona-jwt"' || '' }}
+          persona-select-command: ${{ contains(fromJSON('["landmark"]'), inputs.product) && 'persona=$(fit-terrain substrate pick --format json --memory "wiki/kata-interview/picks.csv") && printf ''%s\n'' "$persona" && email=$(printf ''%s'' "$persona" | jq -r ''.personas[0].email'') && fit-terrain substrate issue --email "$email" --cwd "$AGENT_CWD" --token-env PRODUCT_LANDMARK_TOKEN --stash "$RUNNER_TEMP/.persona-jwt"' || '' }}
           jwt-secret: ${{ secrets.SUPABASE_JWT_SECRET }}
           service-role-key: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           killswitch: ${{ vars.KATA_KILLSWITCH }}

--- a/.github/workflows/test/kata-interview-shape.test.js
+++ b/.github/workflows/test/kata-interview-shape.test.js
@@ -105,3 +105,41 @@ describe("kata-interview.yml wrapper", () => {
     );
   });
 });
+
+describe("kata-interview.yml persona-select-command", () => {
+  const step = wf.jobs.interview.steps.find(
+    (s) => s.uses === "./products/kata/actions/kata-interview",
+  );
+  const withMap = step?.with ?? {};
+  const personaSelect = String(withMap["persona-select-command"] ?? "");
+
+  it("drives persona pick and issue through fit-terrain", () => {
+    assert.match(personaSelect, /fit-terrain substrate pick/);
+    assert.match(personaSelect, /fit-terrain substrate issue/);
+  });
+
+  it("carries the FI pick-memory path and issued-token name as options", () => {
+    assert.match(personaSelect, /--memory "wiki\/kata-interview\/picks\.csv"/);
+    assert.match(personaSelect, /--token-env PRODUCT_LANDMARK_TOKEN/);
+  });
+
+  it("invokes no fit-map — the persona step is terrain-only", () => {
+    assert.doesNotMatch(personaSelect, /fit-map/);
+  });
+
+  it("uses fit-map only in substrate-setup-command across the with: map", () => {
+    for (const [key, value] of Object.entries(withMap)) {
+      if (key === "substrate-setup-command") continue;
+      assert.doesNotMatch(
+        String(value),
+        /fit-map/,
+        `fit-map must not appear in "${key}"`,
+      );
+    }
+    assert.match(
+      String(withMap["substrate-setup-command"]),
+      /fit-map/,
+      "substrate-setup-command should still invoke fit-map",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Part 04 of spec 2180. Switches the `kata-interview` wrapper workflow's `persona-select-command` from the removed `fit-map substrate pick|issue` verbs to `fit-terrain substrate pick|issue`, now published in the release train that carries libterrain's substrate verbs.
- FI-specific literals move up into the workflow as explicit options: the pick memory path (`--memory wiki/kata-interview/picks.csv`) and the issued-token name (`--token-env PRODUCT_LANDMARK_TOKEN`). `bunx fit-map substrate stage` stays the sole remaining `fit-map` line.
- The email extraction corrects to `.personas[0].email` — the path the pick payload has always carried — while switching CLIs (payload shape unchanged).
- Adds shape-test assertions pinning `persona-select-command` to fit-terrain pick+issue, the memory path, the token name, no `fit-map`, and that `fit-map` appears only in `substrate-setup-command` across the `with:` map (SC8).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bat741y2vza5Cf6cc4XEn7)_