### PR TITLE
feat(coaligned-setup): ship a generic starter invariant

### DIFF
--- a/.claude/skills/coaligned-setup/SKILL.md
+++ b/.claude/skills/coaligned-setup/SKILL.md
@@ -63,10 +63,29 @@ Do not restate one file in another. CLAUDE.md orients; CONTRIBUTING.md governs.
 
 ### Step 3 — Create the invariant directory
 
-Create `.coaligned/invariants/`. Leave it empty for now, or add a first rule
-module with coaligned-invariant. The directory is where the repo's own
-declarative checks live; `coaligned invariants` discovers every `*.rules.mjs`
-under it.
+Create `.coaligned/invariants/` and seed it with the starter rule. The
+directory is where the repo's own declarative checks live; `coaligned
+invariants` discovers every `*.rules.mjs` under it, so an empty directory
+enforces nothing and the wired check has nothing to prove.
+
+Copy the bundled starter rule verbatim so every new repo begins with one live
+invariant:
+
+```sh
+cp .claude/skills/coaligned-setup/assets/no-conflict-markers.rules.mjs \
+   .coaligned/invariants/
+```
+
+[`no-conflict-markers`](assets/no-conflict-markers.rules.mjs) fails any tracked
+file that carries a leftover git merge-conflict marker. It is generic by
+design — language-agnostic, zero-configuration, and firing only on an
+unambiguous defect — so it holds in any consuming repository from the first
+commit. It also proves the pipeline end to end: the directory is discovered, a
+module loads, and a planted marker fails the check.
+
+Add repo-specific rules on top with
+[coaligned-invariant](../coaligned-invariant/SKILL.md); keep or remove the
+starter once the repo has invariants of its own.
 
 ### Step 4 — Wire the checks into the repository
 
@@ -102,7 +121,8 @@ the same way [coaligned-audit](../coaligned-audit/SKILL.md) does.
 
 - [ ] `CLAUDE.md`, `CONTRIBUTING.md`, and `JTBD.md` exist and stay within
       their caps.
-- [ ] `.coaligned/invariants/` exists.
+- [ ] `.coaligned/invariants/` exists and holds the `no-conflict-markers`
+      starter rule.
 - [ ] The check is wired into the repository's check command and CI through an
       invocation a clean runner resolves, with the concrete command in
       CONTRIBUTING.md.

--- a/.claude/skills/coaligned-setup/assets/no-conflict-markers.rules.mjs
+++ b/.claude/skills/coaligned-setup/assets/no-conflict-markers.rules.mjs
@@ -1,0 +1,40 @@
+// Invariant: no tracked file may contain a leftover git merge-conflict marker —
+// a line that begins with seven `<` or seven `>` characters followed by a label
+// (`<{7} HEAD`, `>{7} branch`). Git writes these when a merge or rebase
+// conflicts; committing them ships a broken, often unparseable file. This is
+// the generic starter rule coaligned-setup drops into every new repository: it
+// applies to any language, needs no configuration, and fires only on a real,
+// unambiguous problem. Delete it once the repo has invariants of its own, or
+// keep it — an unresolved conflict is never intended.
+//
+// The pattern is written with the `<{7}`/`>{7}` regex quantifier rather than a
+// literal run of the characters, so this module never matches itself. The
+// middle `=======` separator is deliberately left out: a run of seven `=` on
+// its own line occurs legitimately (reStructuredText and some Markdown section
+// underlines), and the begin/end markers already prove a conflict on their own.
+
+const CONFLICT_MARKER = "^(<{7}|>{7})[ \\t]";
+
+export default {
+  name: "no-conflict-markers",
+
+  build({ grep }) {
+    return {
+      subjects: {
+        "conflict-marker": grep({
+          pattern: CONFLICT_MARKER,
+          caseSensitive: true,
+          dedupe: (m) => `${m.rel}:${m.lineNo}`,
+        }),
+      },
+    };
+  },
+
+  rules: ({ failAll }) => [
+    failAll("conflict-marker", {
+      id: "no-conflict-markers.present",
+      message: (s) => `leftover merge-conflict marker: ${s.text.trim()}`,
+      hint: "resolve the conflict and delete the marker lines git inserted, then re-run the check",
+    }),
+  ],
+};


### PR DESCRIPTION
## Summary

- `coaligned-setup` Step 3 now seeds `.coaligned/invariants/` with a bundled starter rule, so a freshly bootstrapped repo begins with one live invariant instead of an empty directory that enforces nothing.
- Adds `no-conflict-markers.rules.mjs` under the skill's `assets/`: it fails any tracked file carrying a leftover git merge-conflict marker (a line beginning with seven `<` or seven `>` plus a label). It is language-agnostic, needs no configuration, and fires only on an unambiguous defect, so it holds in any consuming repo from the first commit and proves the invariant pipeline end to end.
- Updates the "Done When" checklist to require the starter rule's presence.

## Test plan

- [x] `coaligned instructions` passes (SKILL.md stays within its length cap)
- [x] `coaligned invariants` passes (the asset lives under `.claude/skills/`, so it is not discovered here and no existing rule flags it)
- [x] Isolated temp-repo check: rule passes on clean code and fails on planted begin/end markers, while the `=======` separator is correctly ignored


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fwe7Sa774F5QinsV7RRCrV)_