### PR TITLE
fix(release): regenerate gear cask binary block from cli-manifest.json

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -340,10 +340,20 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
           path: tap
 
+      # The cask's binary block is regenerated from cli-manifest.json, so the
+      # manifest and its render script must travel with this job.
+      - name: Checkout monorepo for the cask render script
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          path: main
+          persist-credentials: false
+
       - name: Update cask and push to tap main
         working-directory: tap
         env:
           CASK: ${{ needs.meta.outputs.cask }}
+          BUNDLE: ${{ needs.meta.outputs.bundle }}
+          KIND: ${{ needs.meta.outputs.kind }}
           VERSION: ${{ needs.meta.outputs.version }}
           SHA256: ${{ steps.hash.outputs.sha256 }}
           KATA_APP_ID: ${{ secrets.KATA_APP_ID }}
@@ -351,13 +361,20 @@ jobs:
           set -euo pipefail
           git config user.name "kata-agent-team[bot]"
           git config user.email "${KATA_APP_ID}+kata-agent-team[bot]@users.noreply.github.com"
-          # Only version + sha256 are bumped per release; the cask body (binary
-          # stanzas, livecheck) is human-edited and survives.
           CASK_FILE="Casks/${CASK}.rb"
+          # version + sha256 are per-release; sed them in place.
           sed -i \
             -e "s|^  version \".*\"|  version \"${VERSION}\"|" \
             -e "s|^  sha256 \".*\"|  sha256 \"${SHA256}\"|" \
             "$CASK_FILE"
+          # The gear cask links ~30 CLIs — regenerate that block from the
+          # manifest so it can never drift from the bundle (a stale name fails
+          # `brew install` at link time). Product casks link one binary and
+          # keep their hand-written stanza.
+          if [ "$KIND" = gear ]; then
+            bash ../main/build/render-cask-binaries.sh "$CASK_FILE" "$BUNDLE"
+            ruby -c "$CASK_FILE"
+          fi
           git add "$CASK_FILE"
           git commit -m "Update ${CASK} to ${VERSION}"
           git push origin HEAD:main

--- a/build/render-cask-binaries.sh
+++ b/build/render-cask-binaries.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Rewrite a Homebrew cask's `binary` block from build/cli-manifest.json so the
+# linked binaries can never drift from the ones the app bundle actually ships.
+#
+#   Usage: build/render-cask-binaries.sh <cask-file> <bundle>
+#
+# The block sits between the `app "..."` line and `livecheck do` — both stable,
+# unique cask lines. Everything between them is regenerated in manifest order:
+# `server: true` CLIs first (the gRPC services), then the rest.
+set -euo pipefail
+
+CASK_FILE="${1:?usage: render-cask-binaries.sh <cask-file> <bundle>}"
+BUNDLE="${2:?usage: render-cask-binaries.sh <cask-file> <bundle>}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$ROOT/build/cli-manifest.json"
+
+APP="fit-${BUNDLE}"
+PREFIX="  binary \"#{appdir}/Forward Impact/${APP}.app/Contents/MacOS/"
+
+emit_stanzas() {
+  local filter="$1"
+  jq -r --arg b "$BUNDLE" "$filter" "$MANIFEST" \
+    | while IFS= read -r cli; do
+        printf '%s%s"\n' "$PREFIX" "$cli"
+      done
+}
+
+# Render the block to a temp file — awk reads it line by line, which stays
+# portable across gawk (CI) and macOS's BWK awk (rejects newlines in -v vars).
+BLOCK_FILE="$(mktemp)"
+trap 'rm -f "$BLOCK_FILE"' EXIT
+{
+  echo ""
+  echo "  # gRPC services"
+  emit_stanzas '.clis[] | select(.bundle == $b and .server == true) | .name'
+  echo ""
+  echo "  # Library CLIs"
+  emit_stanzas '.clis[] | select(.bundle == $b and (.server != true)) | .name'
+} > "$BLOCK_FILE"
+
+# Splice: keep everything through the `app` line, drop the old binary region,
+# resume at `livecheck do`.
+awk -v blockfile="$BLOCK_FILE" '
+  /^  app "/ {
+    print
+    while ((getline line < blockfile) > 0) print line
+    close(blockfile)
+    print ""
+    skip = 1
+    next
+  }
+  /^  livecheck do/ { skip = 0 }
+  skip { next }
+  { print }
+' "$CASK_FILE" > "$CASK_FILE.tmp"
+mv "$CASK_FILE.tmp" "$CASK_FILE"


### PR DESCRIPTION
## Problem

A customer's `brew install --cask forwardimpact/tap/fit-gear` fails at the linking step and rolls the whole install back:

```
Error: It seems the symlink source '/Applications/Forward Impact/fit-gear.app/Contents/MacOS/fit-eval' is not there.
```

## Root cause

The `libeval → libharness` rename (spec 2110) renamed the `fit-eval` CLI to `fit-harness`. `build/cli-manifest.json` and the `.app` bundle followed, but the tap cask's hand-maintained `binary` block did not. The release workflow's `tap` job only `sed`s `version` + `sha256` (`publish-binaries.yml`), so **no manifest change could ever reach the cask**. The same gap left three newer gear CLIs unlinked: `fit-benchmark`, `fit-pack`, `coaligned`.

## Fix

The gear cask links ~30 CLIs and is the one prone to drift. Regenerate its `binary` block from `build/cli-manifest.json` at release time so the linked binaries can never diverge from what the bundle ships.

- `build/render-cask-binaries.sh` splices the block between the stable `app "..."` and `livecheck do` anchor lines, in manifest order (`server: true` services first, then the rest). Idempotent; portable across gawk (CI) and macOS's BWK awk.
- The `tap` job checks out the monorepo for the manifest + script and runs it for `kind == gear`, then `ruby -c` validates the result. Product casks link one binary and keep their hand-written stanza.

### Verification

Reconstructed the drifted `0.1.15` cask (with `fit-eval`, missing the three new CLIs), ran the script, and confirmed it produces a cask byte-identical to the corrected one, passes `ruby -c`, and is idempotent on a second run.

## Companion

Immediate unblock for the shipped `0.1.15`: forwardimpact/homebrew-tap#73 (casks resolve from tap HEAD, so no re-release needed). This PR prevents recurrence; after both land, the next `gear@v*` release reproduces the corrected block automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)