### PR TITLE
feat(coaligned): point CONTRIBUTING.md at the invariant tooling in setup

### DIFF
--- a/.claude/skills/coaligned-setup/SKILL.md
+++ b/.claude/skills/coaligned-setup/SKILL.md
@@ -43,8 +43,9 @@ Run this once per repository. For ongoing work use the sibling skills:
       their caps.
 - [ ] `CLAUDE.md` carries a Jobs and Checklists section pointing at JTBD.md and
       the tagged pause-point checklists.
-- [ ] `.coaligned/invariants/` exists and holds the `no-conflict-markers`
-      starter rule.
+- [ ] `.coaligned/invariants/` holds the `no-conflict-markers` starter rule, and
+      CONTRIBUTING.md points at the invariants tooling for finding and adding
+      rules.
 - [ ] The check is wired into the repository's check command and CI through an
       invocation a clean runner resolves, with the concrete command in
       CONTRIBUTING.md.
@@ -89,8 +90,9 @@ its cap (L1 ≤ 192 lines; L2 ≤ 320 lines).
 
   Keep the tag names verbatim — they are the discovery contract contributors
   and the `coaligned` checks rely on.
-- **`CONTRIBUTING.md`** (L2) — contribution standards: invariants, the quality
-  commands, security policy, and the universal checklists.
+- **`CONTRIBUTING.md`** (L2) — contribution standards: the architectural
+  invariants, the quality commands, security policy, and the universal
+  checklists.
 - **`JTBD.md`** (L2) — the jobs, per Step 1. Use coaligned-jtbd to author
   entries to spec.
 
@@ -121,6 +123,13 @@ module loads, and a planted marker fails the check.
 Add repo-specific rules on top with
 [coaligned-invariant](../coaligned-invariant/SKILL.md); keep or remove the
 starter once the repo has invariants of its own.
+
+Point CONTRIBUTING.md at this layer so contributors can find and extend it:
+where the rules live (`.coaligned/invariants/*.rules.mjs`), the `coaligned
+invariants` command that runs them, and
+[coaligned-invariant](../coaligned-invariant/SKILL.md) for authoring a rule.
+This is the invariant *tooling* — distinct from the architectural
+non-negotiables CONTRIBUTING.md already states in prose.
 
 ### Step 4: Wire the checks into the repository
 

--- a/benchmarks/coaligned-skills/README.md
+++ b/benchmarks/coaligned-skills/README.md
@@ -13,7 +13,7 @@ agent's working directory.
 
 | Task | Skill exercised | Agent produces | Grading |
 | --- | --- | --- | --- |
-| `bootstrap-repo` | `coaligned-setup` | `CLAUDE.md`, `CONTRIBUTING.md`, `JTBD.md`, `.coaligned/invariants/` | Invariants (files exist; `CLAUDE.md` surfaces job **and** checklist discovery; `JTBD.md` carries a `<job>`; starter rule present) + judge (orients not governs, faithful to the project) |
+| `bootstrap-repo` | `coaligned-setup` | `CLAUDE.md`, `CONTRIBUTING.md`, `JTBD.md`, `.coaligned/invariants/` | Invariants (files exist; `CLAUDE.md` surfaces job **and** checklist discovery; `JTBD.md` carries a `<job>`; starter rule present; `CONTRIBUTING.md` points at the invariant tooling) + judge (orients not governs, faithful to the project) |
 | `author-job` | `coaligned-jtbd` | a `<job>` entry appended to `JTBD.md` | Invariants (`<job>` tag with `user`/`goal`, Trigger, Big Hire, Little Hire) + judge (progress not features, trigger is a moment, includes nonconsumption) |
 
 `bootstrap-repo` is the primary task: it exercises the full setup path and

--- a/benchmarks/coaligned-skills/tasks/bootstrap-repo/hooks/invariants.sh
+++ b/benchmarks/coaligned-skills/tasks/bootstrap-repo/hooks/invariants.sh
@@ -33,4 +33,11 @@ assert jtbd-has-job --grep '<job' "$JTBD" \
 assert starter-rule-present --exists "$STARTER" \
   --message "no-conflict-markers starter rule not installed"
 
+# CONTRIBUTING.md points at the invariant tooling — the discovery contract for
+# the layer coaligned-setup creates: where machine-checked rules live and the
+# command that runs them.
+assert contributing-surfaces-invariants \
+  --grep 'coaligned invariants|\.coaligned/invariants' "$CONTRIBUTING" \
+  --message "CONTRIBUTING.md does not point at the invariant tooling"
+
 [ "$FAIL" = 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## What

`coaligned-setup` now instructs the author to point `CONTRIBUTING.md` at the machine-checked invariant tooling, and the `coaligned-skills` benchmark enforces it.

## Why

The skill created `.coaligned/invariants/` and told authors to record the check command in `CONTRIBUTING.md`, but never told them to point contributors at **where** the invariants live (`.coaligned/invariants/*.rules.mjs`), the `coaligned invariants` command that runs them, or `coaligned-invariant` for adding one. That discovery contract was missing from every bootstrapped repo. `CONTRIBUTING.md` is the L2 layer that governs invariants, so the pointer belongs there.

## How

- **No new fragment file.** The skill deliberately templates only `CLAUDE.md`'s verbatim discovery section; it ships no `CONTRIBUTING.md` template because that file is repo-specific. So this strengthens the skill *prose* instead:
  - Step 2 names the **architectural** invariants, so the prose non-negotiables aren't conflated with the tooling.
  - Step 3 instructs pointing `CONTRIBUTING.md` at the invariant tooling (directory, command, `coaligned-invariant`), flagged as distinct from the prose invariants.
  - The exit checklist confirms the pointer exists.
- **Benchmark:** `bootstrap-repo/hooks/invariants.sh` gains a `contributing-surfaces-invariants` assertion (`--grep 'coaligned invariants|\.coaligned/invariants'`); README grading cell updated.

## Verification

Ran `bootstrap-repo` locally against the updated skill (`--skills-from=.`). The agent produced a `CONTRIBUTING.md` with separate `## Architectural Invariants` and `## Invariant Tooling` sections, and the agent-free invariants check returned all 9 green including the new assertion:

```
verdict: pass, exitCode: 0 … contributing-surfaces-invariants ✓
```

`bunx coaligned instructions` passes (SKILL.md within its length cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)