### PR TITLE
docs(contributing): point at the invariant tooling from the Invariants section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,10 @@ Architectural non-negotiables — the shape of the codebase.
   `specs/`, `wiki/`, `benchmarks/`, `generated/` are exempt; rewrite, don't
   port, their content. Enforced by `bun run invariants`.
 
+The mechanically checkable subset lives in `.coaligned/invariants/*.rules.mjs`,
+run by `bun run invariants` (inside `bun run check`). Add a rule with the
+[coaligned-invariant](.claude/skills/coaligned-invariant/SKILL.md) skill.
+
 ### READ-DO
 
 Entry gate — read every item before starting.


### PR DESCRIPTION
## What

Apply the `coaligned-setup` guideline (merged in #1924) to this repo's own `CONTRIBUTING.md`.

## Why

The `### Invariants` section listed the architectural non-negotiables in prose but never pointed contributors at **where** the machine-checked rules live or **how** to add one — the same gap the skill change closed for newly bootstrapped repos. `CONTRIBUTING.md` is the L2 layer that governs invariants, so the pointer belongs there.

## How

A three-line trailing pointer, framed as the *mechanically checkable subset* (not all four prose invariants are machine-checked):

> The mechanically checkable subset lives in `.coaligned/invariants/*.rules.mjs`, run by `bun run invariants` (inside `bun run check`). Add a rule with the [coaligned-invariant](.claude/skills/coaligned-invariant/SKILL.md) skill.

## Budget

L2 cap is 320 lines; file is now 284. `bunx coaligned instructions` passes; `rumdl` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)