### PR TITLE
design(2200): an agent-runtime platform product

### DIFF
--- a/specs/2200-agent-platform-product/design-a.md
+++ b/specs/2200-agent-platform-product/design-a.md
@@ -1,0 +1,167 @@
+# Design 2200 — An agent-runtime platform product
+
+Packages the agent-runtime substrate as a Secondary meta-product (`PLATFORM`,
+name deferred) split cleanly out of Gear along one line: **`PLATFORM` ships what
+you run; Gear ships what you import.** The product has two concrete surfaces —
+an npm meta-package that re-exports the three runtime *libraries*, and a GitHub
+Actions surface (`products/<platform>/actions/`) that owns the composite actions
+which execute the coding agent in CI. Extracting those actions leaves
+`libharness` and `libwiki` as pure libraries; `svctrace` stays in Gear.
+
+## Restated problem
+
+The bootstrap layer plus `fit-harness`/`fit-trace`/`fit-wiki`/`fit-xmr` already
+work and are published, but no product frames them. Their libraries are
+re-exported by Gear (a build-time primitives meta-package), the actions that run
+them hang off library directories, and `bootstrap` is filed as CI plumbing under
+`.github/`. The design gives the substrate one product home — an npm axis and an
+actions axis — and sharpens Gear to a single audience.
+
+## Architecture
+
+Two meta-products, one boundary. `PLATFORM` re-exports the three runtime
+libraries and owns the run actions; Gear keeps the build-time set (including
+`svctrace`). The libraries stay on disk under `libraries/`; only their
+`actions/` subdirectories move into the product.
+
+```mermaid
+flowchart TD
+  subgraph PLATFORM["products/&lt;platform&gt; (new, meta-package)"]
+    direction TB
+    subgraph NPM["npm axis: re-exported libraries"]
+      P1[libharness → fit-harness, fit-trace]
+      P3[libwiki → fit-wiki]
+      P4[libxmr → fit-xmr]
+    end
+    subgraph ACT["actions axis: products/&lt;platform&gt;/actions/"]
+      A0[bootstrap — stand up]
+      A1[harness — run]
+      A2[wiki — remember]
+      A3[benchmark — measure]
+    end
+  end
+  subgraph LIBS["libraries/ (now pure, no actions/)"]
+    L1[libharness]
+    L2[libwiki]
+  end
+  subgraph GEAR["products/gear (refocused, build-time only)"]
+    G1[libgraph / libvector / libresource]
+    G2[librpc / libcodegen / svcmcp / svcgraph / svcvector]
+    G3[libstorage / libdoc / librc / libsupervise / svctrace]
+  end
+  LIBS -. actions extracted to .-> ACT
+  KATA[Kata: reference tenant] -.runs on.-> PLATFORM
+```
+
+The runtime loop the product narrates, on both axes: **stand up** (bootstrap
+action) → **run** (harness action / `fit-harness`) → **see** (`fit-trace`,
+reading NDJSON) → **remember** (wiki action / `fit-wiki`) → **measure**
+(benchmark action / `fit-xmr`).
+
+## Components
+
+| Component | Where | Responsibility |
+| --- | --- | --- |
+| Platform package | `products/<platform>/package.json` (new) | Meta-package: `description`, one Big Hire `jobs` entry (`user` `Teams Using Agents`), `dependencies` = the three runtime libraries. No `bin/`, no `src/`, and — like Gear — no hand-authored `README.md`. |
+| Platform actions | `products/<platform>/actions/{bootstrap,harness,wiki,benchmark}/` (moved) | The composite actions that execute the runtime in CI, relocated from `.github/actions/bootstrap/`, `libraries/libharness/actions/{harness,benchmark}/`, and `libraries/libwiki/actions/wiki/`. |
+| Overview page | `websites/fit/<platform>/index.md` (new) | The "stand up and operate an agent team" story by persona; presents the CLIs and the CI actions as one loop; Getting Started names the bring-up layer. `layout: product`. |
+| Platform skill | `.claude/skills/fit-<platform>/SKILL.md` (new) | When to hire the platform; how the capabilities compose into the loop. No `## Documentation` CLI-parity block — the meta-package ships no CLI of its own (the Gear/Kata `private`/no-`bin` exemption in `products/CLAUDE.md`). |
+| Library purification | `libraries/libharness/`, `libraries/libwiki/` | The `actions/` subdirectories are removed; the libraries become import-only. |
+| Publish workflow repoint | `.github/workflows/publish-actions.yml` | Matrix `prefix:` for `bootstrap`/`harness`/`benchmark`/`wiki` repointed under `products/<platform>/actions/`; `paths:` filter updated. `repo:` sibling names unchanged. |
+| Gear package edit | `products/gear/package.json` | Remove the three runtime library deps; remove the operate-time ("chart agent metrics") promise from `jobs.littleHire`. Keep `svctrace`. |
+| Kata framing | `KATA.md`, overview page | Name Kata as the reference tenant; no `products/kata/` change. Update the `sibling-composite-actions` enum / action-home prose to the new homes. |
+| Generated context + counts | `JTBD.md`, `products/README.md`, `CLAUDE.md` | Regenerate the catalog/JTBD blocks via the context command; hand-edit the `products/README.md` intro count and `CLAUDE.md` § Secondary Products (neither is generated). |
+
+## Interfaces
+
+- **The boundary predicate** — a capability belongs to `PLATFORM` iff you *run*
+  it to operate a team (the harness/wiki/xmr CLIs and the bootstrap/harness/
+  wiki/benchmark actions); it stays in Gear iff you *import* it to build an
+  agent (graph, vector, resource, rpc, codegen, svcmcp, storage, doc, rc,
+  supervise, and `svctrace`). Applied once, it partitions the substrate with no
+  package or action in both.
+- **`svctrace` is import-time, not run-time** — `fit-trace` reads NDJSON emitted
+  by `fit-harness`; it has no dependency on `svctrace`. `svctrace` is an OTel
+  gRPC ingestion service whose product consumer is Guide. It therefore stays in
+  Gear's build-time set and is explicitly excluded from the runtime subset.
+- **Action move is a source repoint, not a republish** — the subtree-split maps
+  a monorepo `prefix:` to a **sibling repo name**. Moving a `prefix:` from
+  `libraries/libharness/actions/harness` to `products/<platform>/actions/harness`
+  changes the source path and the `paths:` filter only; the `harness` sibling
+  repo and every downstream `uses: forwardimpact/harness@v…` pin are untouched.
+  Kata's vendored `action.yml` files pin the sibling repos by name, so they are
+  unaffected too.
+- **Package-granular npm split** — library membership is expressed only in each
+  meta-product's `dependencies`, and a whole library moves as a unit.
+  `libharness` carries `fit-benchmark` and `fit-selfedit` besides
+  `fit-harness`/`fit-trace`; those travel with it into `PLATFORM`, which is
+  correct — benchmarking and self-edit are part of proving and running an agent
+  team, not build-time primitives.
+- **Shared foundation is out of scope** — `libtelemetry`, `libutil`, and similar
+  cross-cutting packages are not in the runtime subset. Wherever Gear re-exports
+  them today is left as-is; `PLATFORM` does not claim them.
+- **Name indirection** — every new path carries the deferred name. The design is
+  correct for any chosen slug; implementation substitutes the resolved name into
+  `<platform>` across the new/edited surfaces at once.
+
+## Key Decisions
+
+| Decision | Choice | Rejected alternative |
+| --- | --- | --- |
+| Product tier | Secondary meta-package mirroring Gear/Kata (re-export list + JTBD + page + skill, no CLI) — plus a `products/<platform>/actions/` surface like `products/kata/actions/`. | A Primary product with its own `fit-<platform>` CLI — invents a command with nothing to do; the capabilities already have CLIs. |
+| Split mechanism | Clean break: runtime library deps move out of Gear into `PLATFORM`; run actions move out of the library dirs into `PLATFORM`; no cross-listing. | Cross-list the runtime packages in both products — leaves two products claiming the same capability, the exact blur being removed (spec SC3). |
+| Boundary line | `run` vs `import` (operate a team vs build an agent), applied to both libraries and actions. | Split by layer (libs vs services) or by "agent-ish vs not" — neither yields a clean single-audience cut. |
+| `svctrace` | Excluded from `PLATFORM`; stays a Gear build-time dep (it is Guide's OTel collector, not `fit-trace`'s source). | Include `svctrace` on the strength of its blurb ("prove agent changes") — but `fit-trace` reads local NDJSON and never touches `svctrace`, so it fails the run predicate. |
+| Run-action home | Move `bootstrap`/`harness`/`benchmark`/`wiki` into `products/<platform>/actions/`; repoint the split `prefix:` only. | Leave them under `.github/` and the library dirs and only narrate them — keeps the run surface scattered and leaves `libharness`/`libwiki` shipping CI actions. |
+| `bootstrap` placement | Move it into the product with the other run actions, accepting that most CI workflows consume it as the base FIT environment. That base environment *is* the platform's stand-up step; every CI job is a tenant of it. | Keep `bootstrap` under `.github/` as neutral infra — leaves the "stand up" step of the loop outside the product and the actions surface incomplete. |
+| JTBD binding | New distinct job *Stand Up and Operate an Agent Team* under `Teams Using Agents`; Kata's existing job untouched. | Re-point Kata's job to `PLATFORM` — erases Kata's ownership of its own hire; or two `user`s on one job — the schema allows one `user` per entry. |
+| Kata relationship | Document Kata as the reference tenant; move no code. | Build a fresh demo tenant to prove genericity — the spec already treats Kata as living proof; a second tenant is unbuilt scope. |
+| Naming | Defer; carry `<platform>` placeholder through every surface. | Pick a name now — the user reserved naming for a later iteration. |
+| Boundary cases | `libdoc`, `librc`, `libsupervise`, `svctrace` stay in Gear; `libterrain` and `svcpathway` deferred, untouched. | Pull `fit-doc`/`fit-terrain` into the platform now — doc fails the run-the-team test; terrain is Map-entangled (spec Scope-out). |
+
+## Data flow
+
+```mermaid
+sequenceDiagram
+  participant Author as this change
+  participant Plat as products/&lt;platform&gt;
+  participant Libs as libraries/{libharness,libwiki}
+  participant Gear as products/gear
+  participant CI as publish-actions.yml
+  participant Ctx as context command + hand edits
+  Author->>Plat: add package.json (deps = 3 runtime libs), page, skill
+  Author->>Libs: git mv actions/* into products/<platform>/actions/ (+ .github bootstrap)
+  Author->>CI: repoint matrix prefix + paths (repo names unchanged)
+  Author->>Gear: remove 3 runtime libs; drop operate-time clause; keep svctrace
+  Author->>Plat: name Kata as reference tenant (KATA.md + page)
+  Author->>Ctx: run context:fix (regenerates JTBD + catalog blocks)
+  Author->>Ctx: hand-edit README intro count + CLAUDE § Secondary + action-home prose
+  Ctx-->>Author: bun run check passes → boundary is single-home (SC1–SC7, SC11)
+```
+
+## Success criteria coverage
+
+| # | Met by |
+| --- | --- |
+| 1 | Platform `package.json` deps = the three runtime libraries, nothing else (no `svctrace`). |
+| 2 | Gear `package.json` edit removes all three runtime libraries. |
+| 3 | Clean-break split (no cross-listing) → each runtime library in exactly one product. |
+| 4 | `svctrace` stays a Gear dep, absent from the platform deps. |
+| 5 | Gear `jobs.littleHire` edit removes the operate-time clause. |
+| 6 | `git mv` of the four action sources into `products/<platform>/actions/`; `libharness`/`libwiki` `actions/` and `.github/actions/bootstrap/` removed. |
+| 7 | `publish-actions.yml` matrix repointed (prefix + paths), sibling `repo:` names unchanged. |
+| 8 | Platform `jobs` array carries one `Teams Using Agents` Big Hire with a goal distinct from Kata's. |
+| 9 | New overview page + skill name the bring-up layer, reference the four runtime CLIs, and present the CI actions as the same loop. |
+| 10 | Kata framed as reference tenant in `KATA.md`/page; no `products/kata/` diff. |
+| 11 | `context:fix` regenerates JTBD + catalog; hand edits fix the intro count, `CLAUDE.md`, and action-home prose; `bun run check` passes. |
+| 12 | Spec § Deferred decisions present; name/terrain/svcpathway untouched. |
+
+## Clean break and scope
+
+The change adds one product and edits one, and regroups the run actions under
+the product. Gear loses the three runtime library deps outright — no shim, no
+deprecation alias — and keeps `svctrace`. No runtime library moves on disk (only
+its `actions/` subdirectory does), the sibling action repos keep their names and
+pins, and `products/kata/` gains no code. The product name, `fit-terrain`'s
+home, and the `svcpathway` mis-filing stay out of scope per the spec, each
+recorded as a deferred decision rather than resolved.

--- a/specs/2200-agent-platform-product/spec.md
+++ b/specs/2200-agent-platform-product/spec.md
@@ -1,0 +1,191 @@
+# Spec 2200 — An agent-runtime platform product
+
+**Classification:** Product — defines a new user-facing product and repositions
+an existing one (Gear); it changes what external personas can hire, not just
+internal tooling.
+
+**Naming is deferred.** This spec commits to the product's existence, job, and
+boundary, not its name. Every identifier below is a placeholder: the product is
+`PLATFORM`, its directory `products/<platform>/`, its package
+`@forwardimpact/<platform>`. `PLATFORM` and `<platform>` denote the same
+deferred token. Naming is an explicit open decision (§ Deferred decisions),
+resolved before implementation; the success criteria are written to hold for
+whatever slug is chosen.
+
+## Problem
+
+The monorepo already ships a working substrate for running an agent team — the
+bootstrap layer plus the `fit-harness`, `fit-trace`, `fit-wiki`, and `fit-xmr`
+CLIs, and the composite actions that execute those CLIs in CI — but no product
+frames it. The substrate is homeless in three ways:
+
+- **Its runtime libraries are buried inside Gear.** Gear is a meta-package that
+  re-exports everything a platform builder might import — retrieval (graph,
+  vector, resource), typed contracts (rpc, codegen), MCP exposure, storage —
+  *and* the agent-runtime libraries. Its one Big Hire, "give humans and agents
+  shared capabilities through the same interface," spans both "query graphs, run
+  vector search, expose services as MCP tools" (build-time primitives) and
+  "chart agent metrics" (operate-time runtime). A team that wants to stand up
+  and run an agent team is told to hire the same grab-bag as a team that wants a
+  vector index.
+- **Its run surface is scattered and mis-filed.** The composite actions that
+  actually execute the agent team in CI — `harness` and `benchmark` under
+  `libraries/libharness/actions/`, `wiki` under `libraries/libwiki/actions/` —
+  hang off library directories, so libraries that should be pure import targets
+  also ship CI actions. The `bootstrap` action and its `fit-install.sh` live
+  under `.github/` as CI plumbing. None of them is named as one product's run
+  surface.
+- **Its bring-up has no product narrative.** The `bootstrap` action,
+  `fit-install.sh`, and `scripts/bootstrap.sh` are the install-and-run story,
+  but they are described only in `.github/CLAUDE.md` as CI plumbing. They are
+  already published (`forwardimpact/bootstrap`) yet nowhere framed as one thing
+  a persona hires.
+
+The result: the substrate has no overview page, no skill, and no JTBD entry that
+says "this is how you stand up and operate an agent team." Kata — the reference
+team that runs on exactly this substrate — reads as the only possible tenant,
+when the substrate is in fact generic and swappable.
+
+### Evidence
+
+| Claim | How to confirm |
+| --- | --- |
+| The agent-runtime libraries ship inside Gear today. | `products/gear/package.json` re-exports `libharness`, `libwiki`, and `libxmr` alongside retrieval/contract/storage packages. |
+| Gear's single job mixes build-time and operate-time. | The Gear `jobs` entry's `littleHire` lists "query graphs, run vector search, expose services as MCP tools, **or chart agent metrics**" — the last clause is the operate-time runtime leaking into a build-time product. |
+| The agent-run actions hang off library directories. | `libraries/libharness/actions/{harness,benchmark}/` and `libraries/libwiki/actions/wiki/` are subtree-split action sources co-located with import-only libraries; `publish-actions.yml` splits each prefix to a sibling repo. |
+| The bring-up layer has no product home. | `.github/actions/bootstrap/` and its `fit-install.sh` are published to siblings but described only in `.github/CLAUDE.md` as CI plumbing; no `websites/fit/<product>/` page or skill names them. |
+| `svctrace` is not part of the agent-run loop. | `fit-trace` (a `libharness` bin) reads **NDJSON** output from `fit-harness`; it references neither gRPC nor OpenTelemetry. `@forwardimpact/svctrace` is "OpenTelemetry span ingestion and storage over gRPC," and its only product consumer is `products/guide`. It is a build-time/retrieval service, not the collector `fit-trace` reads from. |
+| The runtime packages are product-independent and already reused beyond Kata. | `libharness`, `libwiki`, `libxmr` live under `libraries/` (none under `products/kata/`); `fit-install.sh` bundles the `fit-*` runtime CLIs that the `kata-*` skills invoke; and the published `harness`/`wiki` actions are invoked by workflows outside the Kata team run. |
+
+### Who is affected
+
+| Affected | How |
+| --- | --- |
+| Teams Using Agents | Cannot find or hire "the thing you run an agent team on" — it has no name, page, or install story of its own; they must reverse-engineer it out of Gear, `libraries/*/actions/`, and `.github/`. |
+| Platform Builders | Gear's promise is blurred by two audiences; a builder wanting composable primitives wades through agent-runtime concerns and vice versa. |
+| Kata | Reads as the substrate's owner rather than its first tenant, obscuring that the platform is generic and another team could run on it. |
+
+## Proposal
+
+Define a new Secondary meta-product, `PLATFORM`, whose single job is to
+**stand up and operate an agent team**, and split the agent-runtime substrate
+out of Gear (and out of the library directories) into it along one boundary:
+**`PLATFORM` ships what you run; Gear ships what you import.**
+Name Kata as the platform's reference implementation.
+
+`PLATFORM` follows the meta-package shape Gear and Kata already establish — a
+`package.json` with a JTBD and no `bin/`/`src/` of its own (each capability
+keeps its existing CLI) — but its concrete surface is two-sided:
+
+- **An npm axis.** It re-exports the three runtime *libraries* whose CLIs you run
+  to operate a team: `@forwardimpact/libharness` (`fit-harness`, `fit-trace`),
+  `@forwardimpact/libwiki` (`fit-wiki`), and `@forwardimpact/libxmr`
+  (`fit-xmr`).
+- **A GitHub Actions axis.** It owns `products/<platform>/actions/` — the
+  composite actions that execute the coding-agent runtime in CI: `bootstrap`
+  (stand up), `harness` (run), `wiki` (remember), and `benchmark` (measure).
+  These move here from `.github/actions/` and the two library directories,
+  mirroring the precedent that `products/kata/actions/` already sets for a
+  product owning its actions.
+
+Extracting the actions out of `libraries/libharness/` and `libraries/libwiki/`
+leaves those two libraries as pure import targets. Gear sheds the three runtime
+libraries and the "chart agent metrics" clause, leaving one clean promise:
+composable primitives you build agents *with*. `svctrace` stays in Gear — it is
+a build-time/retrieval service (Guide's OTel collector), never part of the run
+loop.
+
+**JTBD relationship.** The primary persona is **Teams Using Agents**. Its
+existing job, *Run a Continuously Improving Agent Team*, is Kata-owned (both its
+hires resolve to Kata) and stays unchanged — that job is the reference tenant.
+`PLATFORM` adds a new, distinct job for the same persona, *Stand Up and Operate
+an Agent Team*, which is the substrate Kata's job runs on. Platform Builders
+benefit secondarily (they can adopt the runtime without Kata), but the product
+declares one Big Hire under one `user`. Gear keeps **Platform Builders → Build
+Agent-Capable Systems**, the build half.
+
+This is a clean break, not an additive layer: the runtime libraries move out of
+Gear and the run actions move out of the library directories, rather than being
+cross-listed, so each persona-job has exactly one product to hire.
+
+## Scope
+
+### Included
+
+| Item | What it does |
+| --- | --- |
+| New product `products/<platform>/` | A Secondary meta-package (`package.json` with `description` and one Big Hire `jobs` entry, `user` = `Teams Using Agents`) that re-exports the three runtime libraries and owns the run actions under `actions/`. No `bin/`/`src/`, following the Gear/Kata meta-package exemption. |
+| New JTBD job | Add a *Teams Using Agents → Stand Up and Operate an Agent Team* job to the new package's `jobs`; leave Kata's existing *Run a Continuously Improving Agent Team* job untouched. |
+| Runtime library subset | `PLATFORM` re-exports exactly the three operate-an-agent-team libraries: `@forwardimpact/libharness` (`fit-harness`/`fit-trace`, and its `fit-benchmark`/`fit-selfedit` bins travel with the package), `@forwardimpact/libwiki` (`fit-wiki`), and `@forwardimpact/libxmr` (`fit-xmr`). `svctrace` is **not** in this subset. |
+| Run-actions relocation | Move the agent-run composite actions into `products/<platform>/actions/`: `bootstrap` (from `.github/actions/bootstrap/`), `harness` and `benchmark` (from `libraries/libharness/actions/`), and `wiki` (from `libraries/libwiki/actions/`). Repoint the `publish-actions.yml` matrix `prefix:` and `paths:` filters; the **sibling repo names** (`bootstrap`, `harness`, `benchmark`, `wiki`) and their consumer SHA pins are unchanged. |
+| Libraries become pure | After the move, `libraries/libharness/` and `libraries/libwiki/` no longer contain an `actions/` directory; they are import-only libraries. |
+| Bring-up narrative ownership | The bootstrap layer (now `products/<platform>/actions/bootstrap/`, plus `fit-install.sh` and `scripts/bootstrap.sh`) is framed as `PLATFORM`'s stand-it-up story in the product's overview and skill. |
+| Gear refocus (clean break) | Remove the three runtime libraries from `products/gear/package.json`, and remove the operate-time promise ("chart agent metrics") from Gear's `jobs` entry, so Gear's promise is build-time primitives only. `svctrace` remains a Gear dependency. |
+| Overview page | `websites/fit/<platform>/index.md` — the cohesive "stand up and operate an agent team" story, organized by persona, presenting the CLIs and the CI actions as one runtime loop, with a Getting Started that names the bring-up layer. |
+| Skill | `.claude/skills/fit-<platform>/SKILL.md` describing when to hire the platform and how its capabilities compose (stand up → run → see → remember → measure). |
+| Kata as reference implementation | The overview page and `KATA.md` name Kata as the platform's first tenant — the proof the substrate is generic and swappable — without moving any Kata code. |
+| Generated context + counts | Regenerate the `JTBD.md` and `products/README.md` catalog blocks via the repo's context command, and update the hand-maintained product-count prose in the `products/README.md` intro, `CLAUDE.md` § Secondary Products, and the `sibling-composite-actions` enum / `.github/CLAUDE.md` action-home prose to reflect the new action homes and both products. |
+
+### Excluded
+
+| Item | Why |
+| --- | --- |
+| `svctrace` membership in `PLATFORM` | `svctrace` is an OTel gRPC ingestion service consumed by Guide, not the collector `fit-trace` reads from. It stays a Gear re-export; it never enters the runtime subset. |
+| Renaming the sibling action repos | Only the monorepo `prefix:` (source path) moves; the published sibling repos (`bootstrap`, `harness`, `benchmark`, `wiki`) keep their names, so downstream `uses:` pins are untouched. |
+| `fit-doc` / `libdoc` placement | Stays in Gear as a general infrastructure primitive; it fails the run-the-team test. Reopen only if the platform later claims a "publish team knowledge" verb. |
+| `fit-rc` / `fit-svscan` placement | They operate a *service stack*, not an agent team; they remain Gear infrastructure. |
+| Shared foundation packages | `libtelemetry`, `libutil` and the like are not part of the runtime subset; wherever Gear re-exports them today is untouched, and `PLATFORM` does not claim them. |
+| Generalizing `scripts/bootstrap.sh` → `fit-bootstrap.sh` | Extracting a generic installer is a follow-up; this spec relocates and narrates the bring-up layer, not the installer refactor. |
+| Moving or renaming any runtime *library* on disk | The libraries stay at their `libraries/` paths; only their `actions/` subdirectories move and only the re-export lists change. |
+| A standalone CLI for the platform | Like Gear, the product is a meta-package; capabilities keep their own CLIs. |
+
+## Deferred decisions
+
+Named here as the single home for each, so they are tracked rather than silently
+dropped. None blocks capturing the product; each is resolved in a later
+iteration.
+
+- **Product name.** The placeholder `PLATFORM` / `<platform>` stands in
+  throughout. Success criteria are written against the product's contents and
+  boundary, not its name.
+- **`fit-terrain` / `libterrain` home.** Its placement (platform vs Gear vs its
+  own product) is entangled with the Map standard and the synthetic
+  sub-libraries; decided after this product lands. Untouched here — it stays a
+  Gear re-export for now.
+- **`svcpathway` mis-filing.** `svcpathway` is the Pathway product's service and
+  is arguably mis-listed in Gear today; a pre-existing Gear-hygiene item
+  independent of this boundary. Flagged, not fixed here.
+
+## Success criteria
+
+Written to hold for whatever slug the name decision assigns; each references the
+new product's contents and the Gear boundary, not a brand string. "The new
+product's `package.json`" means the single `package.json` under the new
+`products/<slug>/` directory created by this change.
+
+| # | Claim | Verification |
+| --- | --- | --- |
+| 1 | The new meta-package re-exports exactly the three runtime libraries and nothing from the build-time set. | Static check: the new `package.json` `dependencies` are exactly `@forwardimpact/libharness`, `@forwardimpact/libwiki`, `@forwardimpact/libxmr`; no retrieval/contract/storage package and no `svctrace` appears. |
+| 2 | Gear no longer re-exports any runtime-subset library. | Static check: `products/gear/package.json` `dependencies` contain none of `@forwardimpact/libharness`, `@forwardimpact/libwiki`, `@forwardimpact/libxmr`. |
+| 3 | Each of the three runtime libraries is re-exported by exactly one meta-product. | Static check: no runtime-subset library appears in both `products/gear/package.json` and the new package's `dependencies`. |
+| 4 | `svctrace` stays a Gear build-time dependency and never enters `PLATFORM`. | Static check: `@forwardimpact/svctrace` appears in `products/gear/package.json` `dependencies` and does not appear in the new package's `dependencies`. |
+| 5 | Gear's job no longer promises any operate-time capability. | Static check: Gear's `jobs` `littleHire` no longer contains the "chart agent metrics" clause or any equivalent metrics/operate-a-team verb. |
+| 6 | The four agent-run actions live under the product and the libraries are pure. | Static check: `products/<platform>/actions/{bootstrap,harness,wiki,benchmark}/action.yml` exist; `libraries/libharness/actions/` and `libraries/libwiki/actions/` no longer exist; `.github/actions/bootstrap/` no longer exists. |
+| 7 | The action move preserves publication: same sibling repos, repointed sources. | Static check: `publish-actions.yml` matrix `prefix:` entries for `bootstrap`/`harness`/`benchmark`/`wiki` point under `products/<platform>/actions/`, the `repo:` names are unchanged, and the `paths:` filter matches the new sources. |
+| 8 | The new product declares one Big Hire for the operate persona, distinct from Kata's job. | Static check: the new package's `jobs` array has exactly one entry whose `user` is `Teams Using Agents` and whose `goal` is not `Run a Continuously Improving Agent Team`. |
+| 9 | The product has an overview page and a skill that name the bring-up layer and present the runtime loop as one workflow. | `websites/fit/<slug>/index.md` and `.claude/skills/fit-<slug>/SKILL.md` exist; each names the bootstrap layer and references `fit-harness`, `fit-wiki`, `fit-xmr`, and `fit-trace`, and presents the CI actions as the same loop. |
+| 10 | Kata is documented as the platform's reference implementation, with no Kata code moved. | `KATA.md` and the overview page name Kata as a tenant of the platform; `git diff` shows no change under `products/kata/`. |
+| 11 | Generated context and hand-maintained counts reflect both products and the new action homes. | After `bun run context:fix`, the `JTBD.md` and `products/README.md` catalog blocks list the new product and the refocused Gear; the `products/README.md` intro count, `CLAUDE.md` § Secondary Products, and the `sibling-composite-actions` action-home prose are updated; `bun run check` passes. |
+| 12 | The deferred decisions are recorded, not silently resolved. | § Deferred decisions names the product-name, `fit-terrain`, and `svcpathway` items; `git diff` shows none of the three acted on (no rename, no `libterrain`/`svcpathway` dependency move). |
+
+## Relationship to other specs
+
+- **Distinct from spec 2080 (platform adoption substrate).** 2080 adds an
+  activity-schema substrate for Landmark to *measure* platform adoption across
+  teams. This spec *packages and names* the agent-runtime platform as a product.
+  Different surface (product framing vs data schema), no overlap.
+- **Builds on the debranding line (spec 2140, subtree-split actions).** The
+  bring-up and run actions are already published under debranded sibling names
+  (`bootstrap`, `harness`, `wiki`, `benchmark`); this spec regroups their
+  monorepo sources under one product and gives that published surface a product
+  narrative, without changing the sibling names those consumers pin.


### PR DESCRIPTION
## Summary

Lockstep **spec + design** (combined `design(2200)` PR per the lockstep
co-execution protocol) for a new Secondary meta-product that packages the
agent-runtime substrate as a product in its own right.

- **Problem** — the substrate for running an agent team (the bootstrap layer
  plus `fit-harness`/`fit-trace`/`fit-wiki`/`fit-xmr`) has no product home: its
  runtime is buried inside Gear's build-time grab-bag and its bring-up is filed
  as CI plumbing under `.github/`.
- **Proposal** — define a new meta-product (`PLATFORM`, **name deferred**) split
  cleanly out of Gear along one boundary: **ships what you run vs ships what you
  import**. Gear sheds the runtime subset and its operate-time job clause; the
  new product re-exports the four runtime packages and gives the bring-up layer
  a narrative. **Kata** is named as the reference implementation (no code moved).
- **Deferred by request** — the product name, `fit-terrain`'s home, and the
  `svcpathway` mis-filing are tracked as explicit open decisions, not resolved
  here.

Status: **`design draft`** in `wiki/STATUS.md`. Design approval is human-only —
this PR is opened for a trusted human to review and approve; it is intentionally
**not** self-approved or merged.

## Review panel

Combined lockstep panel (3 product + 3 technical on the spec, 3 technical on the
design) ran cold-start before push. Consensus and verified findings addressed in
the pushed revision:

- JTBD binding — the `Teams Using Agents → Run a Continuously Improving Agent
  Team` job is Kata-owned; the spec now adds a **distinct** `Stand Up and Operate
  an Agent Team` job and leaves Kata's untouched.
- Design named a "generated product README"; corrected — product READMEs are not
  generated (Gear has none), and the hand-maintained product-count prose is now
  an explicit edit.
- Corrected a false `fit-install.sh` evidence claim, the schema-invalid
  two-persona `user`, and noted `libharness`'s extra bins (`fit-benchmark`,
  `fit-selfedit`) travel with the package.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`