### PR TITLE
feat(ci): publish Outpost skills pack

### DIFF
--- a/.github/actions/publish-skill-pack/action.yml
+++ b/.github/actions/publish-skill-pack/action.yml
@@ -15,8 +15,23 @@ description: >
 
 inputs:
   pack-prefix:
-    description: Skill directory prefix under .claude/skills (e.g. fit, coaligned, kata).
-    required: true
+    description: >
+      Skill directory prefix under the source dir's skills/ (e.g. fit,
+      coaligned, kata). Leave empty and set `all` when the source dir is itself
+      the pack boundary and its skills share no common prefix.
+    required: false
+    default: ""
+  source-dir:
+    description: >
+      Directory holding skills/ and agents/ to stage from. Defaults to the
+      repo-root .claude; a product-local pack points this at its own .claude
+      (e.g. products/outpost/templates/.claude).
+    default: .claude
+  all:
+    description: >
+      When "true", stage every skill in the source dir regardless of prefix.
+      Use for a single-pack source dir whose skills share no common prefix.
+    default: "false"
   sibling-repo:
     description: >
       Sibling repo short name (e.g. fit-skills). Names the apm package and the
@@ -64,6 +79,8 @@ runs:
       shell: bash
       env:
         PACK_PREFIX: ${{ inputs.pack-prefix }}
+        SOURCE_DIR: ${{ inputs.source-dir }}
+        STAGE_ALL: ${{ inputs.all }}
         TARGET_DIR: ${{ inputs.target-dir }}
         APM_NAME: ${{ inputs.sibling-repo }}
         APM_DESCRIPTION: ${{ inputs.apm-description }}
@@ -71,13 +88,23 @@ runs:
         README_INTRO: ${{ inputs.readme-intro }}
         SYNC_AGENTS: ${{ inputs.sync-agents }}
       run: |
+        # A matrix entry that omits source-dir/all renders them empty here, not
+        # as the input defaults, so coalesce to the repo-root prefix pack shape.
+        source_dir="${SOURCE_DIR:-.claude}"
+
+        select_flag="--prefix $PACK_PREFIX"
+        if [ "$STAGE_ALL" = "true" ]; then
+          select_flag="--all"
+        fi
+
         agents_flag=""
         if [ "$SYNC_AGENTS" = "true" ]; then
           agents_flag="--with-agents"
         fi
+
         fit-pack stage \
-          --from .claude \
-          --prefix "$PACK_PREFIX" \
+          --from "$source_dir" \
+          $select_flag \
           --into "$TARGET_DIR" \
           --name "$APM_NAME" \
           --pack-version "$VERSION" \

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -9,7 +9,10 @@ on:
       - ".claude/skills/coaligned-*/**"
       - ".claude/skills/monorepo-*/**"
       - ".claude/agents/*.md"
+      - "products/outpost/templates/.claude/skills/**"
+      - "products/outpost/templates/.claude/agents/*.md"
       - "products/gear/package.json"
+      - "products/outpost/package.json"
       - "libraries/libcoaligned/package.json"
       - ".github/actions/publish-skill-pack/**"
       - ".github/workflows/publish-skills.yml"
@@ -77,6 +80,24 @@ jobs:
               Skills for bootstrapping a Forward Impact-style monorepo end to
               end — repository structure, instruction architecture, and the Kata
               Agent Team — composing the Co-Aligned and Kata packs.
+          # Outpost is a product-local pack: its skills and agents live under
+          # the installation template, not repo-root .claude, and its skills
+          # share no common prefix — the directory itself is the pack boundary,
+          # so it stages with `all: "true"` instead of a prefix.
+          - prefix: ""
+            repo: outpost-skills
+            version-file: products/outpost/package.json
+            source-dir: products/outpost/templates/.claude
+            all: "true"
+            sync-agents: "true"
+            readme-title: Outpost Skills
+            readme-intro: >-
+              Agents and skills for [Outpost](https://forwardimpact.team), the
+              personal chief-of-staff that tracks people, projects, and threads.
+            apm-description: >-
+              Outpost agents and skills — the chief-of-staff, concierge,
+              librarian, postman, and recruiter agents plus the skills they run
+              to sync, triage, and brief.
     steps:
       - name: Generate installation token
         id: ci-app
@@ -108,6 +129,8 @@ jobs:
         uses: ./.github/actions/publish-skill-pack
         with:
           pack-prefix: ${{ matrix.pack.prefix }}
+          source-dir: ${{ matrix.pack.source-dir }}
+          all: ${{ matrix.pack.all }}
           sibling-repo: ${{ matrix.pack.repo }}
           version-file: ${{ matrix.pack.version-file }}
           apm-description: ${{ matrix.pack.apm-description }}

--- a/libraries/libpack/bin/fit-pack.js
+++ b/libraries/libpack/bin/fit-pack.js
@@ -25,6 +25,11 @@ const definition = {
           type: "string",
           description: "Skill directory prefix to select (e.g. kata)",
         },
+        all: {
+          type: "boolean",
+          description:
+            "Stage every skill in --from regardless of prefix (source dir is the pack boundary)",
+        },
         into: {
           type: "string",
           description: "Target sibling repo working tree",
@@ -60,6 +65,7 @@ const definition = {
   },
   examples: [
     "fit-pack stage --prefix kata --with-agents --into skills-repo --name kata-skills --pack-version 1.2.3",
+    "fit-pack stage --all --with-agents --from products/outpost/templates/.claude --into skills-repo --name outpost-skills --pack-version 3.11.0",
   ],
   documentation: [
     {
@@ -96,16 +102,21 @@ const [command] = positionals;
 
 const commands = {
   async stage() {
-    for (const required of ["prefix", "into", "name", "pack-version"]) {
+    for (const required of ["into", "name", "pack-version"]) {
       if (!values[required]) {
         cli.usageError(`--${required} is required`);
         process.exit(2);
       }
     }
+    if (!values.all && !values.prefix) {
+      cli.usageError("--prefix or --all is required");
+      process.exit(2);
+    }
     const publisher = new SkillPackPublisher({ runtime });
     const { skills, agents } = await publisher.publish({
       sourceDir: values.from || ".claude",
       prefix: values.prefix,
+      all: Boolean(values.all),
       targetDir: values.into,
       name: values.name,
       version: values["pack-version"],

--- a/libraries/libpack/src/skill-pack.js
+++ b/libraries/libpack/src/skill-pack.js
@@ -30,7 +30,10 @@ export class SkillPackPublisher {
    * @param {string} opts.sourceDir - Directory holding `skills/` and `agents/`
    *   (the monorepo's `.claude` directory).
    * @param {string} opts.prefix - Skill directory prefix to select (e.g. `kata`
-   *   selects `skills/kata-*`).
+   *   selects `skills/kata-*`). Ignored when `all` is set.
+   * @param {boolean} [opts.all] - Stage every skill in `sourceDir` regardless of
+   *   prefix. Use when the source directory is itself the pack boundary (e.g. a
+   *   product-local `.claude` whose skills share no common prefix).
    * @param {string} opts.targetDir - Sibling repo working tree to write into.
    * @param {string} opts.name - APM package name (sibling repo short name).
    * @param {string} opts.version - Stamped into apm.yml and SKILL.md metadata.
@@ -63,15 +66,20 @@ export class SkillPackPublisher {
     }
   }
 
-  /** Copy `skills/<prefix>-*` into `.apm/skills/`, injecting frontmatter. */
-  async #stageSkills({ sourceDir, prefix, targetDir, version }) {
+  /**
+   * Copy skills into `.apm/skills/`, injecting frontmatter. Selects
+   * `skills/<prefix>-*` by default, or every skill when `all` is set.
+   */
+  async #stageSkills({ sourceDir, prefix, all, targetDir, version }) {
     const { mkdir, readdir, cp, readFile, writeFile } = this.#fs;
     const srcDir = join(sourceDir, "skills");
     const destDir = join(targetDir, APM_SKILLS_DIR);
     await mkdir(destDir, { recursive: true });
 
     const dirs = (await readdir(srcDir, { withFileTypes: true }))
-      .filter((e) => e.isDirectory() && e.name.startsWith(`${prefix}-`))
+      .filter(
+        (e) => e.isDirectory() && (all || e.name.startsWith(`${prefix}-`)),
+      )
       .map((e) => e.name)
       .sort();
 

--- a/libraries/libpack/test/skill-pack.integration.test.js
+++ b/libraries/libpack/test/skill-pack.integration.test.js
@@ -107,6 +107,32 @@ describe("SkillPackPublisher", () => {
     ]);
   });
 
+  test("all: stages every skill regardless of prefix", async () => {
+    const source = await makeSource();
+    const target = await makeTempDir();
+
+    const result = await new SkillPackPublisher({ runtime }).publish({
+      sourceDir: source,
+      all: true,
+      targetDir: target,
+      name: "outpost-skills",
+      version: "3.11.0",
+      withAgents: true,
+    });
+
+    // Both prefixes staged — the directory itself is the pack boundary.
+    expect(
+      existsSync(join(target, ".apm", "skills", "kata-review", "SKILL.md")),
+    ).toBe(true);
+    expect(
+      existsSync(join(target, ".apm", "skills", "fit-map", "SKILL.md")),
+    ).toBe(true);
+    expect(result.skills.map((s) => s.name).sort()).toEqual([
+      "fit-map",
+      "kata-review",
+    ]);
+  });
+
   test("injects version metadata into staged SKILL.md", async () => {
     const source = await makeSource();
     const target = await makeTempDir();


### PR DESCRIPTION
## Summary

- Publish Outpost's skills and agents through the shared `publish-skills.yml` pipeline, like every other pack.
- Outpost is a **product-local, prefix-less** pack: its skills/agents live in `products/outpost/templates/.claude/` (not repo-root `.claude`) and its ~28 skills share no common prefix — the directory itself is the pack boundary.
- `libpack`: add `fit-pack stage --all` to stage every skill in `--from` regardless of prefix; `--prefix` is now optional (require `--prefix` or `--all`).
- `publish-skill-pack` action: add `source-dir` (default `.claude`) and `all` inputs; existing prefix packs are unchanged.
- Workflow: new `outpost` matrix entry (`source-dir: products/outpost/templates/.claude`, `all: "true"`, `sync-agents: "true"`, version from `products/outpost/package.json`) publishing to `forwardimpact/outpost-skills`, plus its trigger paths.

Sibling repo `forwardimpact/outpost-skills` (public) already created.

> [!NOTE]
> CI's `fit-pack` is the pinned gear-bundle binary (`FIT_GEAR_RELEASE=gear@v0.1.14`), not the repo-local one. The `--all` flag reaches CI only after a gear release carries this libpack change and the pin is bumped. Until then the Outpost matrix leg fails on an unknown option; the other 4 packs keep publishing (`fail-fast: false`).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`