### PR TITLE
chore(libpack): bump to 0.1.11 for fit-pack stage --all

### DIFF
--- a/libraries/libpack/package.json
+++ b/libraries/libpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libpack",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Pack distribution — tarballs, bare git repos, and skill discovery indices",
   "keywords": [
     "pack",


### PR DESCRIPTION
## Producer step 1 of the gear-release chain

PR #1934 (`4139a89e1`) merged the `fit-pack stage --all` whole-dir staging mode into `libraries/libpack` (`bin/fit-pack.js` + `src/skill-pack.js`) and added an `outpost-skills` matrix leg to `publish-skills.yml` that calls `fit-pack stage --all`. That leg **failed** on the merge run with `Unknown option '--all'` because CI installs `fit-pack` as a pinned gear-bundle binary (`FIT_GEAR_RELEASE=gear@v0.1.14`), which predates `--all`.

This PR bumps `@forwardimpact/libpack` `0.1.10 → 0.1.11` (pre-1.0 patch per CONTRIBUTING § Releasing). Publishable paths (`bin/`, `src/`) changed; `test/` and comment-only edits in other packages do not owe a cut.

### Chain (bottom-up, producer before consumer)

1. **This PR** — libpack `0.1.11` (npm producer).
2. After merge — cut **`gear@v0.1.18`** from the merged `main` commit via `Release: Tag`. Rebuilds the gear bundle so the `fit-pack` binary carries `--all`, and republishes the co-versioned `fit-install.sh` stamped to `gear@v0.1.18`.
3. Follow-up PR — bump `FIT_GEAR_RELEASE` in `.github/actions/bootstrap/fit-install.sh` to `gear@v0.1.18`; the push to `main` subtree-splits the `bootstrap` sibling.
4. Same follow-up — after the `bootstrap` sibling re-releases (`v1.0.x`), bump the `forwardimpact/bootstrap@<sha>` pin in `publish-skills.yml` to the new SHA, then re-run `publish-skills.yml` so the `outpost-skills` leg goes green.

Steps 2–4 are held until this producer lands, to avoid a fail-closed window (a consumer pinned ahead of its producer has no `bunx`/`npx` fallback).

— Release Engineer 🚀

🤖 Generated with [Claude Code](https://claude.com/claude-code)