### PR TITLE
ci: bump bootstrap pin to v1.0.14 (arm64 binary-build fix)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - name: Ensure codegen is current
         run: just codegen
       - name: Compile

--- a/.github/workflows/check-context.yml
+++ b/.github/workflows/check-context.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - uses: ./.github/actions/coaligned-check
         with:
           command: instructions
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun run context:check-metadata
 
   jtbd:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - uses: ./.github/actions/coaligned-check
         with:
           command: jtbd
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - uses: ./.github/actions/coaligned-check
         with:
           command: invariants
@@ -66,5 +66,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun run wiki:rules

--- a/.github/workflows/check-data.yml
+++ b/.github/workflows/check-data.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun run data:check-schema
 
   prose:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun run data:check-prose

--- a/.github/workflows/check-quality.yml
+++ b/.github/workflows/check-quality.yml
@@ -14,33 +14,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun run format:js
 
   lint-js:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun run lint:js
 
   format-md:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun run format:md
 
   lint-md:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun run lint:md
 
   jsdoc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun run jsdoc

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
@@ -37,5 +37,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - run: bun scripts/check-dependabot.mjs

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:

--- a/.github/workflows/curate-wiki.yml
+++ b/.github/workflows/curate-wiki.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
         with:
           clis: fit-wiki
       - name: Checkout wiki (read-only)

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/eval-wiki.yml
+++ b/.github/workflows/eval-wiki.yml
@@ -17,7 +17,7 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
         with:
           # fit-benchmark runs the benchmark binary straight off PATH.
           clis: fit-benchmark

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -125,7 +125,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/outpost-determinism-probe.yml
+++ b/.github/workflows/outpost-determinism-probe.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
       - name: Install diffoscope
         run: brew install diffoscope
       - name: First build

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
 
       - uses: ./.github/actions/audit
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -121,7 +121,7 @@ jobs:
           vulnerability-scanning: "false"
           secret-scanning: "true"
 
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
         with:
           clis: fit-pack
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/bootstrap@52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10
+      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
         with:
           clis: fit-doc
 


### PR DESCRIPTION
## What

Bumps all 27 `forwardimpact/bootstrap` SHA pins across 15 workflows:

- from `52b7f3fe405a559fd8f2c95b102499e0df9b152b # v1.0.10`
- to `ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14`

## Why

`v1.0.14` (freshly cut on the `forwardimpact/bootstrap` sibling at `ccdf5ac7`) carries the arm64 Linux env fix for the binary build. The monorepo root fix commit is `471a0ad3d` (`fix(ci): bootstrap arm64 Linux env for the binary build (#1936)`), subtree-split to the sibling. It fixes the two bugs behind #1936:

1. arm64 runners restored the x64 env-cache -> x64 `just` on aarch64 -> `Exec format error` (126). Fixed by adding `runner.arch` to the env-cache key.
2. `DEFAULT_TOOLS` gear binaries hard-failed on `linux-aarch64` (no raw gear asset per spec 2190). Fixed by skipping the gear-binary install on that platform.

The pinned `v1.0.10` predated the fix, so every arm64 leg (`ubuntu-24.04-arm`) failed. This is the SHA bump Dependabot would otherwise make; batched into one PR for consistency.

The binary-release path is covered: `build-binaries.yml` and `package-macos.yml` (reached via `publish-binaries.yml`) are both bumped; `package-linux.yml` uses no bootstrap action.

Refs #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)