### PR TITLE
chore(gear): bump to 0.1.19 (arm64 binary-build validation)

### DIFF
--- a/products/gear/package.json
+++ b/products/gear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/gear",
-  "version": "0.1.17",
+  "version": "0.1.19",
   "description": "Shared libraries and services for platform builders and agents — CLIs, retrieval, evaluation, and infrastructure published to npm.",
   "keywords": [
     "agent",


### PR DESCRIPTION
## What

Bumps `products/gear` to `0.1.19`. This is the version whose tag (`gear@v0.1.19`) I will push after merge to trigger `publish-binaries.yml` and validate the #1936 arm64 fix.

## Why

`gear@v0.1.18` is a dead tag: its `Publish: Binaries` produced no assets because of the arm64 bug (x64 `just` restored from the wrong env-cache on `ubuntu-24.04-arm` → `Exec format error`). That bug is now fixed:

- root fix commit `471a0ad3d` (#1936), subtree-split to `forwardimpact/bootstrap`
- released as bootstrap `v1.0.14` (`ccdf5ac7`)
- pinned into all 27 monorepo workflow usages by #1937 (merged)

Cutting `gear@v0.1.19` at current `main` HEAD uses the fixed, pinned bootstrap and carries the already-live `libpack@0.1.11` `fit-pack` (with `stage --all`). The tag push (post-merge) is the real proof the arm64 binary build works.

Refs #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)