### PR TITLE
fix(ci): correct apm arm64 asset name and sha in fit-install.sh

### DIFF
--- a/.github/actions/bootstrap/fit-install.sh
+++ b/.github/actions/bootstrap/fit-install.sh
@@ -345,8 +345,9 @@ resolve_apm() {
       target="${OS}-${ARCH}"
       sha256="a9be6afb9f33f63598d11a7de1029722fd2601aa2ecaebfe82f4903e12a23a52" ;;
     linux-aarch64)
-      target="${OS}-${ARCH}"
-      sha256="0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5" ;;
+      # apm names its arm64 asset apm-linux-arm64, not the uname -m "aarch64".
+      target="linux-arm64"
+      sha256="4b64ff40b2b70ae3c97eb64a608cadcb06c4713cd878708c9685a12394278ca0" ;;
     darwin-x86_64)
       target="${OS}-${ARCH}"
       sha256="c76ef17fa3250f87131ee09d1c8e166fce535dc2d7cea6e44fc1c5d0e3df0bac" ;;


### PR DESCRIPTION
## What

`resolve_apm` in `.github/actions/bootstrap/fit-install.sh` built the `linux-aarch64` download URL as `apm-linux-aarch64.tar.gz` (straight from `uname -m`), but Microsoft's apm v0.12.4 release ships the arm64 asset as **`apm-linux-arm64.tar.gz`**. The download 404'd. The pinned `sha256` for that case (`0019dfc4…`) was also a placeholder dummy.

Fix: map `linux-aarch64` → `target="linux-arm64"` and pin the real sha256 `4b64ff40…` (verified against the live asset locally).

## Why this surfaced now

This is the next layer under #1936. The arm64 env-cache-key + gear-skip fix (`471a0ad3d`, released as bootstrap `v1.0.14`, pinned by #1937) is what first let the arm64 bootstrap get *past* the cache/`just` stage and *reach* the apm download — exposing this pre-existing naming bug. Before the #1936 fix, arm64 died earlier with `Exec format error` and never got here.

I verified the other four `DEFAULT_TOOLS` downloads resolve correctly on arm64 (gh 302, rg 302, gitleaks 302, claude 200); only apm was wrong. So this should be the last download-layer blocker for the arm64 binary build.

## Follow-up (not in this PR)

After merge: cut bootstrap `v1.0.15` carrying this fix, bump the monorepo pins, then re-cut the gear tag so `Publish: Binaries` arm64 legs go green.

Refs #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)