### PR TITLE
ci: bump bootstrap pin to v1.0.15 (apm arm64 fix)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - name: Ensure codegen is current
         run: just codegen
       - name: Compile

--- a/.github/workflows/check-context.yml
+++ b/.github/workflows/check-context.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - uses: ./.github/actions/coaligned-check
         with:
           command: instructions
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun run context:check-metadata
 
   jtbd:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - uses: ./.github/actions/coaligned-check
         with:
           command: jtbd
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - uses: ./.github/actions/coaligned-check
         with:
           command: invariants
@@ -66,5 +66,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun run wiki:rules

--- a/.github/workflows/check-data.yml
+++ b/.github/workflows/check-data.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun run data:check-schema
 
   prose:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun run data:check-prose

--- a/.github/workflows/check-quality.yml
+++ b/.github/workflows/check-quality.yml
@@ -14,33 +14,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun run format:js
 
   lint-js:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun run lint:js
 
   format-md:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun run format:md
 
   lint-md:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun run lint:md
 
   jsdoc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun run jsdoc

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
@@ -37,5 +37,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - run: bun scripts/check-dependabot.mjs

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:

--- a/.github/workflows/curate-wiki.yml
+++ b/.github/workflows/curate-wiki.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
         with:
           clis: fit-wiki
       - name: Checkout wiki (read-only)

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/eval-wiki.yml
+++ b/.github/workflows/eval-wiki.yml
@@ -17,7 +17,7 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
         with:
           # fit-benchmark runs the benchmark binary straight off PATH.
           clis: fit-benchmark

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -125,7 +125,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/outpost-determinism-probe.yml
+++ b/.github/workflows/outpost-determinism-probe.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
       - name: Install diffoscope
         run: brew install diffoscope
       - name: First build

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
 
       - uses: ./.github/actions/audit
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -121,7 +121,7 @@ jobs:
           vulnerability-scanning: "false"
           secret-scanning: "true"
 
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
         with:
           clis: fit-pack
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/bootstrap@ccdf5ac74abf2a47f7a1f9af4b06c6ac7444d0d6 # v1.0.14
+      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
         with:
           clis: fit-doc
 


### PR DESCRIPTION
Bumps all 27 `forwardimpact/bootstrap` pins from `ccdf5ac7 # v1.0.14` to `3d474156 # v1.0.15`.

`v1.0.15` carries the apm arm64 asset-name fix (root commit `21595d74d`, #1939): `resolve_apm` downloads `apm-linux-arm64.tar.gz` with the correct sha256 on `ubuntu-24.04-arm`, instead of 404ing on the nonexistent `apm-linux-aarch64.tar.gz`.

This is the final pin bump before re-cutting the gear tag to validate the #1936 arm64 binaries build.

Refs #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)