### PR TITLE
chore(gear): bump to 0.1.20 (re-validate arm64 binaries)

### DIFF
--- a/products/gear/package.json
+++ b/products/gear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/gear",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Shared libraries and services for platform builders and agents — CLIs, retrieval, evaluation, and infrastructure published to npm.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Bumps `products/gear` to `0.1.20`. After merge I push `gear@v0.1.20` to trigger `publish-binaries.yml`.

`gear@v0.1.19` produced no assets — its arm64 legs 404'd on the apm download (the `resolve_apm` naming bug). That is now fixed (#1939, bootstrap `v1.0.15`, pinned by #1940). Cutting a fresh tag at a `main` HEAD carrying the complete arm64 chain to confirm `Publish: Binaries` arm64 legs go green and publish assets.

Refs #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)