### PR TITLE
fix(ci): drop rotting spec reference from render-formula.sh comment

### DIFF
--- a/build/render-formula.sh
+++ b/build/render-formula.sh
@@ -5,7 +5,7 @@
 # skeleton (whose binary block render-cask-binaries.sh regenerates), it ships NO
 # formula skeleton, so this writes the whole file. That also means a new bundle
 # folds in with no hand-seeded tap file: adding its tag + manifest entry is
-# enough, exactly as the spec 2190 scope promises.
+# enough.
 #
 #   Usage: render-formula.sh <formula-file> <token> <bundle> <version> \
 #            <x64-sha> <arm64-sha> <cask-file>


### PR DESCRIPTION
## Summary

- `coaligned invariants` was red on `main` with a `temporal.reference` error in `build/render-formula.sh`. A code comment cited a spec number ("exactly as the spec 2190 scope promises"), which the temporal invariant forbids because such references rot once the spec closes.
- Reworded the comment to keep the WHY without the reference. Not a false positive, so the fix is in the comment rather than the rule.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01DTYG5pkUdDRJH3aCa19nLP)_