### PR TITLE
chore(check): cut check-chain noise and confirm each step

### DIFF
--- a/.env.docker-native.example
+++ b/.env.docker-native.example
@@ -197,8 +197,9 @@ GETDX_BASE_URL=https://api.getdx.com
 # Debug (Optional)
 # ==========================================
 
-# Enable debug logging for all components
-DEBUG=*
-
-# Or enable for specific components
+# Debug logging is off by default. It uses the `debug` package, whose `*`
+# wildcard also switches on verbose internal logging in third-party tools
+# (eslint code-path dumps, etc.) and can bury real output. Prefer scoping to
+# our own namespaces; reach for `*` only when you need everything.
 # DEBUG=mcp,graph
+# DEBUG=*

--- a/.env.docker-supabase.example
+++ b/.env.docker-supabase.example
@@ -197,8 +197,9 @@ GETDX_BASE_URL=https://api.getdx.com
 # Debug (Optional)
 # ==========================================
 
-# Enable debug logging for all components
-DEBUG=*
-
-# Or enable for specific components
+# Debug logging is off by default. It uses the `debug` package, whose `*`
+# wildcard also switches on verbose internal logging in third-party tools
+# (eslint code-path dumps, etc.) and can bury real output. Prefer scoping to
+# our own namespaces; reach for `*` only when you need everything.
 # DEBUG=mcp,graph
+# DEBUG=*

--- a/.env.local.example
+++ b/.env.local.example
@@ -186,8 +186,9 @@ GETDX_BASE_URL=https://api.getdx.com
 # Debug (Optional)
 # ==========================================
 
-# Enable debug logging for all components
-DEBUG=*
-
-# Or enable for specific components
+# Debug logging is off by default. It uses the `debug` package, whose `*`
+# wildcard also switches on verbose internal logging in third-party tools
+# (eslint code-path dumps, etc.) and can bury real output. Prefer scoping to
+# our own namespaces; reach for `*` only when you need everything.
 # DEBUG=mcp,graph
+# DEBUG=*

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "wiki:rules": "bun test libraries/libwiki/test/audit-",
     "wiki:fix": "bunx fit-wiki fix",
     "check:fix": "bun run format:js:fix && bun run lint:js:fix && bun run format:md:fix && bun run lint:md:fix && bun run context:fix && bun run wiki:fix",
-    "jsdoc": "eslint",
+    "jsdoc": "DEBUG= eslint && echo '✓ jsdoc passed'",
     "lint:js": "biome lint .",
     "lint:js:fix": "biome lint --write .",
     "format:js": "biome format .",

--- a/scripts/check-dependabot.mjs
+++ b/scripts/check-dependabot.mjs
@@ -174,4 +174,5 @@ if (violations.length > 0) {
   process.exit(1);
 }
 
+console.log("✓ dependabot coverage intact");
 process.exit(0);

--- a/scripts/check-metadata.mjs
+++ b/scripts/check-metadata.mjs
@@ -140,4 +140,7 @@ for (const file of files) {
   }
 }
 
+if (!stale)
+  console.log(`✓ package.json metadata current (${files.length} files)`);
+
 process.exit(stale ? 1 : 0);


### PR DESCRIPTION
## Summary

- `bun run check` emitted ~2.3M lines because the `eslint` (jsdoc) step inherited an ambient `DEBUG=*`. The `debug` package's `*` wildcard turns on eslint's internal logging and code-path `digraph` dumps, burying the only signal that matters: pass or fail.
- `jsdoc` script now runs eslint with `DEBUG` neutralized so the wildcard can't reach it, while leaving `DEBUG` intact for our own CLIs; it also prints a pass line.
- `.env.*.example` (all three) make debug logging opt-in and explain that the `*` wildcard also lights up third-party tools, so a fresh dev environment no longer reproduces the explosion.
- `check-metadata.mjs` and `check-dependabot.mjs` print a one-line pass confirmation so every check step visibly reports completion, matching the coaligned steps.
- Net effect: `bun run check` output drops from ~2.3M lines to ~26, all signal.

## Test plan

- [x] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uecvpdVEbmaMfMLX3SQ6m)_