### PR TITLE
feat(bootstrap): trusted install channels and quieter session-start hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .github/actions/bootstrap/fit-install.sh"
+            "command": "bash .github/actions/bootstrap/fit-install.sh --soft"
           },
           {
             "type": "command",

--- a/.coaligned/invariants/public-cli-set.rules.mjs
+++ b/.coaligned/invariants/public-cli-set.rules.mjs
@@ -4,6 +4,9 @@
 // workspace package. Every public CLI must have a matching launcher package
 // under `launchers/` (npm name = invoked name), and nothing else may live
 // there — the launcher set is computed from the rule, never hand-maintained.
+// Nearly all public CLIs are `fit-*`; the rare non-fit public CLI (coaligned,
+// invoked as `npx coaligned …` in the published setup skills) is named in
+// PUBLISHED_NON_FIT_CLIS, since the fit-only invocation scan cannot see it.
 // See launchers/README.md for the published contract.
 //
 // Checks, each failing CI with a message naming the offending dir/file:
@@ -38,6 +41,13 @@ export const SIBLING_ACTION_CLIS = [
   "fit-trace",
   "fit-wiki",
 ];
+
+// Public CLIs the fit-only invocation scan cannot capture. coaligned ships to
+// external users via `apm` and is invoked as `npx coaligned …` in the published
+// setup skills, but INVOKE_RE matches only fit-* names and the skill scan only
+// walks fit-*/kata-* dirs — so it is named here to stay public, the same escape
+// hatch SIBLING_ACTION_CLIS gives action-only CLIs.
+export const PUBLISHED_NON_FIT_CLIS = ["coaligned"];
 
 const REQUIRED_KEYS = [
   "name",
@@ -229,7 +239,7 @@ export function checkPublicCliSet({ invokedNames, packages, launchers }) {
 }
 
 function collectInvokedNames({ listDir, scan }) {
-  const names = new Set(SIBLING_ACTION_CLIS);
+  const names = new Set([...SIBLING_ACTION_CLIS, ...PUBLISHED_NON_FIT_CLIS]);
   const dirs = ["websites/fit/docs"];
   for (const entry of listDir(".claude/skills")) {
     if (/^(fit|kata)-/.test(entry)) dirs.push(`.claude/skills/${entry}`);

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -64,7 +64,13 @@ with no output.
 installs the external tools and pinned, SHA-verified `fit-*` binaries into
 `$HOME/.local`, beside the `bootstrap` action so it travels with the subtree
 split. `publish-binaries.yml` publishes it on `gear@v*` for `curl | bash`
-bootstrap. A missing binary fails hard — no `bunx`/`npx` fallback.
+bootstrap. Each tool resolves through an ordered list of channels (`release` →
+platform package manager): CI and local get the pinned, reproducible download;
+where github.com is unreachable — a Claude Code web session blocks it outright,
+release assets included — tools fall back to a trusted registry (`apt` for the
+distro CLIs, `npm` for our gear CLIs). `apm` has no registry build, so a blocked
+web session skips it. Session hooks pass `--soft` so a skipped tool is reported,
+not fatal; CI omits it, keeping a missing tool a hard failure.
 
 ## Local composite actions
 

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -64,13 +64,7 @@ with no output.
 installs the external tools and pinned, SHA-verified `fit-*` binaries into
 `$HOME/.local`, beside the `bootstrap` action so it travels with the subtree
 split. `publish-binaries.yml` publishes it on `gear@v*` for `curl | bash`
-bootstrap. Each tool resolves through an ordered list of channels (`release` →
-platform package manager): CI and local get the pinned, reproducible download;
-where github.com is unreachable — a Claude Code web session blocks it outright,
-release assets included — tools fall back to a trusted registry (`apt` for the
-distro CLIs, `npm` for our gear CLIs). `apm` has no registry build, so a blocked
-web session skips it. Session hooks pass `--soft` so a skipped tool is reported,
-not fatal; CI omits it, keeping a missing tool a hard failure.
+bootstrap. A blocked download falls back to `apt`/`npm` registries.
 
 ## Local composite actions
 

--- a/.github/actions/bootstrap/fit-install.sh
+++ b/.github/actions/bootstrap/fit-install.sh
@@ -497,25 +497,56 @@ resolve_claude() {
 
 # ── Install ──────────────────────────────────────────────────────
 
+# Session-start accounting. A warm session re-runs this hook with everything
+# already present; rather than a line per tool, we tally outcomes and print one
+# summary at the end. Only real deltas (a fresh install, printed by the install
+# helpers) and a one-time degraded-mode notice speak up as they happen.
+PRESENT=()
+SKIPPED=()
+
+# Lazily probe whether the gear release host (github.com) is reachable, caching
+# the verdict. Some environments — notably the web-session network policy —
+# allow the npm registry but block github.com, so the gear-binary download
+# channel cannot work there. We detect that once, say so plainly, and skip the
+# native gear install instead of dying on a raw `curl: (56)` error: the fit-*
+# CLIs still run via `bunx fit-*` from npm.
+GEAR_NET=""   # "" (unprobed) | "ok" | "blocked"
+gear_net_ok() {
+  if [ -z "$GEAR_NET" ]; then
+    if curl -fsS --max-time 8 -o /dev/null "https://github.com" 2>/dev/null; then
+      GEAR_NET=ok
+    else
+      GEAR_NET=blocked
+      echo "note: github.com unreachable (network policy?) — skipping native gear binaries; fit-* run via 'bunx fit-*'"
+    fi
+  fi
+  [ "$GEAR_NET" = ok ]
+}
+
 # install_one NAME — route one tool to its install channel for this platform.
 install_one() {
   local name="$1" kind
 
   if command -v "$name" &>/dev/null; then
-    echo "$name already installed"
+    PRESENT+=("$name")
     return 0
   fi
 
   if is_gear_binary "$name"; then
     if [ "$IS_DARWIN" = 1 ]; then
       brew_install_gear
-    elif [ "$GEAR_DOWNLOAD" = 1 ]; then
-      install_gear_binary "$name"
-    else
+    elif [ "$GEAR_DOWNLOAD" = 0 ]; then
       # No raw gear asset for this platform (e.g. linux-aarch64). Skip rather
       # than hard-fail: the arm64 release runner builds gear from source and
       # never needs a pre-built one, and arm64 runtime installs go via Homebrew.
-      echo "::notice::skipping gear binary '$name' on $OS-$ARCH — no raw gear asset (arm64 gear ships via Homebrew; CI builds from source)"
+      SKIPPED+=("$name")
+    elif gear_net_ok; then
+      # A single asset that 404s (unpublished release) must not abort the whole
+      # hook either — record it and move on. Calling in `||` context suppresses
+      # errexit inside install_gear_binary.
+      install_gear_binary "$name" || SKIPPED+=("$name")
+    else
+      SKIPPED+=("$name")   # github blocked; gear_net_ok already explained why
     fi
     return 0
   fi
@@ -538,3 +569,11 @@ install_one() {
 for name in "${NAMES[@]}"; do
   install_one "$name"
 done
+
+# ── Summary ──────────────────────────────────────────────────────
+# One line for the steady state (everything already present) and an explicit
+# list for anything skipped — so a warm session is near-silent and a degraded
+# one says exactly what is missing.
+[ "${#PRESENT[@]}" -gt 0 ] && echo "tools ready (${#PRESENT[@]}): ${PRESENT[*]}"
+[ "${#SKIPPED[@]}" -gt 0 ] && echo "tools skipped, will run via bunx: ${SKIPPED[*]}"
+exit 0

--- a/.github/actions/bootstrap/fit-install.sh
+++ b/.github/actions/bootstrap/fit-install.sh
@@ -15,6 +15,15 @@
 #             release tag (FIT_GEAR_RELEASE) and verified against a .sha256
 #             sidecar. This is the reproducible, cacheable path.
 #
+# When the reproducible channel is unreachable — notably a Claude Code web
+# session, whose network policy blocks github.com entirely (release assets
+# included, for every repo) while allowing package registries — each tool falls
+# back to a trusted registry: apt for the distro CLIs (ripgrep, just, gh,
+# gitleaks) and the npm registry for our own gear CLIs (published as node
+# launchers). claude already downloads from the npm registry, so it needs no
+# fallback. apm has no trusted-registry build, so a blocked web session skips it
+# rather than failing. See the CHANNELS section below.
+#
 # Two tools stay on the pinned download path on BOTH platforms (no brew): `claude`
 # is the SDK-embedded Claude Code CLI whose version must track
 # @anthropic-ai/claude-agent-sdk in libraries/libharness/package.json, and `apm`
@@ -61,24 +70,24 @@ DEFAULT_TOOLS=(apm just gh rg gitleaks claude coaligned
 FIT_RELEASE_REPO="${FIT_RELEASE_REPO:-forwardimpact/monorepo}"
 FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.14}"
 
-# ── tool registry ────────────────────────────────────────────────
-# The routing table: how each external tool is installed on Darwin.
-#   formula   — a homebrew-core formula (brew install <token>)
-#   cask      — a homebrew cask (brew install --cask <token>)
-#   download  — never brew, on any platform; pinned+verified download into
-#               $HOME/.local (the resolve_<name> function below). This is the
-#               escape hatch for version-pinned tools (claude, apm).
-# On Linux every external tool uses its resolve_<name>, regardless of kind.
-#
-#            name      kind      brew-token
-TOOL_TABLE="
-apm       download  -
-just      formula   just
-gh        formula   gh
-rg        formula   ripgrep
-gitleaks  formula   gitleaks
-claude    download  -
-"
+# ── tool classification ──────────────────────────────────────────
+# System-package-manager token for the four third-party CLIs a distro packages.
+# The homebrew formula name and the Debian/Ubuntu package name are identical for
+# all four, so one map serves both the brew (macOS) and apt (Linux) channels.
+# The installed command can differ from the package name (ripgrep ships `rg`).
+pkg_token() {
+  case "$1" in
+    rg)       echo ripgrep ;;
+    just)     echo just ;;
+    gh)       echo gh ;;
+    gitleaks) echo gitleaks ;;
+    *)        return 1 ;;
+  esac
+}
+
+# A "system tool" is one a platform package manager can provide (the four
+# above). Everything else is a gear binary, apm, or claude.
+is_system_tool() { pkg_token "$1" >/dev/null 2>&1; }
 
 # The gear cask ships ALL gear CLIs (every fit-* plus coaligned) via `binary`
 # stanzas that symlink each one onto brew's bin. The fully-qualified name
@@ -100,9 +109,10 @@ IS_DARWIN=0
 GEAR_DOWNLOAD=0
 [ "$OS-$ARCH" = "linux-x86_64" ] && GEAR_DOWNLOAD=1
 
-# Bun compile target for this platform. Binaries are built only for linux-x64
-# and darwin-arm64; any other platform is unsupported and fails hard — this is
-# the binary distribution path, with no bunx/npx fallback.
+# Bun compile target for the gear-binary download channel. Raw per-CLI assets
+# exist only for linux-x64 and darwin-arm64; the dispatcher only calls this on a
+# supported target (GEAR_DOWNLOAD gates it), and other platforms fall back to the
+# npm channel (node launchers).
 fit_target() {
   case "$(uname -s)-$(uname -m)" in
     Linux-x86_64)  echo "bun-linux-x64" ;;
@@ -116,33 +126,17 @@ fit_target() {
 # bare {name}-{target} file in the gear release beside a .sha256 sidecar.
 is_gear_binary() { case "$1" in fit-*|coaligned) return 0 ;; *) return 1 ;; esac; }
 
-# tool_field NAME COLUMN(kind|token) — look up a column in TOOL_TABLE. Prints
-# nothing (and returns non-zero via the empty read) for an unknown name.
-tool_field() {
-  local want="$1" col="$2" n kind token
-  while read -r n kind token; do
-    [ -z "$n" ] && continue
-    if [ "$n" = "$want" ]; then
-      case "$col" in
-        kind)  printf '%s\n' "$kind" ;;
-        token) printf '%s\n' "$token" ;;
-      esac
-      return 0
-    fi
-  done <<EOF
-$TOOL_TABLE
-EOF
-}
-
 # ── --paths / argument parsing ───────────────────────────────────
 # The default set is ALWAYS installed; named gear CLIs add to it (deduped). So
 # `clis: fit-doc` yields the external tools plus fit-doc, never fit-doc alone —
 # bootstrap.sh still finds `just`.
 PRINT_PATHS=0
+SOFT=0
 EXTRA=()
 for arg in "$@"; do
   case "$arg" in
     --paths) PRINT_PATHS=1 ;;
+    --soft)  SOFT=1 ;;         # best-effort: report unavailable tools, still exit 0
     *)       EXTRA+=("$arg") ;;
   esac
 done
@@ -173,8 +167,8 @@ if [ "$PRINT_PATHS" = "1" ]; then
       [ "$GEAR_DOWNLOAD" = 0 ] && continue     # no raw gear asset (e.g. linux-arm64)
       echo "$BIN_DIR/$name"
     else
-      if [ "$IS_DARWIN" = 1 ] && [ "$(tool_field "$name" kind)" != "download" ]; then
-        continue                              # brew formula/cask — not cached
+      if [ "$IS_DARWIN" = 1 ] && is_system_tool "$name"; then
+        continue                              # brew formula — installed in brew's prefix, not cached
       fi
       echo "$LIB_DIR/$name"
       echo "$BIN_DIR/$name"
@@ -254,9 +248,9 @@ install_tool() {
 #
 # Download a pre-compiled gear binary (any fit-* CLI or coaligned) from its
 # pinned gear release, verify it against the published .sha256 sidecar, and
-# install it straight into BIN_DIR. A missing binary (unsupported platform or
-# unpublished release) fails hard — there is no bunx/npx fallback. Linux only;
-# on Darwin the fit-gear cask supersedes this.
+# install it straight into BIN_DIR. Returns non-zero on any failure (missing
+# asset, blocked network) so the dispatcher can fall back to the npm channel.
+# Linux only; on Darwin the fit-gear cask supersedes this.
 install_gear_binary() {
   local name="$1"
   local target release base
@@ -285,8 +279,9 @@ install_gear_binary() {
 # ── Helpers (brew path, Darwin) ──────────────────────────────────
 
 # Ensure `brew` is callable, sourcing its shellenv from the standard prefixes if
-# it is installed but not yet on PATH (fresh shells, some CI images). A genuinely
-# absent brew fails hard — Darwin has no download fallback for brew-managed tools.
+# it is installed but not yet on PATH (fresh shells, some CI images). Returns
+# non-zero when brew is genuinely absent, so the caller's channel can step aside
+# — the release channel resolves these tools on Darwin too.
 require_brew() {
   if ! command -v brew &>/dev/null; then
     local p
@@ -294,19 +289,17 @@ require_brew() {
       if [ -x "$p" ]; then eval "$("$p" shellenv)"; break; fi
     done
   fi
-  command -v brew &>/dev/null || {
-    echo "::error::brew not found on Darwin; install Homebrew first" >&2
-    exit 1
-  }
+  command -v brew &>/dev/null
 }
 
 # brew_install_formula TOKEN NAME — install a homebrew-core formula if its
 # command isn't already present. `brew list` short-circuits reinstalls so this
 # is cheap to re-run (the bootstrap action always runs the install step on macOS).
+# Returns non-zero on any failure so the dispatcher can try the next channel.
 brew_install_formula() {
   local token="$1" name="$2"
-  require_brew
-  brew list --formula "$token" &>/dev/null || brew install "$token"
+  require_brew || return 1
+  brew list --formula "$token" &>/dev/null || brew install "$token" || return 1
   echo "Installed $name $("$name" --version 2>/dev/null | head -1)"
 }
 
@@ -314,8 +307,8 @@ brew_install_formula() {
 # (kept for when a download tool moves to a cask), mirrors the formula helper.
 brew_install_cask() {
   local token="$1" name="$2"
-  require_brew
-  brew list --cask "${token##*/}" &>/dev/null || brew install --cask "$token"
+  require_brew || return 1
+  brew list --cask "${token##*/}" &>/dev/null || brew install --cask "$token" || return 1
   echo "Installed $name $("$name" --version 2>/dev/null | head -1)"
 }
 
@@ -324,8 +317,8 @@ brew_install_cask() {
 _GEAR_CASK_DONE=0
 brew_install_gear() {
   [ "$_GEAR_CASK_DONE" = 1 ] && return 0
-  require_brew
-  brew list --cask "${GEAR_CASK##*/}" &>/dev/null || brew install --cask "$GEAR_CASK"
+  require_brew || return 1
+  brew list --cask "${GEAR_CASK##*/}" &>/dev/null || brew install --cask "$GEAR_CASK" || return 1
   _GEAR_CASK_DONE=1
   echo "Installed gear cask (${GEAR_CASK##*/})"
 }
@@ -496,74 +489,127 @@ resolve_claude() {
 }
 
 # ── Install ──────────────────────────────────────────────────────
+#
+# Each tool resolves through an ordered list of CHANNELS; the first that
+# succeeds wins. This is what makes one script correct on every platform AND in
+# the restricted web-session sandbox. A channel returns 0 on success, or
+# non-zero when it is inapplicable here or its install failed — so the loop
+# moves to the next one. Channels run in `if`/`||` context, which disables
+# errexit for the whole call chain, so an internal curl/apt failure is caught
+# rather than aborting the script.
+#
+#   release      pinned, SHA-verified download into $HOME/.local (resolve_<name>).
+#                Reproducible; the CI/local default. github-hosted tools are
+#                gated on github reachability, since a web-session policy blocks
+#                github.com outright — the download can never succeed there.
+#   brew         Homebrew formula/cask (macOS only). The native macOS channel.
+#   apt          Debian/Ubuntu package (Linux only). The trusted fallback when
+#                github is blocked; archive.ubuntu.com is on every web allowlist.
+#   npm          global install from the npm registry (any platform). Always
+#                allowlisted, so it is the universal fallback for our gear CLIs
+#                (published as node launchers).
+#
+# claude's "release" is an npm-registry tarball, not github, so it is NOT gated
+# and works in web sessions as-is. apm has no channel but its github release, so
+# a blocked web session skips it (reported, not fatal under --soft).
 
-# Session-start accounting. A warm session re-runs this hook with everything
-# already present; rather than a line per tool, we tally outcomes and print one
-# summary at the end. Only real deltas (a fresh install, printed by the install
-# helpers) and a one-time degraded-mode notice speak up as they happen.
-PRESENT=()
-SKIPPED=()
+PRESENT=()      # already on PATH
+INSTALLED=()    # freshly installed this run, via any channel
+SKIPPED=()      # no channel could provide it (reported; fatal unless --soft)
 
-# Lazily probe whether the gear release host (github.com) is reachable, caching
-# the verdict. Some environments — notably the web-session network policy —
-# allow the npm registry but block github.com, so the gear-binary download
-# channel cannot work there. We detect that once, say so plainly, and skip the
-# native gear install instead of dying on a raw `curl: (56)` error: the fit-*
-# CLIs still run via `bunx fit-*` from npm.
-GEAR_NET=""   # "" (unprobed) | "ok" | "blocked"
-gear_net_ok() {
-  if [ -z "$GEAR_NET" ]; then
+# Probe github.com once, caching the verdict. Web-session network policies allow
+# the npm/apt registries but block github.com, so github-hosted release assets
+# — third-party or our own gear, whatever the repo — simply cannot download
+# there. Detecting this lets the release channel step aside for a trusted one
+# instead of dying on a raw `curl: (56)`.
+GITHUB_NET=""   # "" (unprobed) | "ok" | "blocked"
+github_reachable() {
+  if [ -z "$GITHUB_NET" ]; then
     if curl -fsS --max-time 8 -o /dev/null "https://github.com" 2>/dev/null; then
-      GEAR_NET=ok
+      GITHUB_NET=ok
     else
-      GEAR_NET=blocked
-      echo "note: github.com unreachable (network policy?) — skipping native gear binaries; fit-* run via 'bunx fit-*'"
+      GITHUB_NET=blocked
+      echo "note: github.com unreachable (network policy?) — using package registries (apt/npm) instead"
     fi
   fi
-  [ "$GEAR_NET" = ok ]
+  [ "$GITHUB_NET" = ok ]
 }
 
-# install_one NAME — route one tool to its install channel for this platform.
-install_one() {
-  local name="$1" kind
+# Every release download is github-hosted EXCEPT claude, whose pinned tarball
+# comes from the (always-allowlisted) npm registry — so it is never gated.
+github_hosted() { [ "$1" != claude ]; }
 
+# apt plumbing (Linux fallback): one guarded `apt-get update` per run, executed
+# as root directly or via sudo when available.
+AS_ROOT=""
+[ "$(id -u)" != 0 ] && command -v sudo &>/dev/null && AS_ROOT="sudo"
+_APT_UPDATED=0
+apt_update_once() {
+  [ "$_APT_UPDATED" = 1 ] && return 0
+  $AS_ROOT env DEBIAN_FRONTEND=noninteractive apt-get update -qq >/dev/null 2>&1 || return 1
+  _APT_UPDATED=1
+}
+
+# ── Channels ─────────────────────────────────────────────────────
+
+ch_release() {
+  if github_hosted "$1"; then github_reachable || return 1; fi
+  "resolve_$1"
+}
+
+ch_release_gear() {
+  [ "$GEAR_DOWNLOAD" = 1 ] || return 1     # no raw gear asset (e.g. linux-arm64)
+  github_reachable || return 1
+  install_gear_binary "$1"
+}
+
+ch_brew()      { [ "$IS_DARWIN" = 1 ] && brew_install_formula "$(pkg_token "$1")" "$1"; }
+ch_brew_gear() { [ "$IS_DARWIN" = 1 ] && brew_install_gear; }
+
+ch_apt() {
+  [ "$IS_DARWIN" = 0 ] || return 1
+  local pkg; pkg="$(pkg_token "$1")" || return 1
+  apt_update_once || return 1
+  $AS_ROOT env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$pkg" >/dev/null 2>&1 || return 1
+  echo "Installed $1 $("$1" --version 2>/dev/null | head -1) (apt $pkg)"
+}
+
+ch_npm() {
+  # Our gear CLIs publish to npm as node launchers; a global install puts the
+  # command on PATH (npm's global bin is already there). Not every gear CLI is
+  # published (coaligned is not yet), so a 404 just falls through.
+  npm install -g "$1" >/dev/null 2>&1 || return 1
+  echo "Installed $1 $("$1" --version 2>/dev/null | head -1) (npm)"
+}
+
+# channels_for NAME — the ordered channel list for a tool on this platform.
+# macOS resolves via its first channel (brew) since github is reachable there
+# anyway; Linux CI/local hits `release` (pinned, reproducible); a blocked Linux
+# web session falls through to the trusted registry.
+channels_for() {
+  if is_gear_binary "$1"; then
+    echo "brew_gear release_gear npm"
+  elif is_system_tool "$1"; then
+    echo "brew release apt"
+  else
+    echo "release"        # apm, claude — pinned download only (claude via npm)
+  fi
+}
+
+# install_one NAME — try each channel in order; first success wins.
+install_one() {
+  local name="$1" ch
   if command -v "$name" &>/dev/null; then
     PRESENT+=("$name")
     return 0
   fi
-
-  if is_gear_binary "$name"; then
-    if [ "$IS_DARWIN" = 1 ]; then
-      brew_install_gear
-    elif [ "$GEAR_DOWNLOAD" = 0 ]; then
-      # No raw gear asset for this platform (e.g. linux-aarch64). Skip rather
-      # than hard-fail: the arm64 release runner builds gear from source and
-      # never needs a pre-built one, and arm64 runtime installs go via Homebrew.
-      SKIPPED+=("$name")
-    elif gear_net_ok; then
-      # A single asset that 404s (unpublished release) must not abort the whole
-      # hook either — record it and move on. Calling in `||` context suppresses
-      # errexit inside install_gear_binary.
-      install_gear_binary "$name" || SKIPPED+=("$name")
-    else
-      SKIPPED+=("$name")   # github blocked; gear_net_ok already explained why
+  for ch in $(channels_for "$name"); do
+    if "ch_$ch" "$name"; then
+      INSTALLED+=("$name")
+      return 0
     fi
-    return 0
-  fi
-
-  kind="$(tool_field "$name" kind)"
-  if [ -z "$kind" ]; then
-    echo "::error::unknown tool '$name' (expected one of: ${DEFAULT_TOOLS[*]}, a fit-* CLI, or coaligned)" >&2
-    exit 1
-  fi
-
-  if [ "$IS_DARWIN" = 1 ] && [ "$kind" = "formula" ]; then
-    brew_install_formula "$(tool_field "$name" token)" "$name"
-  elif [ "$IS_DARWIN" = 1 ] && [ "$kind" = "cask" ]; then
-    brew_install_cask "$(tool_field "$name" token)" "$name"
-  else
-    "resolve_$name"
-  fi
+  done
+  SKIPPED+=("$name")
 }
 
 for name in "${NAMES[@]}"; do
@@ -571,9 +617,17 @@ for name in "${NAMES[@]}"; do
 done
 
 # ── Summary ──────────────────────────────────────────────────────
-# One line for the steady state (everything already present) and an explicit
-# list for anything skipped — so a warm session is near-silent and a degraded
-# one says exactly what is missing.
-[ "${#PRESENT[@]}" -gt 0 ] && echo "tools ready (${#PRESENT[@]}): ${PRESENT[*]}"
-[ "${#SKIPPED[@]}" -gt 0 ] && echo "tools skipped, will run via bunx: ${SKIPPED[*]}"
+# Steady state on one line; explicit lists for what changed or is missing. A
+# warm session stays near-silent; a degraded one names exactly what it lacks.
+[ "${#PRESENT[@]}" -gt 0 ]   && echo "tools ready (${#PRESENT[@]}): ${PRESENT[*]}"
+[ "${#INSTALLED[@]}" -gt 0 ] && echo "tools installed (${#INSTALLED[@]}): ${INSTALLED[*]}"
+if [ "${#SKIPPED[@]}" -gt 0 ]; then
+  echo "tools unavailable: ${SKIPPED[*]}" >&2
+  if [ "$SOFT" = "1" ]; then
+    echo "note: continuing without them (--soft); published gear CLIs still run via 'bunx <name>'" >&2
+  else
+    echo "::error::no install channel succeeded for: ${SKIPPED[*]}" >&2
+    exit 1
+  fi
+fi
 exit 0

--- a/launchers/README.md
+++ b/launchers/README.md
@@ -7,6 +7,12 @@ npm name equals the invoked name (`fit-harness`, `fit-wiki`, …), so the
 documented `npx fit-*` contract resolves from the registry
 ([originating spec](../specs/1670-public-cli-launcher-packages/spec.md)).
 
+The one non-`fit-*` public CLI is `coaligned` (backed by
+`@forwardimpact/libcoaligned`), invoked as `npx coaligned …` in the published
+setup skills. The fit-only invocation scan cannot see it, so it is named in the
+rule's `PUBLISHED_NON_FIT_CLIS` — the launcher stays computed, not
+hand-maintained.
+
 ## Contract
 
 - **npm name = invoked name.** The launcher's only content is a two-line

--- a/launchers/coaligned/bin/coaligned.js
+++ b/launchers/coaligned/bin/coaligned.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "@forwardimpact/libcoaligned/bin/coaligned.js";

--- a/launchers/coaligned/package.json
+++ b/launchers/coaligned/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "coaligned",
+  "version": "0.0.0",
+  "description": "Run coaligned from the npm registry — launcher for @forwardimpact/libcoaligned",
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "launchers/coaligned"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "type": "module",
+  "bin": {
+    "coaligned": "./bin/coaligned.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "dependencies": {
+    "@forwardimpact/libcoaligned": "0.0.0"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,19 +14,7 @@ set -euo pipefail
 # against a stale cache (e.g. one saved before relative symlinks, whose links
 # dangle once restored at a different path) by verifying the generated tree
 # resolves, and fall back to codegen only when it does not.
-if [ "${BOOTSTRAP_WORKSPACE_CACHE_HIT:-}" = "true" ]; then
-  needs_codegen=0
-  [ -d generated/types ] || needs_codegen=1
-  for link in libraries/*/src/generated; do
-    [ -e "$link" ] || needs_codegen=1
-  done
-  if [ "$needs_codegen" = "0" ]; then
-    echo "Workspace cache hit — generated restored; skipping bun install and codegen"
-  else
-    echo "Workspace cache hit — generated tree incomplete; running codegen"
-    just codegen
-  fi
-else
+if [ "${BOOTSTRAP_WORKSPACE_CACHE_HIT:-}" = "false" ]; then
   # cache-hit=false signals an exact-key miss, but actions/cache may still
   # have served a restore-keys prefix match — leaving node_modules and
   # generated/ from an unrelated commit's tree on disk. bun install
@@ -37,6 +25,27 @@ else
   # so the resulting tree derives solely from bun.lock.
   rm -rf node_modules generated libraries/*/src/generated
   just install
+else
+  # A warm cache (cache-hit=true) OR a resumed/web session (the env var is
+  # unset — it is a CI-only signal). Reuse the tree when it fully resolves:
+  # node_modules present, generated/ built, and every relative symlink intact.
+  # Only do work when something is missing, so most sessions start instantly
+  # instead of wiping a valid tree and reinstalling from scratch every time.
+  needs_install=0
+  [ -d node_modules ] || needs_install=1
+  [ -d generated/types ] || needs_install=1
+  for link in libraries/*/src/generated; do
+    [ -e "$link" ] || needs_install=1
+  done
+  if [ "$needs_install" = "0" ]; then
+    echo "Workspace ready — node_modules and generated resolve; skipping install and codegen"
+  elif [ -d node_modules ]; then
+    echo "Workspace present but generated tree incomplete; running codegen"
+    just codegen
+  else
+    echo "Workspace missing; installing"
+    just install
+  fi
 fi
 
 # ── Wiki sync ────────────────────────────────────────────────────
@@ -54,5 +63,21 @@ if [[ -n "$origin_url" && "$origin_url" != *github.com* ]]; then
   fi
 fi
 
-bunx fit-wiki init || echo "bootstrap: wiki init skipped (continuing)" >&2
-bunx fit-wiki pull || echo "bootstrap: wiki pull skipped (continuing)" >&2
+wiki_status=synced
+bunx fit-wiki init || { wiki_status=skipped; echo "bootstrap: wiki init skipped (continuing)" >&2; }
+bunx fit-wiki pull || { wiki_status=skipped; echo "bootstrap: wiki pull skipped (continuing)" >&2; }
+
+# ── Session banner ───────────────────────────────────────────────
+# One compact summary of what is worth knowing at a glance when a session
+# opens: where HEAD sits relative to origin/main, the runtime versions, and
+# whether the wiki synced. Everything here is read-only and best-effort.
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')
+echo "─── session ready ───"
+echo "branch: $branch"
+if git rev-parse --verify -q origin/main >/dev/null 2>&1; then
+  counts=$(git rev-list --left-right --count origin/main...HEAD 2>/dev/null || echo '? ?')
+  behind=${counts%%[[:space:]]*}
+  ahead=${counts##*[[:space:]]}
+  echo "vs origin/main: ${ahead:-?} ahead, ${behind:-?} behind"
+fi
+echo "node $(node --version 2>/dev/null || echo '?') · bun $(bun --version 2>/dev/null || echo '?') · wiki $wiki_status"


### PR DESCRIPTION
## Summary

- **Quieter, more honest session-start hooks.** `fit-install.sh` collapses the per-tool "already installed" noise into a single summary line and no longer dies on a raw `curl: (56)`; `bootstrap.sh` reuses a valid workspace instead of wiping and reinstalling on every web session, and ends with a compact banner (branch, ahead/behind `origin/main`, versions, wiki status).
- **Ordered install channels.** Each tool resolves through `release → brew/apt/npm`, first success wins. CI and local keep the pinned, SHA-verified download; where `github.com` is unreachable (a Claude Code web session blocks it outright, release assets included) tools fall back to a trusted registry — `apt` for the distro CLIs, `npm` for our gear CLIs. `apm` has no trusted-registry build, so a blocked web session skips it rather than failing. New `--soft` flag makes session hooks report unavailable tools and exit 0; CI omits it, keeping a missing tool a hard failure.
- **`coaligned` launcher.** Added `launchers/coaligned/` (backed by `@forwardimpact/libcoaligned`) so `npx coaligned` resolves from the registry and the npm install channel can provision it in web sessions. Extended the `public-cli-set` invariant's curated escape hatch (`PUBLISHED_NON_FIT_CLIS`) so the one non-`fit-*` public CLI stays part of the computed set.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- Verified in a web session: `apt` installs ripgrep from the Ubuntu archive, `npm` installs all five `fit-*` CLIs, soft/strict exit codes behave as specified, and `coaligned invariants` passes for the new launcher.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTphwfuV2YntzPbwdaFQPQ)_