### PR TITLE
feat(svcspan): rename svctrace to svcspan (#2200)

### DIFF
--- a/.claude/skills/fit-guide/references/data.md
+++ b/.claude/skills/fit-guide/references/data.md
@@ -15,7 +15,7 @@ any step after editing its inputs.
 | `data/vectors/`   | Embedding vector indices                |
 | `data/graphs/`    | RDF quad index + ontology               |
 | `data/memories/`  | Conversation state                      |
-| `data/traces/`    | Distributed traces                      |
+| `data/spans/`     | Distributed traces                      |
 | `data/policies/`  | Access control policies                 |
 | `data/logs/`      | Service logs                            |
 | `data/cli/`       | CLI session data                        |

--- a/.claude/skills/fit-visualize/SKILL.md
+++ b/.claude/skills/fit-visualize/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: fit-visualize
 description: >
-  Query recorded traces with JMESPath and render them as Mermaid sequence
-  diagrams. Use when you need to read back spans from the trace index, filter by
-  trace or resource id, and see the call flow without wiring up a tracing UI.
+  Query recorded OpenTelemetry spans with JMESPath and render them as Mermaid
+  sequence diagrams. Use when you need to read spans back from the span index,
+  filter by trace or resource id, and see the call flow without wiring up a
+  tracing UI.
 ---
 
-# Visualize Recorded Traces
+# Visualize Recorded Spans
 
-`fit-visualize` reads spans from the trace index, filters them with a JMESPath
+`fit-visualize` reads spans from the span index, filters them with a JMESPath
 expression piped on stdin, and prints a Mermaid sequence diagram you can paste
-into any Markdown renderer. Use it to see what a service did after traces are
+into any Markdown renderer. Use it to see what a service did once spans are
 flowing.
 
 ## When to Use
@@ -39,13 +40,13 @@ The JMESPath expression is read from stdin and applied to the spans before
 rendering. `--trace` and `--resource` narrow the set first. Output is a fenced
 `mermaid` block, ready to paste into Markdown.
 
-The trace index is read from the `traces` storage location. Record spans first —
-see the guide below.
+Spans are read from the `spans` storage location. Record spans first — see the
+guide below.
 
 ## Documentation
 
 - [Add Observability](https://www.forwardimpact.team/docs/libraries/service-lifecycle/add-observability/index.md)
-  — Structured logs and traces with no framework setup, including querying and
-  visualizing recorded traces with `fit-visualize`.
+  — Structured logs and spans with no framework setup, including querying and
+  visualizing recorded spans with `fit-visualize`.
 - [Manage Service Lifecycle from One Interface](https://www.forwardimpact.team/docs/libraries/service-lifecycle/index.md)
   — The full lifecycle setup for services, from supervision to observability.

--- a/.coaligned/invariants/service-url-drift.registry.yml
+++ b/.coaligned/invariants/service-url-drift.registry.yml
@@ -18,8 +18,8 @@
 # kinds — kept consistent by hand when a manifest port changes, not gated).
 
 services:
-  trace:
-    manifest: services/trace/server.js
+  span:
+    manifest: services/span/server.js
     consumers:
       - { kind: env, path: .env.local.example }
       - { kind: env, path: .env.docker-native.example }

--- a/.env.docker-native.example
+++ b/.env.docker-native.example
@@ -45,7 +45,7 @@ NO_PROXY=localhost,127.0.0.1,*.local
 # Core Services
 # ==========================================
 
-SERVICE_TRACE_URL=grpc://localhost:3001
+SERVICE_SPAN_URL=grpc://localhost:3001
 SERVICE_VECTOR_URL=grpc://localhost:3002
 SERVICE_GRAPH_URL=grpc://localhost:3003
 SERVICE_MAP_URL=grpc://localhost:3004

--- a/.env.docker-supabase.example
+++ b/.env.docker-supabase.example
@@ -45,7 +45,7 @@ NO_PROXY=localhost,127.0.0.1,*.local
 # Core Services
 # ==========================================
 
-SERVICE_TRACE_URL=grpc://localhost:3001
+SERVICE_SPAN_URL=grpc://localhost:3001
 SERVICE_VECTOR_URL=grpc://localhost:3002
 SERVICE_GRAPH_URL=grpc://localhost:3003
 SERVICE_MAP_URL=grpc://localhost:3004

--- a/.env.local.example
+++ b/.env.local.example
@@ -37,7 +37,7 @@
 # Core Services
 # ==========================================
 
-SERVICE_TRACE_URL=grpc://localhost:3001
+SERVICE_SPAN_URL=grpc://localhost:3001
 SERVICE_VECTOR_URL=grpc://localhost:3002
 SERVICE_GRAPH_URL=grpc://localhost:3003
 SERVICE_MAP_URL=grpc://localhost:3004

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -144,7 +144,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p data/logs
-          bun run services/trace/server.js     > data/logs/trace.log   2>&1 &
+          bun run services/span/server.js     > data/logs/span.log   2>&1 &
           bun run services/graph/server.js     > data/logs/graph.log   2>&1 &
           bun run services/pathway/server.js   > data/logs/pathway.log 2>&1 &
           bun run services/mcp/server.js       > data/logs/mcp.log     2>&1 &
@@ -188,7 +188,7 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          for f in data/logs/trace.log data/logs/graph.log data/logs/pathway.log data/logs/mcp.log; do
+          for f in data/logs/span.log data/logs/graph.log data/logs/pathway.log data/logs/mcp.log; do
             echo "=== $f ==="
             cat "$f" 2>/dev/null || echo "(not found)"
           done
@@ -196,4 +196,4 @@ jobs:
       - name: Stop services
         if: always()
         shell: bash
-        run: pkill -f "svcgraph\|svcpathway\|svcmcp\|svctrace" || true
+        run: pkill -f "svcgraph\|svcpathway\|svcmcp\|svcspan" || true

--- a/build/cli-manifest.json
+++ b/build/cli-manifest.json
@@ -49,7 +49,7 @@
       "server": true
     },
     {
-      "name": "fit-svctrace",
+      "name": "fit-svcspan",
       "targets": ["bun-linux-x64", "bun-linux-arm64", "bun-darwin-arm64"],
       "bundle": "gear",
       "server": true

--- a/bun.lock
+++ b/bun.lock
@@ -153,7 +153,7 @@
     },
     "libraries/libharness": {
       "name": "@forwardimpact/libharness",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "bin": {
         "fit-harness": "./bin/fit-harness.js",
         "fit-trace": "./bin/fit-trace.js",
@@ -231,7 +231,7 @@
     },
     "libraries/libpack": {
       "name": "@forwardimpact/libpack",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "bin": {
         "fit-pack": "./bin/fit-pack.js",
       },
@@ -356,7 +356,7 @@
     },
     "libraries/libskill": {
       "name": "@forwardimpact/libskill",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
       },
@@ -419,7 +419,7 @@
     },
     "libraries/libsyntheticprose": {
       "name": "@forwardimpact/libsyntheticprose",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "dependencies": {
         "@forwardimpact/libprompt": "^0.1.0",
         "@forwardimpact/libsyntheticgen": "^0.1.21",
@@ -485,7 +485,7 @@
     },
     "libraries/libterrain": {
       "name": "@forwardimpact/libterrain",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "bin": {
         "fit-terrain": "./bin/fit-terrain.js",
       },
@@ -495,7 +495,7 @@
         "@forwardimpact/libpreflight": "^0.1.0",
         "@forwardimpact/libprompt": "^0.1.0",
         "@forwardimpact/libsecret": "^0.1.14",
-        "@forwardimpact/libskill": "^6.1.0",
+        "@forwardimpact/libskill": "^6.2.0",
         "@forwardimpact/libsyntheticgen": "^0.1.0",
         "@forwardimpact/libsyntheticprose": "^0.1.0",
         "@forwardimpact/libsyntheticrender": "^0.1.0",
@@ -610,7 +610,7 @@
     },
     "products/gear": {
       "name": "@forwardimpact/gear",
-      "version": "0.1.13",
+      "version": "0.1.21",
       "dependencies": {
         "@forwardimpact/libcodegen": "^0.1.49",
         "@forwardimpact/libdoc": "^0.2.24",
@@ -622,7 +622,7 @@
         "@forwardimpact/libstorage": "^0.1.72",
         "@forwardimpact/libsupervise": "^0.1.22",
         "@forwardimpact/libtelemetry": "^0.1.39",
-        "@forwardimpact/libterrain": "^0.1.22",
+        "@forwardimpact/libterrain": "^0.1.41",
         "@forwardimpact/libutil": "^0.1.78",
         "@forwardimpact/libvector": "^0.1.88",
         "@forwardimpact/libwiki": "^0.2.0",
@@ -630,7 +630,7 @@
         "@forwardimpact/svcgraph": "^0.1.68",
         "@forwardimpact/svcmcp": "^0.1.6",
         "@forwardimpact/svcpathway": "^0.1.13",
-        "@forwardimpact/svctrace": "^0.1.41",
+        "@forwardimpact/svcspan": "^0.1.41",
         "@forwardimpact/svcvector": "^0.1.120",
       },
     },
@@ -658,7 +658,7 @@
         "@forwardimpact/svcgraph": "^0.1.60",
         "@forwardimpact/svcmcp": "^0.1.0",
         "@forwardimpact/svcpathway": "^0.1.8",
-        "@forwardimpact/svctrace": "^0.1.34",
+        "@forwardimpact/svcspan": "^0.1.34",
         "@forwardimpact/svcvector": "^0.1.111",
       },
       "devDependencies": {
@@ -670,7 +670,7 @@
     },
     "products/landmark": {
       "name": "@forwardimpact/landmark",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "bin": {
         "fit-landmark": "./bin/fit-landmark.js",
       },
@@ -678,7 +678,7 @@
         "@forwardimpact/libcli": "^0.1.0",
         "@forwardimpact/libconfig": "^0.1.79",
         "@forwardimpact/libpreflight": "^0.1.0",
-        "@forwardimpact/libskill": "^6.0.0",
+        "@forwardimpact/libskill": "^6.2.0",
         "@forwardimpact/libtelemetry": "^0.1.33",
         "@forwardimpact/libutil": "^0.1.72",
         "@forwardimpact/map": "^0.15.18",
@@ -692,7 +692,7 @@
     },
     "products/map": {
       "name": "@forwardimpact/map",
-      "version": "0.15.62",
+      "version": "0.15.63",
       "bin": {
         "fit-map": "./bin/fit-map.js",
       },
@@ -701,11 +701,11 @@
         "@forwardimpact/libconfig": "^0.1.79",
         "@forwardimpact/libpreflight": "^0.1.0",
         "@forwardimpact/libsecret": "^0.1.14",
-        "@forwardimpact/libskill": "^6.0.0",
+        "@forwardimpact/libskill": "^6.2.0",
         "@forwardimpact/libsyntheticgen": "^0.1.0",
         "@forwardimpact/libtelemetry": "^0.1.33",
         "@forwardimpact/libtemplate": "^0.2.0",
-        "@forwardimpact/libterrain": "^0.1.40",
+        "@forwardimpact/libterrain": "^0.1.41",
         "@forwardimpact/libutil": "^0.1.64",
         "@supabase/supabase-js": "^2.108.1",
         "ajv": "^8.20.0",
@@ -743,7 +743,7 @@
     },
     "products/pathway": {
       "name": "@forwardimpact/pathway",
-      "version": "0.26.8",
+      "version": "0.26.9",
       "bin": {
         "fit-pathway": "./bin/fit-pathway.js",
       },
@@ -769,7 +769,7 @@
     },
     "products/summit": {
       "name": "@forwardimpact/summit",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "bin": {
         "fit-summit": "./bin/fit-summit.js",
       },
@@ -777,7 +777,7 @@
         "@forwardimpact/libcli": "^0.1.0",
         "@forwardimpact/libconfig": "^0.1.79",
         "@forwardimpact/libpreflight": "^0.1.0",
-        "@forwardimpact/libskill": "^6.0.0",
+        "@forwardimpact/libskill": "^6.2.0",
         "@forwardimpact/libtelemetry": "^0.1.33",
         "@forwardimpact/libutil": "^0.1.72",
         "@forwardimpact/map": "^0.15.18",
@@ -1038,6 +1038,27 @@
         "@forwardimpact/libmock": "^0.1.0",
       },
     },
+    "services/span": {
+      "name": "@forwardimpact/svcspan",
+      "version": "0.1.49",
+      "bin": {
+        "fit-svcspan": "./server.js",
+      },
+      "dependencies": {
+        "@forwardimpact/libcli": "^0.1.14",
+        "@forwardimpact/libconfig": "^0.1.58",
+        "@forwardimpact/libindex": "^0.1.27",
+        "@forwardimpact/libpreflight": "^0.1.0",
+        "@forwardimpact/librpc": "^0.1.77",
+        "@forwardimpact/libstorage": "^0.1.53",
+        "@forwardimpact/libtelemetry": "^0.1.41",
+        "@forwardimpact/libtype": "^0.1.63",
+        "@forwardimpact/libutil": "^0.1.85",
+      },
+      "devDependencies": {
+        "@forwardimpact/libmock": "^0.1.0",
+      },
+    },
     "services/tenancy": {
       "name": "@forwardimpact/svctenancy",
       "version": "0.1.2",
@@ -1052,27 +1073,6 @@
         "@forwardimpact/librpc": "^0.1.99",
         "@forwardimpact/libstorage": "^0.1.78",
         "@forwardimpact/libtelemetry": "^0.1.42",
-        "@forwardimpact/libutil": "^0.1.85",
-      },
-      "devDependencies": {
-        "@forwardimpact/libmock": "^0.1.0",
-      },
-    },
-    "services/trace": {
-      "name": "@forwardimpact/svctrace",
-      "version": "0.1.49",
-      "bin": {
-        "fit-svctrace": "./server.js",
-      },
-      "dependencies": {
-        "@forwardimpact/libcli": "^0.1.14",
-        "@forwardimpact/libconfig": "^0.1.58",
-        "@forwardimpact/libindex": "^0.1.27",
-        "@forwardimpact/libpreflight": "^0.1.0",
-        "@forwardimpact/librpc": "^0.1.77",
-        "@forwardimpact/libstorage": "^0.1.53",
-        "@forwardimpact/libtelemetry": "^0.1.41",
-        "@forwardimpact/libtype": "^0.1.63",
         "@forwardimpact/libutil": "^0.1.85",
       },
       "devDependencies": {
@@ -1392,9 +1392,9 @@
 
     "@forwardimpact/svcpathway": ["@forwardimpact/svcpathway@workspace:services/pathway"],
 
-    "@forwardimpact/svctenancy": ["@forwardimpact/svctenancy@workspace:services/tenancy"],
+    "@forwardimpact/svcspan": ["@forwardimpact/svcspan@workspace:services/span"],
 
-    "@forwardimpact/svctrace": ["@forwardimpact/svctrace@workspace:services/trace"],
+    "@forwardimpact/svctenancy": ["@forwardimpact/svctenancy@workspace:services/tenancy"],
 
     "@forwardimpact/svcvector": ["@forwardimpact/svcvector@workspace:services/vector"],
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -45,7 +45,7 @@ Defines which processes `fit-rc` manages.
     "log_dir": "data/logs",
     "shutdown_timeout": 3000,
     "services": [
-      { "name": "trace",   "command": "node -e \"import('@forwardimpact/svctrace/server.js')\"" },
+      { "name": "span",   "command": "node -e \"import('@forwardimpact/svcspan/server.js')\"" },
       { "name": "vector",  "command": "node -e \"import('@forwardimpact/svcvector/server.js')\"" },
       { "name": "graph",   "command": "node -e \"import('@forwardimpact/svcgraph/server.js')\"" },
       { "name": "map",     "command": "node -e \"import('@forwardimpact/svcmap/server.js')\"" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,21 +104,21 @@ services:
         aliases:
           - graph.local
 
-  trace:
+  span:
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        TARGET_PATH: services/trace
+        TARGET_PATH: services/span
       secrets:
         - github_token
-    image: fi/trace:latest
-    container_name: trace
+    image: fi/span:latest
+    container_name: span
     env_file: .env
     networks:
       internal:
         aliases:
-          - trace.local
+          - span.local
 
   # ==========================================
   # Embedding Service (TEI)

--- a/justfile
+++ b/justfile
@@ -115,11 +115,11 @@ process-graphs:
 
 # Initialize data directories
 data-init:
-    mkdir -p generated data/cli data/eval data/graphs data/ingest/in data/ingest/pipeline data/ingest/done data/knowledge data/logs data/memories data/policies data/resources data/traces data/vectors data/teams-tenant-configs data/teams-resource-ids data/tenants data/activity data/pathway data/personal
+    mkdir -p generated data/cli data/eval data/graphs data/ingest/in data/ingest/pipeline data/ingest/done data/knowledge data/logs data/memories data/policies data/resources data/spans data/vectors data/teams-tenant-configs data/teams-resource-ids data/tenants data/activity data/pathway data/personal
 
 # Remove generated data
 data-clean:
-    rm -rf generated data/cli data/eval data/logs data/graphs data/knowledge data/memories data/policies data/resources data/traces data/vectors data/teams-tenant-configs data/teams-resource-ids data/tenants
+    rm -rf generated data/cli data/eval data/logs data/graphs data/knowledge data/memories data/policies data/resources data/spans data/vectors data/teams-tenant-configs data/teams-resource-ids data/tenants
 
 # Clean, init, and regenerate code
 data-reset: data-clean data-init codegen

--- a/libraries/libmock/src/mock/clients.js
+++ b/libraries/libmock/src/mock/clients.js
@@ -76,11 +76,11 @@ export function createMockAgentClient(overrides = {}) {
 }
 
 /**
- * Creates a mock trace client
+ * Creates a mock span client
  * @param {object} overrides - Method overrides
- * @returns {object} Mock trace client
+ * @returns {object} Mock span client
  */
-export function createMockTraceClient(overrides = {}) {
+export function createMockSpanClient(overrides = {}) {
   return {
     RecordSpan: spy(() => Promise.resolve()),
     ...overrides,

--- a/libraries/libmock/src/mock/index.js
+++ b/libraries/libmock/src/mock/index.js
@@ -18,7 +18,7 @@ export {
   createMockMemoryClient,
   createMockLlmClient,
   createMockAgentClient,
-  createMockTraceClient,
+  createMockSpanClient,
   createMockVectorClient,
   createMockGraphClient,
   createMockToolClient,

--- a/libraries/librc/README.md
+++ b/libraries/librc/README.md
@@ -30,7 +30,7 @@ Omit `[service]` to operate on all configured services.
     "log_dir": "data/logs",
     "shutdown_timeout": 3000,
     "services": [
-      { "name": "trace", "command": "node -e \"import('@forwardimpact/svctrace/server.js')\"" }
+      { "name": "span", "command": "node -e \"import('@forwardimpact/svcspan/server.js')\"" }
     ]
   }
 }

--- a/libraries/librpc/src/index.js
+++ b/libraries/librpc/src/index.js
@@ -26,20 +26,20 @@ export const clients = exports.clients || {};
  * This factory should be called at startup in server.js files or when creating clients
  * @param {string} serviceName - Name of the service being traced
  * @returns {Promise<Tracer>} Configured tracer instance
- * @throws {Error} If trace service configuration cannot be loaded
+ * @throws {Error} If span service configuration cannot be loaded
  */
 export async function createTracer(serviceName) {
-  const traceConfig = await createServiceConfig("trace");
-  const { TraceClient } = clients;
+  const spanConfig = await createServiceConfig("span");
+  const { SpanClient } = clients;
   // createTracer is a composition-root factory; it builds the production
-  // runtime as its DI root, threads it into the TraceClient (so the client's
+  // runtime as its DI root, threads it into the SpanClient (so the client's
   // auth reads SERVICE_SECRET off the bag) and into the Tracer (and thus every
   // Span) via its clock.
   const runtime = createDefaultRuntime();
-  const traceClient = new TraceClient(traceConfig, runtime);
+  const spanClient = new SpanClient(spanConfig, runtime);
   return new Tracer({
     serviceName,
-    traceClient,
+    spanClient,
     grpcMetadata: grpc.Metadata,
     clock: runtime.clock,
   });

--- a/libraries/libtelemetry/bin/fit-visualize.js
+++ b/libraries/libtelemetry/bin/fit-visualize.js
@@ -102,8 +102,8 @@ const repl = new Repl({
   usage,
 
   setup: async (state) => {
-    const traceStorage = createStorage("traces");
-    state.traceIndex = new TraceIndex(traceStorage, "index.jsonl", {
+    const spanStorage = createStorage("spans");
+    state.traceIndex = new TraceIndex(spanStorage, "index.jsonl", {
       clock: runtime.clock,
     });
     state.visualizer = new TraceVisualizer(state.traceIndex, runtime);

--- a/libraries/libtelemetry/bin/fit-visualize.js
+++ b/libraries/libtelemetry/bin/fit-visualize.js
@@ -13,12 +13,13 @@ const runtime = createDefaultRuntime();
 
 const definition = {
   name: "fit-visualize",
-  description: "Query and visualize traces using JMESPath expressions",
+  description:
+    "Query and visualize OpenTelemetry spans using JMESPath expressions",
   globalOptions: {
-    trace: { type: "string", description: "Filter traces by trace ID" },
+    trace: { type: "string", description: "Filter spans by trace ID" },
     resource: {
       type: "string",
-      description: "Filter traces by resource ID",
+      description: "Filter spans by resource ID",
     },
     help: { type: "boolean", short: "h", description: "Show this help" },
     version: { type: "boolean", description: "Show version" },
@@ -33,7 +34,7 @@ const definition = {
       title: "Add Observability",
       url: "https://www.forwardimpact.team/docs/libraries/service-lifecycle/add-observability/index.md",
       description:
-        "Structured logs and traces with no framework setup, including querying and visualizing recorded traces with fit-visualize.",
+        "Structured logs and spans with no framework setup, including querying and visualizing recorded spans with fit-visualize.",
     },
     {
       title: "Manage Service Lifecycle from One Interface",
@@ -56,8 +57,8 @@ const { values } = parsed;
 
 const usage = `**Usage:** <JMESPath expression>
 
-Query and visualize traces from the trace index using JMESPath expressions.
-Apply filters to narrow down traces before querying.
+Query and visualize spans from the span index using JMESPath expressions.
+Apply filters to narrow the spans before querying.
 
 **Examples:**
 
@@ -67,9 +68,9 @@ Apply filters to narrow down traces before querying.
     echo "[?contains(name, 'QueryByPattern')]" | just cli-visualize ARGS="--resource common.Conversation.abc123"`;
 
 /**
- * Queries and visualizes traces using JMESPath
+ * Queries and visualizes spans using JMESPath
  * @param {string} prompt - The JMESPath query expression
- * @param {object} state - REPL state containing trace filters and indices
+ * @param {object} state - REPL state containing span filters and indices
  * @param {import("stream").Writable} outputStream - Stream to write results to
  */
 async function queryTraces(prompt, state, outputStream) {
@@ -116,7 +117,7 @@ const repl = new Repl({
 
   commands: {
     trace: {
-      usage: "Filter traces by trace ID",
+      usage: "Filter spans by trace ID",
       handler: (args, state) => {
         if (args.length === 0) {
           return "Usage: /trace <id>";
@@ -125,7 +126,7 @@ const repl = new Repl({
       },
     },
     resource: {
-      usage: "Filter traces by resource ID",
+      usage: "Filter spans by resource ID",
       handler: (args, state) => {
         if (args.length === 0) {
           return "Usage: /resource <id>";

--- a/libraries/libtelemetry/src/index/trace.js
+++ b/libraries/libtelemetry/src/index/trace.js
@@ -1,6 +1,6 @@
 import jmespath from "jmespath";
 import { BufferedIndex } from "@forwardimpact/libindex";
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 
 /**
  * Specialized index for trace spans with custom filtering
@@ -29,14 +29,14 @@ export class TraceIndex extends BufferedIndex {
     // Reconstruct span objects from plain JSON to ensure proper enum values
     for (const item of this.index.values()) {
       if (item.span && typeof item.span === "object") {
-        item.span = trace.Span.fromObject(item.span);
+        item.span = spanType.SpanItem.fromObject(item.span);
       }
     }
   }
 
   /**
    * Adds a span to the index with custom item structure
-   * @param {import("@forwardimpact/libtype").trace.Span} span - Span to add to the index
+   * @param {import("@forwardimpact/libtype").span.SpanItem} span - Span to add to the index
    * @returns {Promise<void>}
    */
   async add(span) {
@@ -49,8 +49,8 @@ export class TraceIndex extends BufferedIndex {
 
   /**
    * Sorts spans chronologically by start time
-   * @param {import("@forwardimpact/libtype").trace.Span[]} spans - Array of spans to sort
-   * @returns {import("@forwardimpact/libtype").trace.Span[]} Sorted array of spans
+   * @param {import("@forwardimpact/libtype").span.SpanItem[]} spans - Array of spans to sort
+   * @returns {import("@forwardimpact/libtype").span.SpanItem[]} Sorted array of spans
    */
   #sortSpansByTime(spans) {
     return spans.sort((a, b) => {
@@ -81,7 +81,7 @@ export class TraceIndex extends BufferedIndex {
   /**
    * Gets all spans from the given trace IDs
    * @param {Set<string>} traceIds - Set of trace IDs to retrieve spans for
-   * @returns {import("@forwardimpact/libtype").trace.Span[]} Array of spans from those traces
+   * @returns {import("@forwardimpact/libtype").span.SpanItem[]} Array of spans from those traces
    */
   #getSpansFromTraces(traceIds) {
     const spans = [];
@@ -97,7 +97,7 @@ export class TraceIndex extends BufferedIndex {
   /**
    * Gets all spans matching the optional trace_id filter
    * @param {string} [trace_id] - Optional trace ID filter
-   * @returns {import("@forwardimpact/libtype").trace.Span[]} Array of matching spans
+   * @returns {import("@forwardimpact/libtype").span.SpanItem[]} Array of matching spans
    */
   #getSpansByTraceId(trace_id) {
     const spans = [];
@@ -113,7 +113,7 @@ export class TraceIndex extends BufferedIndex {
   /**
    * Filters traces by evaluating JMESPath query per-trace
    * Returns trace IDs where the JMESPath query has a positive match
-   * @param {Map<string, import("@forwardimpact/libtype").trace.Span[]>} traceGroups - Spans grouped by trace_id
+   * @param {Map<string, import("@forwardimpact/libtype").span.SpanItem[]>} traceGroups - Spans grouped by trace_id
    * @param {string} query - JMESPath expression to evaluate
    * @returns {string[]} Array of matching trace IDs
    */
@@ -147,7 +147,7 @@ export class TraceIndex extends BufferedIndex {
    * @param {object} [filter] - Filter object for query constraints
    * @param {string} [filter.trace_id] - Filter by trace ID
    * @param {string} [filter.resource_id] - Filter by resource ID
-   * @returns {Promise<import("@forwardimpact/libtype").trace.Span[]>} Array of spans matching the filter, sorted by start time
+   * @returns {Promise<import("@forwardimpact/libtype").span.SpanItem[]>} Array of spans matching the filter, sorted by start time
    */
   async queryItems(query = null, filter = {}) {
     if (!this.loaded) await this.loadData();

--- a/libraries/libtelemetry/src/span.js
+++ b/libraries/libtelemetry/src/span.js
@@ -1,4 +1,4 @@
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 
 /**
  * Compute the wall-clock offset (ns) relative to hrtime.bigint() using the
@@ -31,7 +31,7 @@ function nowNano(wallClockOffsetNs) {
  */
 export class Span {
   #object;
-  #traceClient;
+  #spanClient;
   #wallClockOffsetNs;
 
   /**
@@ -43,7 +43,7 @@ export class Span {
    * @param {object} options.attributes - Initial span attributes
    * @param {string} [options.traceId] - Trace ID from parent context
    * @param {string} [options.parentSpanId] - Parent span ID from parent context
-   * @param {object} options.traceClient - Trace service client
+   * @param {object} options.spanClient - Span service client
    * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} options.clock -
    *   Injected clock collaborator (drives the wall-clock offset).
    */
@@ -54,7 +54,7 @@ export class Span {
     attributes,
     traceId,
     parentSpanId,
-    traceClient,
+    spanClient,
     clock,
   }) {
     if (!clock) throw new Error("clock is required");
@@ -69,9 +69,9 @@ export class Span {
       end_time_unix_nano: "",
       attributes: { service_name: serviceName, ...attributes },
       events: [],
-      status: { code: trace.Code.UNSET, message: "" },
+      status: { code: spanType.Code.UNSET, message: "" },
     };
-    this.#traceClient = traceClient;
+    this.#spanClient = spanClient;
   }
 
   /**
@@ -103,7 +103,7 @@ export class Span {
    */
   setError(error) {
     this.#object.status = {
-      code: trace.Code.ERROR,
+      code: spanType.Code.ERROR,
       message: error?.message || String(error),
     };
   }
@@ -114,19 +114,19 @@ export class Span {
    */
   setOk() {
     this.#object.status = {
-      code: trace.Code.OK,
+      code: spanType.Code.OK,
     };
   }
 
   /**
-   * Ends the span and sends it to trace service
+   * Ends the span and sends it to span service
    * @returns {Promise<void>}
    */
   async end() {
     this.#object.end_time_unix_nano = nowNano(this.#wallClockOffsetNs);
 
-    const span = trace.Span.fromObject(this.#object);
-    await this.#traceClient.RecordSpan(span);
+    const span = spanType.SpanItem.fromObject(this.#object);
+    await this.#spanClient.RecordSpan(span);
   }
 
   /**

--- a/libraries/libtelemetry/src/tracer.js
+++ b/libraries/libtelemetry/src/tracer.js
@@ -8,7 +8,7 @@ import { extractAttributes } from "./attributes.js";
  */
 export class Tracer {
   #serviceName;
-  #traceClient;
+  #spanClient;
   #spanContext;
   #grpcMetadata;
   #clock;
@@ -17,19 +17,19 @@ export class Tracer {
    * Creates a new tracer instance
    * @param {object} options - Tracer configuration
    * @param {string} options.serviceName - Name of the service
-   * @param {object} options.traceClient - Trace service client
+   * @param {object} options.spanClient - Span service client
    * @param {Function} options.grpcMetadata - gRPC Metadata constructor for creating metadata instances
    * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} options.clock -
    *   Injected clock collaborator, threaded into every Span.
    */
-  constructor({ serviceName, traceClient, grpcMetadata, clock }) {
+  constructor({ serviceName, spanClient, grpcMetadata, clock }) {
     if (!serviceName) throw new Error("serviceName is required");
-    if (!traceClient) throw new Error("traceClient is required");
+    if (!spanClient) throw new Error("spanClient is required");
     if (!grpcMetadata) throw new Error("grpcMetadata is required");
     if (!clock) throw new Error("clock is required");
 
     this.#serviceName = serviceName;
-    this.#traceClient = traceClient;
+    this.#spanClient = spanClient;
     this.#grpcMetadata = grpcMetadata;
     this.#clock = clock;
     this.#spanContext = new AsyncLocalStorage();
@@ -62,7 +62,7 @@ export class Tracer {
       attributes: options.attributes || {},
       traceId: options.traceId,
       parentSpanId: options.parentSpanId,
-      traceClient: this.#traceClient,
+      spanClient: this.#spanClient,
       clock: this.#clock,
     });
 

--- a/libraries/libtelemetry/src/visualizer.js
+++ b/libraries/libtelemetry/src/visualizer.js
@@ -1,4 +1,4 @@
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 
 import { msToIso } from "./time.js";
 
@@ -55,8 +55,8 @@ export class TraceVisualizer {
 
   /**
    * Groups spans by trace_id
-   * @param {import("@forwardimpact/libtype").trace.Span[]} spans - Array of spans
-   * @returns {Map<string, import("@forwardimpact/libtype").trace.Span[]>} Map of trace_id to spans
+   * @param {import("@forwardimpact/libtype").span.SpanItem[]} spans - Array of spans
+   * @returns {Map<string, import("@forwardimpact/libtype").span.SpanItem[]>} Map of trace_id to spans
    */
   #groupByTrace(spans) {
     const groups = new Map();
@@ -72,7 +72,7 @@ export class TraceVisualizer {
   /**
    * Visualizes a single trace as a Mermaid sequence diagram
    * @param {string} traceId - Trace ID
-   * @param {import("@forwardimpact/libtype").trace.Span[]} spans - Array of spans in the trace
+   * @param {import("@forwardimpact/libtype").span.SpanItem[]} spans - Array of spans in the trace
    * @returns {string} Raw Mermaid sequence diagram syntax
    */
   #visualizeTrace(traceId, spans) {
@@ -101,7 +101,7 @@ export class TraceVisualizer {
   /**
    * Generates timeline events from spans for chronological processing
    * Creates both "start" and "end" events for each span
-   * @param {import("@forwardimpact/libtype").trace.Span[]} spans - Array of spans
+   * @param {import("@forwardimpact/libtype").span.SpanItem[]} spans - Array of spans
    * @returns {Array<{type: 'start'|'end', time: bigint, span: object}>} Timeline events
    */
   #generateTimelineEvents(spans) {
@@ -109,7 +109,7 @@ export class TraceVisualizer {
 
     for (const span of spans) {
       // Only process CLIENT spans (they represent the interactions)
-      if (span.kind === trace.Kind.CLIENT) {
+      if (span.kind === spanType.Kind.CLIENT) {
         const startTime = BigInt(span.start_time_unix_nano);
         const endTime = BigInt(span.end_time_unix_nano);
 
@@ -134,7 +134,7 @@ export class TraceVisualizer {
   /**
    * Processes timeline events in chronological order to generate properly nested interactions
    * @param {Array<{type: 'start'|'end', time: bigint, span: object}>} events - Timeline events
-   * @param {import("@forwardimpact/libtype").trace.Span[]} allSpans - All spans in trace
+   * @param {import("@forwardimpact/libtype").span.SpanItem[]} allSpans - All spans in trace
    * @returns {string[]} Array of Mermaid sequence diagram lines
    */
   #processTimelineEvents(events, allSpans) {
@@ -184,15 +184,15 @@ export class TraceVisualizer {
    * Generates the return line for a service interaction
    * @param {string} fromService - Source service name
    * @param {string} toService - Target service name
-   * @param {import("@forwardimpact/libtype").trace.Span} serverSpan - SERVER span
+   * @param {import("@forwardimpact/libtype").span.SpanItem} serverSpan - SERVER span
    * @returns {string} Mermaid return line
    */
   #generateReturnLine(fromService, toService, serverSpan) {
     // Convert numeric Code enum to string representation
-    const statusCodeNum = serverSpan.status?.code ?? trace.Code.UNSET;
+    const statusCodeNum = serverSpan.status?.code ?? spanType.Code.UNSET;
     const statusCode =
-      Object.keys(trace.Code).find(
-        (key) => trace.Code[key] === statusCodeNum,
+      Object.keys(spanType.Code).find(
+        (key) => spanType.Code[key] === statusCodeNum,
       ) || "UNSET";
     const errorMessage = serverSpan.status?.message || "";
 
@@ -211,7 +211,7 @@ export class TraceVisualizer {
 
   /**
    * Extracts unique service participants from spans in architectural order
-   * @param {import("@forwardimpact/libtype").trace.Span[]} spans - Array of spans
+   * @param {import("@forwardimpact/libtype").span.SpanItem[]} spans - Array of spans
    * @returns {string[]} Array of participant service names in architectural order
    */
   #extractParticipants(spans) {
@@ -224,7 +224,7 @@ export class TraceVisualizer {
       }
 
       // For CLIENT spans, also add the target service
-      if (span.kind === trace.Kind.CLIENT) {
+      if (span.kind === spanType.Kind.CLIENT) {
         const rpcService = span.attributes["rpc_service"];
         if (rpcService) {
           participantSet.add(rpcService);
@@ -249,15 +249,15 @@ export class TraceVisualizer {
 
   /**
    * Finds the corresponding SERVER span for a CLIENT span
-   * @param {import("@forwardimpact/libtype").trace.Span[]} spans - Array of all spans
-   * @param {import("@forwardimpact/libtype").trace.Span} clientSpan - CLIENT span to find match for
-   * @returns {import("@forwardimpact/libtype").trace.Span|null} Matching SERVER span or null
+   * @param {import("@forwardimpact/libtype").span.SpanItem[]} spans - Array of all spans
+   * @param {import("@forwardimpact/libtype").span.SpanItem} clientSpan - CLIENT span to find match for
+   * @returns {import("@forwardimpact/libtype").span.SpanItem|null} Matching SERVER span or null
    */
   #findServerSpan(spans, clientSpan) {
     return (
       spans.find(
         (span) =>
-          span.kind === trace.Kind.SERVER &&
+          span.kind === spanType.Kind.SERVER &&
           span.parent_span_id === clientSpan.span_id,
       ) || null
     );
@@ -265,7 +265,7 @@ export class TraceVisualizer {
 
   /**
    * Extracts attributes from span events matching specified event names
-   * @param {import("@forwardimpact/libtype").trace.Span} span - Span to extract attributes from
+   * @param {import("@forwardimpact/libtype").span.SpanItem} span - Span to extract attributes from
    * @param {string[]} eventNames - Event names to search for
    * @returns {string} Formatted attribute string or empty string
    */
@@ -314,7 +314,7 @@ export class TraceVisualizer {
   /**
    * Visualizes multiple traces as a single combined Mermaid sequence diagram
    * Used when filtering by resource_id to show conversation flow across requests
-   * @param {Map<string, import("@forwardimpact/libtype").trace.Span[]>} traceGroups - Map of trace_id to spans
+   * @param {Map<string, import("@forwardimpact/libtype").span.SpanItem[]>} traceGroups - Map of trace_id to spans
    * @param {string} resourceId - Resource ID being visualized
    * @returns {string} Raw Mermaid sequence diagram syntax
    */

--- a/libraries/libtelemetry/test/error.test.js
+++ b/libraries/libtelemetry/test/error.test.js
@@ -5,7 +5,7 @@ import { Tracer } from "../src/tracer.js";
 import { createMockClock } from "@forwardimpact/libmock";
 
 test("Tracer enriches errors with trace context in observeClientUnaryCall", async () => {
-  const mockTraceClient = {
+  const mockSpanClient = {
     RecordSpan: async () => ({}),
   };
 
@@ -35,7 +35,7 @@ test("Tracer enriches errors with trace context in observeClientUnaryCall", asyn
 
   const tracer = new Tracer({
     serviceName: "test-service",
-    traceClient: mockTraceClient,
+    spanClient: mockSpanClient,
     grpcMetadata: mockGrpcMetadata,
     clock: createMockClock(),
   });
@@ -70,7 +70,7 @@ test("Tracer enriches errors with trace context in observeClientUnaryCall", asyn
 });
 
 test("Tracer enriches errors with trace context in observeServerUnaryCall", async () => {
-  const mockTraceClient = {
+  const mockSpanClient = {
     RecordSpan: async () => ({}),
   };
 
@@ -100,7 +100,7 @@ test("Tracer enriches errors with trace context in observeServerUnaryCall", asyn
 
   const tracer = new Tracer({
     serviceName: "test-service",
-    traceClient: mockTraceClient,
+    spanClient: mockSpanClient,
     grpcMetadata: mockGrpcMetadata,
     clock: createMockClock(),
   });
@@ -138,7 +138,7 @@ test("Tracer enriches errors with trace context in observeServerUnaryCall", asyn
 });
 
 test("Logger extracts trace context from error", async () => {
-  const mockTraceClient = {
+  const mockSpanClient = {
     RecordSpan: async () => ({}),
   };
 
@@ -168,7 +168,7 @@ test("Logger extracts trace context from error", async () => {
 
   const tracer = new Tracer({
     serviceName: "test-service",
-    traceClient: mockTraceClient,
+    spanClient: mockSpanClient,
     grpcMetadata: mockGrpcMetadata,
     clock: createMockClock(),
   });
@@ -195,7 +195,7 @@ test("Logger extracts trace context from error", async () => {
 });
 
 test("Tracer handles non-Error objects gracefully", async () => {
-  const mockTraceClient = {
+  const mockSpanClient = {
     RecordSpan: async () => ({}),
   };
 
@@ -225,7 +225,7 @@ test("Tracer handles non-Error objects gracefully", async () => {
 
   const tracer = new Tracer({
     serviceName: "test-service",
-    traceClient: mockTraceClient,
+    spanClient: mockSpanClient,
     grpcMetadata: mockGrpcMetadata,
     clock: createMockClock(),
   });

--- a/libraries/libtelemetry/test/index-core.test.js
+++ b/libraries/libtelemetry/test/index-core.test.js
@@ -2,7 +2,7 @@ import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert";
 
 import { TraceIndex } from "../src/index/trace.js";
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 import { assertThrowsMessage, createMockStorage } from "@forwardimpact/libmock";
 import { createMockClock } from "@forwardimpact/libmock";
 const _clock = createMockClock();
@@ -52,7 +52,7 @@ describe("TraceIndex - Core", () => {
 
   describe("add() Method", () => {
     test("adds span to index with correct item structure", async () => {
-      const span = trace.Span.fromObject({
+      const span = spanType.SpanItem.fromObject({
         trace_id: "trace123",
         span_id: "span456",
         parent_span_id: "",
@@ -62,7 +62,7 @@ describe("TraceIndex - Core", () => {
         end_time_unix_nano: "2000000",
         attributes: { "service.name": "test-service" },
         events: [],
-        status: { code: trace.Code.OK, message: "" },
+        status: { code: spanType.Code.OK, message: "" },
         resource: { attributes: {} },
       });
 
@@ -75,7 +75,7 @@ describe("TraceIndex - Core", () => {
     });
 
     test("adds span with resource_id to index", async () => {
-      const span = trace.Span.fromObject({
+      const span = spanType.SpanItem.fromObject({
         trace_id: "trace123",
         span_id: "span789",
         parent_span_id: "span456",
@@ -85,7 +85,7 @@ describe("TraceIndex - Core", () => {
         end_time_unix_nano: "2000000",
         attributes: { "service.name": "agent" },
         events: [],
-        status: { code: trace.Code.OK, message: "" },
+        status: { code: spanType.Code.OK, message: "" },
         resource: { attributes: { id: "common.Conversation.abc-123" } },
       });
 
@@ -104,7 +104,7 @@ describe("TraceIndex - Core", () => {
   describe("queryItems() - Basic Filtering", () => {
     beforeEach(async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
@@ -114,13 +114,13 @@ describe("TraceIndex - Core", () => {
           end_time_unix_nano: "2000000",
           attributes: {},
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
@@ -130,13 +130,13 @@ describe("TraceIndex - Core", () => {
           end_time_unix_nano: "2000000",
           attributes: {},
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace2",
           span_id: "span3",
           parent_span_id: "",
@@ -146,7 +146,7 @@ describe("TraceIndex - Core", () => {
           end_time_unix_nano: "2000000",
           attributes: {},
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );

--- a/libraries/libtelemetry/test/index-resource.test.js
+++ b/libraries/libtelemetry/test/index-resource.test.js
@@ -2,7 +2,7 @@ import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert";
 
 import { TraceIndex } from "../src/index/trace.js";
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 import { createMockStorage } from "@forwardimpact/libmock";
 import { createMockClock } from "@forwardimpact/libmock";
 const _clock = createMockClock();
@@ -21,7 +21,7 @@ describe("TraceIndex - Resource ID Filtering", () => {
   describe("queryItems() - Resource ID Filtering with Complete Traces", () => {
     beforeEach(async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
@@ -31,13 +31,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "5000000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
@@ -47,13 +47,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "2500000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "common.Conversation.conv1" } },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span3",
           parent_span_id: "span2",
@@ -63,13 +63,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "2400000",
           attributes: { "service.name": "memory" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "common.Conversation.conv1" } },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span4",
           parent_span_id: "span1",
@@ -79,13 +79,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "4000000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace2",
           span_id: "span5",
           parent_span_id: "",
@@ -95,7 +95,7 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "2000000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "common.Conversation.conv2" } },
         }),
       );
@@ -149,7 +149,7 @@ describe("TraceIndex - Resource ID Filtering", () => {
 
     test("combines resource_id and trace_id filters", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace3",
           span_id: "span6",
           parent_span_id: "",
@@ -159,7 +159,7 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "2000000",
           attributes: {},
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "common.Conversation.conv1" } },
         }),
       );
@@ -194,7 +194,7 @@ describe("TraceIndex - Resource ID Filtering", () => {
   describe("queryItems() - Multiple Traces with Same Resource", () => {
     test("returns complete traces when resource appears in multiple traces", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
@@ -204,13 +204,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "3000000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
@@ -220,13 +220,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "2500000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "test.Resource.id" } },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace2",
           span_id: "span3",
           parent_span_id: "",
@@ -236,13 +236,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "7000000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace2",
           span_id: "span4",
           parent_span_id: "span3",
@@ -252,13 +252,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "5500000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "test.Resource.id" } },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace2",
           span_id: "span5",
           parent_span_id: "span3",
@@ -268,7 +268,7 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "6500000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -292,7 +292,7 @@ describe("TraceIndex - Resource ID Filtering", () => {
 
     test("handles sibling spans with and without resource_id", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
@@ -302,13 +302,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "5000000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
@@ -318,13 +318,13 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "2500000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "test.Resource.id" } },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span3",
           parent_span_id: "span1",
@@ -334,7 +334,7 @@ describe("TraceIndex - Resource ID Filtering", () => {
           end_time_unix_nano: "4000000",
           attributes: { "service.name": "agent" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );

--- a/libraries/libtelemetry/test/tracer.test.js
+++ b/libraries/libtelemetry/test/tracer.test.js
@@ -36,10 +36,10 @@ class MockMetadata {
 describe("Tracer", () => {
   describe("AsyncLocalStorage context isolation", () => {
     test("maintains separate span contexts for concurrent operations", async () => {
-      const mockTraceClient = { RecordSpan: () => Promise.resolve() };
+      const mockSpanClient = { RecordSpan: () => Promise.resolve() };
       const tracer = new Tracer({
         serviceName: "test-service",
-        traceClient: mockTraceClient,
+        spanClient: mockSpanClient,
         grpcMetadata: MockMetadata,
         clock: createMockClock(),
       });
@@ -90,10 +90,10 @@ describe("Tracer", () => {
     });
 
     test("startClientSpan reads parent from AsyncLocalStorage", () => {
-      const mockTraceClient = { RecordSpan: () => Promise.resolve() };
+      const mockSpanClient = { RecordSpan: () => Promise.resolve() };
       const tracer = new Tracer({
         serviceName: "test-service",
-        traceClient: mockTraceClient,
+        spanClient: mockSpanClient,
         grpcMetadata: MockMetadata,
         clock: createMockClock(),
       });
@@ -123,10 +123,10 @@ describe("Tracer", () => {
     });
 
     test("startServerSpan extracts trace context from metadata", () => {
-      const mockTraceClient = { RecordSpan: () => Promise.resolve() };
+      const mockSpanClient = { RecordSpan: () => Promise.resolve() };
       const tracer = new Tracer({
         serviceName: "test-service",
-        traceClient: mockTraceClient,
+        spanClient: mockSpanClient,
         grpcMetadata: MockMetadata,
         clock: createMockClock(),
       });

--- a/libraries/libtelemetry/test/visualizer-attributes.test.js
+++ b/libraries/libtelemetry/test/visualizer-attributes.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 
 import { TraceVisualizer } from "../src/visualizer.js";
 import { TraceIndex } from "../src/index/trace.js";
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 import { createMockStorage } from "@forwardimpact/libmock";
 import { createMockClock } from "@forwardimpact/libmock";
 const _clock = createMockClock();
@@ -25,12 +25,12 @@ describe("TraceVisualizer - attributes and errors", () => {
   describe("visualize() - Request and Response Attributes", () => {
     test("includes request attributes in visualization", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "memory.AppendMemory",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -48,18 +48,18 @@ describe("TraceVisualizer - attributes and errors", () => {
               },
             },
           ],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "memory.AppendMemory",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "1900000",
           attributes: {
@@ -67,7 +67,7 @@ describe("TraceVisualizer - attributes and errors", () => {
             rpc_method: "AppendMemory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -86,12 +86,12 @@ describe("TraceVisualizer - attributes and errors", () => {
 
     test("includes response attributes in visualization", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "vector.QueryItems",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -100,18 +100,18 @@ describe("TraceVisualizer - attributes and errors", () => {
             rpc_service: "vector",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "vector.QueryItems",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "1900000",
           attributes: {
@@ -128,7 +128,7 @@ describe("TraceVisualizer - attributes and errors", () => {
               },
             },
           ],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -147,12 +147,12 @@ describe("TraceVisualizer - attributes and errors", () => {
 
     test("filters out empty and null attributes", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "test.Method",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -172,18 +172,18 @@ describe("TraceVisualizer - attributes and errors", () => {
               },
             },
           ],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "test.Method",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "1900000",
           attributes: {
@@ -191,7 +191,7 @@ describe("TraceVisualizer - attributes and errors", () => {
             rpc_method: "Method",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -220,12 +220,12 @@ describe("TraceVisualizer - attributes and errors", () => {
   describe("visualize() - Error Status Handling", () => {
     test("displays error status and message", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "tool.ExecuteTool",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -234,18 +234,18 @@ describe("TraceVisualizer - attributes and errors", () => {
             rpc_service: "tool",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "tool.ExecuteTool",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "1900000",
           attributes: {
@@ -254,7 +254,7 @@ describe("TraceVisualizer - attributes and errors", () => {
           },
           events: [],
           status: {
-            code: trace.Code.ERROR,
+            code: spanType.Code.ERROR,
             message: "Tool execution failed: timeout",
           },
           resource: { attributes: {} },
@@ -276,12 +276,12 @@ describe("TraceVisualizer - attributes and errors", () => {
 
     test("prefers error message over response attributes", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "graph.QueryTriples",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -290,18 +290,18 @@ describe("TraceVisualizer - attributes and errors", () => {
             rpc_service: "graph",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "graph.QueryTriples",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "1900000",
           attributes: {
@@ -318,7 +318,7 @@ describe("TraceVisualizer - attributes and errors", () => {
             },
           ],
           status: {
-            code: trace.Code.ERROR,
+            code: spanType.Code.ERROR,
             message: "Invalid query pattern",
           },
           resource: { attributes: {} },

--- a/libraries/libtelemetry/test/visualizer-basics.test.js
+++ b/libraries/libtelemetry/test/visualizer-basics.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 
 import { TraceVisualizer } from "../src/visualizer.js";
 import { TraceIndex } from "../src/index/trace.js";
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 import { assertThrowsMessage, createMockStorage } from "@forwardimpact/libmock";
 import { createMockClock } from "@forwardimpact/libmock";
 const _clock = createMockClock();
@@ -73,12 +73,12 @@ describe("TraceVisualizer - basics", () => {
     beforeEach(async () => {
       // Create a simple CLIENT -> SERVER interaction
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "agent.ProcessStream",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "3000000",
           attributes: {
@@ -87,18 +87,18 @@ describe("TraceVisualizer - basics", () => {
             rpc_service: "memory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "agent.ProcessStream",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1500000",
           end_time_unix_nano: "2500000",
           attributes: {
@@ -106,7 +106,7 @@ describe("TraceVisualizer - basics", () => {
             rpc_method: "ProcessStream",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -148,12 +148,12 @@ describe("TraceVisualizer - basics", () => {
     test("filters spans by trace_id", async () => {
       // Add spans for a different trace
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace2",
           span_id: "span3",
           parent_span_id: "",
           name: "test.Operation",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "4000000",
           end_time_unix_nano: "5000000",
           attributes: {
@@ -162,7 +162,7 @@ describe("TraceVisualizer - basics", () => {
             rpc_service: "llm",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -180,12 +180,12 @@ describe("TraceVisualizer - basics", () => {
     test("orders participants in architectural sequence", async () => {
       // Add more services in non-architectural order
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span3",
           parent_span_id: "",
           name: "llm.CreateCompletions",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "3500000",
           end_time_unix_nano: "4500000",
           attributes: {
@@ -194,18 +194,18 @@ describe("TraceVisualizer - basics", () => {
             rpc_service: "llm",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span4",
           parent_span_id: "span3",
           name: "llm.CreateCompletions",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "3600000",
           end_time_unix_nano: "4400000",
           attributes: {
@@ -213,7 +213,7 @@ describe("TraceVisualizer - basics", () => {
             rpc_method: "CreateCompletions",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );

--- a/libraries/libtelemetry/test/visualizer-edge-cases-basic.test.js
+++ b/libraries/libtelemetry/test/visualizer-edge-cases-basic.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 
 import { TraceVisualizer } from "../src/visualizer.js";
 import { TraceIndex } from "../src/index/trace.js";
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 import { createMockStorage } from "@forwardimpact/libmock";
 import { createMockClock } from "@forwardimpact/libmock";
 const _clock = createMockClock();
@@ -24,12 +24,12 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
   describe("visualize() - Edge Cases", () => {
     test("handles CLIENT span without corresponding SERVER span", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "external.Call",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -38,7 +38,7 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_service: "external",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -58,33 +58,33 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
 
     test("handles spans with missing attributes gracefully", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "incomplete.Operation",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {}, // Missing service.name and rpc.method
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "incomplete.Operation",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "1900000",
           attributes: {}, // Missing service.name and rpc.method
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -104,12 +104,12 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
 
     test("handles spans with empty events array", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "test.Method",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -118,18 +118,18 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_service: "memory",
           },
           events: [], // Empty events
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "test.Method",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "1900000",
           attributes: {
@@ -137,7 +137,7 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_method: "Method",
           },
           events: [], // Empty events
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -161,12 +161,12 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
 
     test("handles single-service traces", async () => {
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "agent.InternalOperation",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -174,7 +174,7 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_method: "InternalOperation",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );

--- a/libraries/libtelemetry/test/visualizer-edge-cases-complex.test.js
+++ b/libraries/libtelemetry/test/visualizer-edge-cases-complex.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 
 import { TraceVisualizer } from "../src/visualizer.js";
 import { TraceIndex } from "../src/index/trace.js";
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 import { createMockStorage } from "@forwardimpact/libmock";
 import { createMockClock } from "@forwardimpact/libmock";
 const _clock = createMockClock();
@@ -25,12 +25,12 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
     test("handles multi-level service chains", async () => {
       // agent -> memory -> graph
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "memory.GetWindow",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "5000000",
           attributes: {
@@ -39,18 +39,18 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_service: "memory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "memory.GetWindow",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1500000",
           end_time_unix_nano: "4500000",
           attributes: {
@@ -58,18 +58,18 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_method: "GetWindow",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span3",
           parent_span_id: "span2",
           name: "graph.QueryTriples",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "2000000",
           end_time_unix_nano: "4000000",
           attributes: {
@@ -78,18 +78,18 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_service: "graph",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span4",
           parent_span_id: "span3",
           name: "graph.QueryTriples",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "2500000",
           end_time_unix_nano: "3500000",
           attributes: {
@@ -97,7 +97,7 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_method: "QueryTriples",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -128,12 +128,12 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
     test("handles parallel service calls", async () => {
       // agent calls both memory and llm in parallel
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "memory.GetWindow",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "3000000",
           attributes: {
@@ -142,18 +142,18 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_service: "memory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "memory.GetWindow",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "2900000",
           attributes: {
@@ -161,18 +161,18 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_method: "GetWindow",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span3",
           parent_span_id: "",
           name: "llm.CreateCompletions",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1500000",
           end_time_unix_nano: "4000000",
           attributes: {
@@ -181,18 +181,18 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_service: "llm",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span4",
           parent_span_id: "span3",
           name: "llm.CreateCompletions",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1600000",
           end_time_unix_nano: "3900000",
           attributes: {
@@ -200,7 +200,7 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
             rpc_method: "CreateCompletions",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );

--- a/libraries/libtelemetry/test/visualizer-timeline.test.js
+++ b/libraries/libtelemetry/test/visualizer-timeline.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 
 import { TraceVisualizer } from "../src/visualizer.js";
 import { TraceIndex } from "../src/index/trace.js";
-import { trace } from "@forwardimpact/libtype";
+import { span as spanType } from "@forwardimpact/libtype";
 import { createMockStorage } from "@forwardimpact/libmock";
 import { createMockClock } from "@forwardimpact/libmock";
 const _clock = createMockClock();
@@ -26,12 +26,12 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
     beforeEach(async () => {
       // First trace with resource_id
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "",
           name: "agent.ProcessStream",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -40,18 +40,18 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_service: "memory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "common.Conversation.conv1" } },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "agent.ProcessStream",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "1900000",
           attributes: {
@@ -59,19 +59,19 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_method: "ProcessStream",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "common.Conversation.conv1" } },
         }),
       );
 
       // Second trace with same resource_id
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace2",
           span_id: "span3",
           parent_span_id: "",
           name: "agent.ProcessStream",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "3000000",
           end_time_unix_nano: "4000000",
           attributes: {
@@ -80,18 +80,18 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_service: "memory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "common.Conversation.conv1" } },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace2",
           span_id: "span4",
           parent_span_id: "span3",
           name: "agent.ProcessStream",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "3100000",
           end_time_unix_nano: "3900000",
           attributes: {
@@ -99,7 +99,7 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_method: "ProcessStream",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: { id: "common.Conversation.conv1" } },
         }),
       );
@@ -157,12 +157,12 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
     test("processes spans in chronological order", async () => {
       // Add spans in non-chronological order
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span3",
           parent_span_id: "span2",
           name: "llm.CreateCompletions",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "3100000",
           end_time_unix_nano: "3900000",
           attributes: {
@@ -170,18 +170,18 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_method: "CreateCompletions",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span1",
           parent_span_id: "span0",
           name: "memory.AppendMemory",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1100000",
           end_time_unix_nano: "1900000",
           attributes: {
@@ -189,18 +189,18 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_method: "AppendMemory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "",
           name: "llm.CreateCompletions",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "3000000",
           end_time_unix_nano: "4000000",
           attributes: {
@@ -209,18 +209,18 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_service: "llm",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span0",
           parent_span_id: "",
           name: "memory.AppendMemory",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1000000",
           end_time_unix_nano: "2000000",
           attributes: {
@@ -229,7 +229,7 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_service: "memory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -262,12 +262,12 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
       //   span2: 1500000 - 2500000 (inner, starts first)
       //   span3: 3000000 - 4000000 (inner, starts later)
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span2",
           parent_span_id: "span1",
           name: "memory.AppendMemory",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "1500000",
           end_time_unix_nano: "2500000",
           attributes: {
@@ -276,18 +276,18 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_service: "memory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span3",
           parent_span_id: "span2",
           name: "memory.AppendMemory",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "1600000",
           end_time_unix_nano: "2400000",
           attributes: {
@@ -295,18 +295,18 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_method: "AppendMemory",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span4",
           parent_span_id: "span1",
           name: "llm.CreateCompletions",
-          kind: trace.Kind.CLIENT,
+          kind: spanType.Kind.CLIENT,
           start_time_unix_nano: "3000000",
           end_time_unix_nano: "4000000",
           attributes: {
@@ -315,18 +315,18 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_service: "llm",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await traceIndex.add(
-        trace.Span.fromObject({
+        spanType.SpanItem.fromObject({
           trace_id: "trace1",
           span_id: "span5",
           parent_span_id: "span4",
           name: "llm.CreateCompletions",
-          kind: trace.Kind.SERVER,
+          kind: spanType.Kind.SERVER,
           start_time_unix_nano: "3100000",
           end_time_unix_nano: "3900000",
           attributes: {
@@ -334,7 +334,7 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
             rpc_method: "CreateCompletions",
           },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: spanType.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );

--- a/libraries/libtype/README.md
+++ b/libraries/libtype/README.md
@@ -10,5 +10,5 @@ contracts.
 ## Getting Started
 
 ```js
-import { common, resource, vector, graph, tool, trace } from '@forwardimpact/libtype';
+import { common, resource, vector, graph, tool, span } from '@forwardimpact/libtype';
 ```

--- a/libraries/libtype/src/index.js
+++ b/libraries/libtype/src/index.js
@@ -16,7 +16,7 @@ const {
   vector = {},
   graph = {},
   tool = {},
-  trace = {},
+  span = {},
 } = types;
 
 /**
@@ -176,5 +176,5 @@ export {
   vector,
   graph,
   tool,
-  trace,
+  span,
 };

--- a/products/gear/package.json
+++ b/products/gear/package.json
@@ -40,7 +40,7 @@
     "@forwardimpact/svcgraph": "^0.1.68",
     "@forwardimpact/svcmcp": "^0.1.6",
     "@forwardimpact/svcpathway": "^0.1.13",
-    "@forwardimpact/svctrace": "^0.1.41",
+    "@forwardimpact/svcspan": "^0.1.41",
     "@forwardimpact/svcvector": "^0.1.120",
     "@forwardimpact/libcodegen": "^0.1.49",
     "@forwardimpact/libdoc": "^0.2.24",

--- a/products/guide/package.json
+++ b/products/guide/package.json
@@ -69,7 +69,7 @@
     "@forwardimpact/svcgraph": "^0.1.60",
     "@forwardimpact/svcmcp": "^0.1.0",
     "@forwardimpact/svcpathway": "^0.1.8",
-    "@forwardimpact/svctrace": "^0.1.34",
+    "@forwardimpact/svcspan": "^0.1.34",
     "@forwardimpact/svcvector": "^0.1.111"
   },
   "devDependencies": {

--- a/products/guide/src/commands/init.js
+++ b/products/guide/src/commands/init.js
@@ -50,7 +50,7 @@ export async function runInitCommand(runtime) {
     env: {
       SERVICE_SECRET: serviceSecret,
       MCP_TOKEN: mcpToken,
-      SERVICE_TRACE_URL: "grpc://localhost:3001",
+      SERVICE_SPAN_URL: "grpc://localhost:3001",
       SERVICE_VECTOR_URL: "grpc://localhost:3002",
       SERVICE_GRAPH_URL: "grpc://localhost:3003",
       SERVICE_PATHWAY_URL: "grpc://localhost:3005",

--- a/products/guide/src/lib/status.js
+++ b/products/guide/src/lib/status.js
@@ -105,9 +105,9 @@ async function queryDataInventory(graphConfig, runtime) {
   return { resources, triples };
 }
 
-const SERVICE_NAMES = ["trace", "vector", "graph", "pathway", "mcp"];
+const SERVICE_NAMES = ["span", "vector", "graph", "pathway", "mcp"];
 
-const GRPC_SERVICES = ["trace", "vector", "graph", "pathway"];
+const GRPC_SERVICES = ["span", "vector", "graph", "pathway"];
 
 const HTTP_SERVICES = {
   mcp: "/health",

--- a/products/guide/starter/config.json
+++ b/products/guide/starter/config.json
@@ -4,8 +4,8 @@
     "shutdown_timeout": 3000,
     "services": [
       {
-        "name": "trace",
-        "command": "node -e \"import('@forwardimpact/svctrace/server.js')\""
+        "name": "span",
+        "command": "node -e \"import('@forwardimpact/svcspan/server.js')\""
       },
       {
         "name": "vector",

--- a/products/guide/test/init.integration.test.js
+++ b/products/guide/test/init.integration.test.js
@@ -53,7 +53,7 @@ describe("fit-guide init", () => {
     for (const key of [
       "SERVICE_SECRET",
       "MCP_TOKEN",
-      "SERVICE_TRACE_URL",
+      "SERVICE_SPAN_URL",
       "SERVICE_VECTOR_URL",
       "SERVICE_GRAPH_URL",
       "SERVICE_PATHWAY_URL",

--- a/products/guide/test/status.test.js
+++ b/products/guide/test/status.test.js
@@ -14,8 +14,8 @@ import { runStatus } from "../src/lib/status.js";
  */
 function createMockConfigFactory(overrides = {}) {
   const defaults = {
-    trace: {
-      name: "trace",
+    span: {
+      name: "span",
       host: "localhost",
       port: 3001,
       url: "grpc://localhost:3001",

--- a/services/README.md
+++ b/services/README.md
@@ -23,8 +23,8 @@ that let agents consume backend functionality natively.
 | **oauth**     | OAuth 2.1 authorization server adapter — protocol-only HTTP front that delegates to a configured provider backend over gRPC.                      |
 | **oidc**      | GitHub Actions OIDC exchange front — validates a workflow OIDC token and mints a repo-scoped installation token without holding signing material. |
 | **pathway**   | Engineering standard queries over gRPC — career paths and agent profiles as derivable data for products.                                          |
+| **span**      | OpenTelemetry span ingestion and storage over gRPC — prove whether agent changes improved outcomes.                                               |
 | **tenancy**   | Tenant registry — `(channel, channel_tenant_key) → Tenant` lookup for the hosted control plane.                                                   |
-| **trace**     | OpenTelemetry span ingestion and storage over gRPC — prove whether agent changes improved outcomes.                                               |
 | **vector**    | Vector similarity search over gRPC — semantic retrieval without a dedicated database per product.                                                 |
 
 <!-- END:catalog -->
@@ -153,15 +153,15 @@ logic; hardcoding role definitions.
 ## Platform Builders: Prove Agent Changes
 
 **Trigger:** Finishing an agent improvement and realizing there is no
-centralized place to store and compare trace spans.
+centralized place to store and compare spans.
 
-**Big Hire:** Help me collect trace spans from any product without each one
-managing its own storage. → **trace**
+**Big Hire:** Help me collect spans from any product without each one managing
+its own storage. → **span**
 
 **Little Hire:** Help me send spans from a product and trust they are queryable
-later. → **trace**
+later. → **span**
 
-**Competes With:** per-product trace files; manual log comparison; skipping
+**Competes With:** per-product span files; manual log comparison; skipping
 observability entirely.
 
 </job>

--- a/services/span/README.md
+++ b/services/span/README.md
@@ -1,4 +1,4 @@
-# Trace Service
+# Span Service
 
 <!-- BEGIN:description — Do not edit. Generated from package.json. -->
 
@@ -10,5 +10,5 @@ improved outcomes.
 ## Getting Started
 
 ```sh
-bun services/trace/server.js
+bun services/span/server.js
 ```

--- a/services/span/index.js
+++ b/services/span/index.js
@@ -1,17 +1,17 @@
 import { services } from "@forwardimpact/librpc";
 import { TraceIndex } from "@forwardimpact/libtelemetry/index/trace.js";
 
-const { TraceBase } = services;
+const { SpanBase } = services;
 
 /**
- * Trace service for receiving and storing trace spans
+ * Span service for receiving and storing trace spans
  */
-export class TraceService extends TraceBase {
+export class SpanService extends SpanBase {
   #index;
 
   /**
-   * Creates a new Trace service instance
-   * Note: Trace service does NOT accept a tracer parameter to avoid infinite recursion
+   * Creates a new Span service instance
+   * Note: Span service does NOT accept a tracer parameter to avoid infinite recursion
    * @param {import("@forwardimpact/libconfig").ServiceConfig} config - Service configuration
    * @param {TraceIndex} traceIndex - Initialized TraceIndex for storing traces
    */
@@ -24,8 +24,8 @@ export class TraceService extends TraceBase {
 
   /**
    * Records a span to the trace index
-   * @param {import("@forwardimpact/libtype").trace.Span} req - Span to record
-   * @returns {Promise<import("@forwardimpact/libtype").trace.RecordSpanResponse>} Response
+   * @param {import("@forwardimpact/libtype").span.SpanItem} req - Span to record
+   * @returns {Promise<import("@forwardimpact/libtype").span.RecordResponse>} Response
    */
   async RecordSpan(req) {
     if (!req.trace_id) throw new Error("trace_id is required");
@@ -37,8 +37,8 @@ export class TraceService extends TraceBase {
 
   /**
    * Queries spans from the trace index
-   * @param {import("@forwardimpact/libtype").trace.QueryRequest} req - Query request
-   * @returns {Promise<import("@forwardimpact/libtype").trace.QueryResponse>} Response with spans
+   * @param {import("@forwardimpact/libtype").span.QueryRequest} req - Query request
+   * @returns {Promise<import("@forwardimpact/libtype").span.QueryResponse>} Response with spans
    */
   async QuerySpans(req) {
     const filter = req.filter || {};

--- a/services/span/package.json
+++ b/services/span/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "@forwardimpact/svctrace",
+  "name": "@forwardimpact/svcspan",
   "version": "0.1.49",
   "description": "OpenTelemetry span ingestion and storage over gRPC — prove whether agent changes improved outcomes.",
   "keywords": [
-    "trace",
     "opentelemetry",
     "spans",
     "grpc",
@@ -13,7 +12,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/forwardimpact/monorepo.git",
-    "directory": "services/trace"
+    "directory": "services/span"
   },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
@@ -21,16 +20,16 @@
     {
       "user": "Platform Builders",
       "goal": "Prove Agent Changes",
-      "trigger": "Finishing an agent improvement and realizing there is no centralized place to store and compare trace spans.",
-      "bigHire": "collect trace spans from any product without each one managing its own storage.",
+      "trigger": "Finishing an agent improvement and realizing there is no centralized place to store and compare spans.",
+      "bigHire": "collect spans from any product without each one managing its own storage.",
       "littleHire": "send spans from a product and trust they are queryable later.",
-      "competesWith": "per-product trace files; manual log comparison; skipping observability entirely"
+      "competesWith": "per-product span files; manual log comparison; skipping observability entirely"
     }
   ],
   "type": "module",
   "main": "index.js",
   "bin": {
-    "fit-svctrace": "./server.js"
+    "fit-svcspan": "./server.js"
   },
   "files": [
     "proto/",

--- a/services/span/proto/span.proto
+++ b/services/span/proto/span.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
-package trace;
+package span;
 
-service Trace {
-  rpc RecordSpan(Span) returns (RecordResponse);
+service Span {
+  rpc RecordSpan(SpanItem) returns (RecordResponse);
   rpc QuerySpans(QueryRequest) returns (QueryResponse);
 }
 
@@ -20,7 +20,7 @@ enum Code {
   ERROR = 2;
 }
 
-message Span {
+message SpanItem {
   string trace_id = 1;
   string span_id = 2;
   string parent_span_id = 3;
@@ -64,5 +64,5 @@ message QueryRequest {
 }
 
 message QueryResponse {
-  repeated Span spans = 1;
+  repeated SpanItem spans = 1;
 }

--- a/services/span/server.js
+++ b/services/span/server.js
@@ -8,29 +8,29 @@ import { createStorage } from "@forwardimpact/libstorage";
 import { TraceIndex } from "@forwardimpact/libtelemetry/index/trace.js";
 import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
-import { TraceService } from "./index.js";
+import { SpanService } from "./index.js";
 
 const handled = serverFlagsShortCircuit({
-  name: "fit-svctrace",
-  description: "Trace index gRPC service",
+  name: "fit-svcspan",
+  description: "Span index gRPC service",
   packageJsonUrl: new URL("./package.json", import.meta.url),
   argv: process.argv.slice(2),
 });
 
 if (!handled) {
-  const config = await createServiceConfig("trace", {
+  const config = await createServiceConfig("span", {
     port: 3001,
   });
   const runtime = createDefaultRuntime();
   const { clock } = runtime;
 
-  // Initialize storage for traces
-  const traceStorage = createStorage("traces");
+  // Initialize storage for spans
+  const spanStorage = createStorage("spans");
 
-  // Create trace index
-  const traceIndex = new TraceIndex(traceStorage, "index.jsonl", { clock });
+  // Create span index
+  const traceIndex = new TraceIndex(spanStorage, "index.jsonl", { clock });
 
-  const service = new TraceService(config, traceIndex);
+  const service = new SpanService(config, traceIndex);
   const server = new Server(service, config, { runtime });
   await server.start();
 }

--- a/services/span/test/bin-smoke.integration.test.js
+++ b/services/span/test/bin-smoke.integration.test.js
@@ -33,7 +33,7 @@ function run(token) {
   };
 }
 
-describe("fit-svctrace bin smoke", () => {
+describe("fit-svcspan bin smoke", () => {
   for (const token of TOKENS) {
     test(`${token} exits 0, prints output, binds no port`, () => {
       const { code, signal, out } = run(token);

--- a/services/span/test/span.test.js
+++ b/services/span/test/span.test.js
@@ -2,39 +2,39 @@ import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert";
 
 // Module under test
-import { TraceService } from "../index.js";
+import { SpanService } from "../index.js";
 import { TraceIndex } from "@forwardimpact/libtelemetry/index/trace.js";
-import { trace } from "@forwardimpact/libtype";
+import { span } from "@forwardimpact/libtype";
 import { createMockConfig, createMockStorage } from "@forwardimpact/libmock";
 import { createMockClock } from "@forwardimpact/libmock";
 const _clock = createMockClock();
 
-describe("trace service", () => {
-  describe("TraceService", () => {
-    test("exports TraceService class", () => {
-      assert.strictEqual(typeof TraceService, "function");
-      assert.ok(TraceService.prototype);
+describe("span service", () => {
+  describe("SpanService", () => {
+    test("exports SpanService class", () => {
+      assert.strictEqual(typeof SpanService, "function");
+      assert.ok(SpanService.prototype);
     });
 
-    test("TraceService has RecordSpan method", () => {
-      assert.strictEqual(typeof TraceService.prototype.RecordSpan, "function");
+    test("SpanService has RecordSpan method", () => {
+      assert.strictEqual(typeof SpanService.prototype.RecordSpan, "function");
     });
 
-    test("TraceService has QuerySpans method", () => {
-      assert.strictEqual(typeof TraceService.prototype.QuerySpans, "function");
+    test("SpanService has QuerySpans method", () => {
+      assert.strictEqual(typeof SpanService.prototype.QuerySpans, "function");
     });
 
-    test("TraceService has shutdown method", () => {
-      assert.strictEqual(typeof TraceService.prototype.shutdown, "function");
+    test("SpanService has shutdown method", () => {
+      assert.strictEqual(typeof SpanService.prototype.shutdown, "function");
     });
 
-    test("TraceService constructor accepts expected parameters", () => {
+    test("SpanService constructor accepts expected parameters", () => {
       // Test constructor signature by checking parameter count
-      assert.strictEqual(TraceService.length, 2); // config, traceIndex
+      assert.strictEqual(SpanService.length, 2); // config, traceIndex
     });
 
-    test("TraceService has proper method signatures", () => {
-      const methods = Object.getOwnPropertyNames(TraceService.prototype);
+    test("SpanService has proper method signatures", () => {
+      const methods = Object.getOwnPropertyNames(SpanService.prototype);
       assert(methods.includes("RecordSpan"));
       assert(methods.includes("QuerySpans"));
       assert(methods.includes("shutdown"));
@@ -42,13 +42,13 @@ describe("trace service", () => {
     });
   });
 
-  describe("TraceService business logic", () => {
+  describe("SpanService business logic", () => {
     let mockConfig;
     let mockTraceIndex;
     let mockStorage;
 
     beforeEach(() => {
-      mockConfig = createMockConfig("trace");
+      mockConfig = createMockConfig("span");
 
       // Create mock storage for TraceIndex
       mockStorage = createMockStorage();
@@ -60,7 +60,7 @@ describe("trace service", () => {
     });
 
     test("creates service instance with trace index", () => {
-      const service = new TraceService(mockConfig, mockTraceIndex);
+      const service = new SpanService(mockConfig, mockTraceIndex);
 
       assert.ok(service);
       assert.strictEqual(service.config, mockConfig);
@@ -69,16 +69,16 @@ describe("trace service", () => {
     test("throws error if traceIndex is missing", () => {
       assert.throws(
         () => {
-          new TraceService(mockConfig);
+          new SpanService(mockConfig);
         },
         { message: "traceIndex is required" },
       );
     });
 
     test("RecordSpan stores span in index", async () => {
-      const service = new TraceService(mockConfig, mockTraceIndex);
+      const service = new SpanService(mockConfig, mockTraceIndex);
 
-      const spanRequest = trace.Span.fromObject({
+      const spanRequest = span.SpanItem.fromObject({
         trace_id: "trace123",
         span_id: "span456",
         parent_span_id: "",
@@ -88,7 +88,7 @@ describe("trace service", () => {
         end_time_unix_nano: "1698345601000000000",
         attributes: { "service.name": "test-service" },
         events: [],
-        status: { code: trace.Code.OK, message: "" },
+        status: { code: span.Code.OK, message: "" },
         resource: { attributes: {} },
       });
 
@@ -101,11 +101,11 @@ describe("trace service", () => {
     });
 
     test("QuerySpans returns stored spans", async () => {
-      const service = new TraceService(mockConfig, mockTraceIndex);
+      const service = new SpanService(mockConfig, mockTraceIndex);
 
       // Record a span first
       await service.RecordSpan(
-        trace.Span.fromObject({
+        span.SpanItem.fromObject({
           trace_id: "trace123",
           span_id: "span456",
           parent_span_id: "",
@@ -115,7 +115,7 @@ describe("trace service", () => {
           end_time_unix_nano: "1698345601000000000",
           attributes: { "service.name": "test-service" },
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: span.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -132,11 +132,11 @@ describe("trace service", () => {
     });
 
     test("QuerySpans filters by trace_id", async () => {
-      const service = new TraceService(mockConfig, mockTraceIndex);
+      const service = new SpanService(mockConfig, mockTraceIndex);
 
       // Record spans with different trace IDs
       await service.RecordSpan(
-        trace.Span.fromObject({
+        span.SpanItem.fromObject({
           trace_id: "trace123",
           span_id: "span1",
           parent_span_id: "",
@@ -146,13 +146,13 @@ describe("trace service", () => {
           end_time_unix_nano: "1698345601000000000",
           attributes: {},
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: span.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await service.RecordSpan(
-        trace.Span.fromObject({
+        span.SpanItem.fromObject({
           trace_id: "trace456",
           span_id: "span2",
           parent_span_id: "",
@@ -162,7 +162,7 @@ describe("trace service", () => {
           end_time_unix_nano: "1698345601000000000",
           attributes: {},
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: span.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
@@ -179,12 +179,12 @@ describe("trace service", () => {
     });
 
     test("QuerySpans respects limit parameter", async () => {
-      const service = new TraceService(mockConfig, mockTraceIndex);
+      const service = new SpanService(mockConfig, mockTraceIndex);
 
       // Record multiple spans
       for (let i = 0; i < 5; i++) {
         await service.RecordSpan(
-          trace.Span.fromObject({
+          span.SpanItem.fromObject({
             trace_id: "trace123",
             span_id: `span${i}`,
             parent_span_id: "",
@@ -194,7 +194,7 @@ describe("trace service", () => {
             end_time_unix_nano: "1698345601000000000",
             attributes: {},
             events: [],
-            status: { code: trace.Code.OK, message: "" },
+            status: { code: span.Code.OK, message: "" },
             resource: { attributes: {} },
           }),
         );
@@ -211,9 +211,9 @@ describe("trace service", () => {
     });
 
     test("RecordSpan handles span with events", async () => {
-      const service = new TraceService(mockConfig, mockTraceIndex);
+      const service = new SpanService(mockConfig, mockTraceIndex);
 
-      const spanRequest = trace.Span.fromObject({
+      const spanRequest = span.SpanItem.fromObject({
         trace_id: "trace123",
         span_id: "span456",
         parent_span_id: "span123",
@@ -229,7 +229,7 @@ describe("trace service", () => {
             attributes: { hit_rate: "0.95" },
           },
         ],
-        status: { code: trace.Code.OK, message: "" },
+        status: { code: span.Code.OK, message: "" },
         resource: { attributes: {} },
       });
 
@@ -245,9 +245,9 @@ describe("trace service", () => {
     });
 
     test("RecordSpan handles error status", async () => {
-      const service = new TraceService(mockConfig, mockTraceIndex);
+      const service = new SpanService(mockConfig, mockTraceIndex);
 
-      const spanRequest = trace.Span.fromObject({
+      const spanRequest = span.SpanItem.fromObject({
         trace_id: "trace123",
         span_id: "span789",
         parent_span_id: "",
@@ -258,7 +258,7 @@ describe("trace service", () => {
         attributes: { "service.name": "test-service" },
         events: [],
         status: {
-          code: trace.Code.ERROR,
+          code: span.Code.ERROR,
           message: "Connection timeout",
         },
         resource: { attributes: {} },
@@ -271,12 +271,12 @@ describe("trace service", () => {
 
       const stored = mockTraceIndex.index.get("span789");
       assert.ok(stored);
-      assert.strictEqual(stored.span.status.code, trace.Code.ERROR);
+      assert.strictEqual(stored.span.status.code, span.Code.ERROR);
       assert.strictEqual(stored.span.status.message, "Connection timeout");
     });
 
     test("QuerySpans requires either trace_id or resource_id", async () => {
-      const service = new TraceService(mockConfig, mockTraceIndex);
+      const service = new SpanService(mockConfig, mockTraceIndex);
 
       await assert.rejects(
         async () => {
@@ -287,11 +287,11 @@ describe("trace service", () => {
     });
 
     test("QuerySpans filters by resource_id", async () => {
-      const service = new TraceService(mockConfig, mockTraceIndex);
+      const service = new SpanService(mockConfig, mockTraceIndex);
 
       // Record spans with resource_id
       await service.RecordSpan(
-        trace.Span.fromObject({
+        span.SpanItem.fromObject({
           trace_id: "trace123",
           span_id: "span1",
           parent_span_id: "",
@@ -301,13 +301,13 @@ describe("trace service", () => {
           end_time_unix_nano: "1698345601000000000",
           attributes: {},
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: span.Code.OK, message: "" },
           resource: { attributes: {} },
         }),
       );
 
       await service.RecordSpan(
-        trace.Span.fromObject({
+        span.SpanItem.fromObject({
           trace_id: "trace123",
           span_id: "span2",
           parent_span_id: "span1",
@@ -317,7 +317,7 @@ describe("trace service", () => {
           end_time_unix_nano: "1698345601000000000",
           attributes: {},
           events: [],
-          status: { code: trace.Code.OK, message: "" },
+          status: { code: span.Code.OK, message: "" },
           resource: { attributes: { id: "common.Conversation.test123" } },
         }),
       );

--- a/websites/README.md
+++ b/websites/README.md
@@ -200,5 +200,5 @@ tenancy)
 
 | Hire | Path | Title |
 | ---- | ---- | ----- |
-| Big | `prove-changes/` | Collect Trace Spans from Any Product |
+| Big | `prove-changes/` | Collect Spans from Any Product |
 | Little | `prove-changes/send-spans/` | Send Spans from a Product |

--- a/websites/fit/docs/getting-started/contributors/index.md
+++ b/websites/fit/docs/getting-started/contributors/index.md
@@ -113,8 +113,8 @@ The services tree holds these gRPC microservices:
 - oauth
 - oidc
 - pathway
+- span
 - tenancy
-- trace
 - vector
 
 <!-- /enum -->

--- a/websites/fit/docs/internals/release/index.md
+++ b/websites/fit/docs/internals/release/index.md
@@ -120,7 +120,7 @@ when the bundle set changes.
 | `fit-landmark` | `fit-landmark` | 1 |
 | `fit-summit` | `fit-summit` | 1 |
 | `fit-outpost` | `fit-outpost` | 1 |
-| `fit-gear` | `fit-svcgraph`, `fit-svcmcp`, `fit-svcpathway`, `fit-svctrace`, `fit-svcvector`, `fit-codegen`, `fit-terrain`, `fit-harness`, `fit-doc`, `fit-rc`, `fit-xmr`, `fit-storage`, `fit-logger`, `fit-svscan`, `fit-trace`, `fit-visualize`, `fit-query`, `fit-subjects`, `fit-process-graphs`, `fit-process-resources`, `fit-process-vectors`, `fit-search`, `fit-unary`, `fit-tiktoken`, `fit-download-bundle`, `fit-wiki`, `fit-benchmark`, `fit-pack`, `coaligned` | 29 |
+| `fit-gear` | `fit-svcgraph`, `fit-svcmcp`, `fit-svcpathway`, `fit-svcspan`, `fit-svcvector`, `fit-codegen`, `fit-terrain`, `fit-harness`, `fit-doc`, `fit-rc`, `fit-xmr`, `fit-storage`, `fit-logger`, `fit-svscan`, `fit-trace`, `fit-visualize`, `fit-query`, `fit-subjects`, `fit-process-graphs`, `fit-process-resources`, `fit-process-vectors`, `fit-search`, `fit-unary`, `fit-tiktoken`, `fit-download-bundle`, `fit-wiki`, `fit-benchmark`, `fit-pack`, `coaligned` | 29 |
 
 Both the `.app` assembly and the cask `binary` block derive from
 `build/cli-manifest.json` for **every** bundle — one code path, no gear

--- a/websites/fit/docs/libraries/service-lifecycle/add-observability/index.md
+++ b/websites/fit/docs/libraries/service-lifecycle/add-observability/index.md
@@ -1,6 +1,6 @@
 ---
 title: Add Observability
-description: Structured, machine-readable logs and traces without configuring a logging framework — drop in a log line or trace span and it works.
+description: Structured, machine-readable logs and spans without configuring a logging framework — drop in a log line or a span and it works.
 ---
 
 You need to log what a service is doing and trace operations across service
@@ -85,7 +85,7 @@ and appends the stack trace when debug output is enabled:
 logger.exception("db", err, { host: "localhost" });
 ```
 
-## Add a trace span
+## Add a span
 
 The `Tracer` requires a span service client and a gRPC metadata constructor.
 Once configured, creating a span is a single call:
@@ -193,9 +193,9 @@ spans are created, and the gRPC calls proceed without trace context. This means
 you can add the observer first and wire up tracing later without changing your
 handler code.
 
-## Query and visualize recorded traces
+## Query and visualize recorded spans
 
-Once spans are flowing into the trace index, `fit-visualize` reads them back and
+Once spans are flowing into the span index, `fit-visualize` reads them back and
 renders them as Mermaid sequence diagrams. It is a filter-and-query tool: pipe a
 [JMESPath](https://jmespath.org/) expression on stdin to select spans, and it
 emits a diagram of the service interactions in those traces.

--- a/websites/fit/docs/libraries/service-lifecycle/add-observability/index.md
+++ b/websites/fit/docs/libraries/service-lifecycle/add-observability/index.md
@@ -7,7 +7,7 @@ You need to log what a service is doing and trace operations across service
 boundaries, but you do not want to configure a logging framework, pick a format,
 or wire up an export pipeline. `@forwardimpact/libtelemetry` provides three
 tools that work out of the box: a `Logger` that produces RFC 5424-formatted
-lines, a `Tracer` that records spans to a trace service, and an `Observer` that
+lines, a `Tracer` that records spans to a span service, and an `Observer` that
 unifies both for gRPC operations. This page covers the bounded task of adding
 observability to a service. For the full lifecycle setup, see
 [Service Lifecycle](/docs/libraries/service-lifecycle/).
@@ -87,7 +87,7 @@ logger.exception("db", err, { host: "localhost" });
 
 ## Add a trace span
 
-The `Tracer` requires a trace service client and a gRPC metadata constructor.
+The `Tracer` requires a span service client and a gRPC metadata constructor.
 Once configured, creating a span is a single call:
 
 ```js
@@ -95,7 +95,7 @@ import { Tracer } from "@forwardimpact/libtelemetry/tracer.js";
 
 const tracer = new Tracer({
   serviceName: "my-service",
-  traceClient,      // gRPC client for the trace service
+  spanClient,      // gRPC client for the span service
   grpcMetadata,     // gRPC Metadata constructor
 });
 

--- a/websites/fit/docs/libraries/typed-contracts/index.md
+++ b/websites/fit/docs/libraries/typed-contracts/index.md
@@ -172,15 +172,15 @@ shared schemas:
 | `tool`     | Tool-call types -- `ToolFunction`, `ToolCall`, `ToolCallResult`, `QueryFilter`   |
 | `vector`   | Vector-search request and result types                                          |
 | `graph`    | Graph-query request and result types                                            |
-| `trace`    | Distributed-tracing span and event types                                        |
+| `span`     | Distributed-tracing span and event types                                        |
 
 Import any of them the same way:
 
 ```js
-import { common, resource, vector, graph, trace } from "@forwardimpact/libtype";
+import { common, resource, vector, graph, span } from "@forwardimpact/libtype";
 ```
 
-The `common`, `resource`, `vector`, `graph`, and `trace` namespaces are reused
+The `common`, `resource`, `vector`, `graph`, and `span` namespaces are reused
 across services, so a graph service constructs a `graph.SubjectsQuery` and a
 vector service constructs a `vector` request without redefining those shapes.
 

--- a/websites/fit/docs/services/prove-changes/index.md
+++ b/websites/fit/docs/services/prove-changes/index.md
@@ -1,11 +1,11 @@
 ---
-title: Collect Trace Spans from Any Product
-description: Products that emit trace spans without managing storage — shared span gRPC service with a single collection point.
+title: Collect Spans from Any Product
+description: Products that emit spans without managing storage — shared span gRPC service with a single collection point.
 ---
 
-You are building a product that generates trace spans -- recording what an agent
+You are building a product that generates spans -- recording what an agent
 did, how long each step took, and whether it succeeded -- and you need those
-spans stored somewhere queryable. Managing per-product trace files means each
+spans stored somewhere queryable. Managing per-product span files means each
 product reinvents storage, indexing, and query logic. The span gRPC service
 accepts spans from any product, stores them in a shared JSONL-backed index, and
 serves them back through a query interface. Your product sends a span; the
@@ -46,7 +46,7 @@ Product B ──┘                    └── (query interface)
 ```
 
 The span service intentionally does not trace itself -- connecting a tracer
-to a service that records traces would create infinite recursion.
+to a service that records spans would create infinite recursion.
 
 ## Connect to the span service
 

--- a/websites/fit/docs/services/prove-changes/index.md
+++ b/websites/fit/docs/services/prove-changes/index.md
@@ -1,24 +1,24 @@
 ---
 title: Collect Trace Spans from Any Product
-description: Products that emit trace spans without managing storage — shared trace gRPC service with a single collection point.
+description: Products that emit trace spans without managing storage — shared span gRPC service with a single collection point.
 ---
 
 You are building a product that generates trace spans -- recording what an agent
 did, how long each step took, and whether it succeeded -- and you need those
 spans stored somewhere queryable. Managing per-product trace files means each
-product reinvents storage, indexing, and query logic. The trace gRPC service
+product reinvents storage, indexing, and query logic. The span gRPC service
 accepts spans from any product, stores them in a shared JSONL-backed index, and
 serves them back through a query interface. Your product sends a span; the
 service handles persistence and retrieval.
 
-This guide walks through connecting to the trace service, recording a span,
+This guide walks through connecting to the span service, recording a span,
 querying it back, and verifying the round trip works.
 
 ## Prerequisites
 
 - Node.js 18+
 - Generated client code available (run `npx fit-codegen --all` if not)
-- The trace service running (`npx fit-rc start`)
+- The span service running (`npx fit-rc start`)
 
 Install the transport and type packages:
 
@@ -28,29 +28,29 @@ npm install @forwardimpact/librpc @forwardimpact/libtype
 
 ## Architecture overview
 
-The trace service owns two RPCs:
+The span service owns two RPCs:
 
 | RPC           | Purpose                          | Request type          | Response type           |
 | ------------- | -------------------------------- | --------------------- | ----------------------- |
-| `RecordSpan`  | Store a span in the trace index  | `trace.Span`          | `trace.RecordResponse`  |
-| `QuerySpans`  | Retrieve spans by query or filter| `trace.QueryRequest`  | `trace.QueryResponse`   |
+| `RecordSpan`  | Store a span in the span index  | `span.SpanItem`          | `span.RecordResponse`  |
+| `QuerySpans`  | Retrieve spans by query or filter| `span.QueryRequest`  | `span.QueryResponse`   |
 
 The service stores spans in a `TraceIndex` backed by a JSONL file at
-`data/traces/index.jsonl`. The index is append-only during the service
+`data/spans/index.jsonl`. The index is append-only during the service
 lifetime and flushed on shutdown.
 
 ```text
-Product A ──┐                    ┌── data/traces/index.jsonl
-            ├── gRPC ── trace ──┤
+Product A ──┐                    ┌── data/spans/index.jsonl
+            ├── gRPC ── span ──┤
 Product B ──┘                    └── (query interface)
 ```
 
-The trace service intentionally does not trace itself -- connecting a tracer
+The span service intentionally does not trace itself -- connecting a tracer
 to a service that records traces would create infinite recursion.
 
-## Connect to the trace service
+## Connect to the span service
 
-Create a trace client. Because the trace service cannot use distributed
+Create a span client. Because the span service cannot use distributed
 tracing internally, the client connection is simpler than other services:
 
 ```js
@@ -58,18 +58,18 @@ import { createClient } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
 const logger = createLogger("my-product");
-const traceClient = await createClient("trace", logger);
+const spanClient = await createClient("span", logger);
 ```
 
 ## Record a span
 
-Build a `trace.Span` message and call `RecordSpan`. Every span requires a
+Build a `span.SpanItem` message and call `RecordSpan`. Every span requires a
 `trace_id` and `span_id`:
 
 ```js
-import { trace } from "@forwardimpact/libtype";
+import { span } from "@forwardimpact/libtype";
 
-const span = trace.Span.fromObject({
+const record = span.SpanItem.fromObject({
   trace_id: "abc123",
   span_id: "span-001",
   parent_span_id: "",
@@ -90,7 +90,7 @@ const span = trace.Span.fromObject({
   },
 });
 
-const result = await traceClient.RecordSpan(span);
+const result = await spanClient.RecordSpan(record);
 console.log("Recorded:", result.success);
 ```
 
@@ -121,7 +121,7 @@ Recorded: true
 Events mark points of interest within a span:
 
 ```js
-const spanWithEvents = trace.Span.fromObject({
+const spanWithEvents = span.SpanItem.fromObject({
   trace_id: "abc123",
   span_id: "span-002",
   parent_span_id: "span-001",
@@ -147,7 +147,7 @@ const spanWithEvents = trace.Span.fromObject({
   },
 });
 
-await traceClient.RecordSpan(spanWithEvents);
+await spanClient.RecordSpan(spanWithEvents);
 ```
 
 ## Query spans
@@ -158,11 +158,11 @@ resource ID -- at least one must be provided:
 ### By trace ID
 
 ```js
-const queryByTrace = trace.QueryRequest.fromObject({
+const queryByTrace = span.QueryRequest.fromObject({
   filter: { trace_id: "abc123" },
 });
 
-const result = await traceClient.QuerySpans(queryByTrace);
+const result = await spanClient.QuerySpans(queryByTrace);
 console.log("Spans found:", result.spans?.length ?? 0);
 
 for (const span of result.spans ?? []) {
@@ -181,34 +181,34 @@ Spans found: 2
 ### By resource ID
 
 ```js
-const queryByResource = trace.QueryRequest.fromObject({
+const queryByResource = span.QueryRequest.fromObject({
   filter: { resource_id: "my-product" },
 });
 
-const result = await traceClient.QuerySpans(queryByResource);
+const result = await spanClient.QuerySpans(queryByResource);
 console.log("Spans from my-product:", result.spans?.length ?? 0);
 ```
 
 ### By text query
 
 ```js
-const queryByText = trace.QueryRequest.fromObject({
+const queryByText = span.QueryRequest.fromObject({
   query: "evaluate",
 });
 
-const result = await traceClient.QuerySpans(queryByText);
+const result = await spanClient.QuerySpans(queryByText);
 console.log("Matching spans:", result.spans?.length ?? 0);
 ```
 
 ### Combine query and filter
 
 ```js
-const combined = trace.QueryRequest.fromObject({
+const combined = span.QueryRequest.fromObject({
   query: "evaluate",
   filter: { trace_id: "abc123" },
 });
 
-const result = await traceClient.QuerySpans(combined);
+const result = await spanClient.QuerySpans(combined);
 ```
 
 ## Build a trace tree
@@ -248,8 +248,8 @@ function buildTree(spans) {
   }
 }
 
-const result = await traceClient.QuerySpans(
-  trace.QueryRequest.fromObject({ filter: { trace_id: "abc123" } })
+const result = await spanClient.QuerySpans(
+  span.QueryRequest.fromObject({ filter: { trace_id: "abc123" } })
 );
 buildTree(result.spans ?? []);
 ```
@@ -265,13 +265,13 @@ evaluate-agent-output (1500ms)
 
 You have reached the outcome of this guide when:
 
-- `createClient("trace")` connects without error.
+- `createClient("span")` connects without error.
 - `RecordSpan` with a valid `trace_id` and `span_id` returns
   `{ success: true }`.
 - `QuerySpans` with the same `trace_id` returns the recorded spans.
 - Span attributes, events, and status are preserved in the round trip.
 
-If the connection fails, confirm the trace service is running with
+If the connection fails, confirm the span service is running with
 `npx fit-rc status`. If `RecordSpan` fails, check that both `trace_id` and
 `span_id` are non-empty strings.
 

--- a/websites/fit/docs/services/prove-changes/send-spans/index.md
+++ b/websites/fit/docs/services/prove-changes/send-spans/index.md
@@ -1,9 +1,9 @@
 ---
 title: Send Spans from a Product
-description: Trace spans emitted and immediately queryable — without managing storage infrastructure.
+description: Spans emitted and immediately queryable — without managing storage infrastructure.
 ---
 
-You need to record trace spans from within a product -- what happened, how long
+You need to record spans from within a product -- what happened, how long
 it took, whether it succeeded -- and trust that those spans are stored and
 queryable afterward. This page walks through the bounded task of connecting to
 the span service, building a span, sending it, and querying it back to
@@ -11,12 +11,12 @@ confirm the round trip.
 
 For the full setup including architecture context, the query interface, and
 tree reconstruction, see
-[Collect Trace Spans from Any Product](/docs/services/prove-changes/).
+[Collect Spans from Any Product](/docs/services/prove-changes/).
 
 ## Prerequisites
 
 - Completed the
-  [Collect Trace Spans from Any Product](/docs/services/prove-changes/) guide --
+  [Collect Spans from Any Product](/docs/services/prove-changes/) guide --
   you have `@forwardimpact/librpc` and `@forwardimpact/libtype` installed, and
   the span service is running.
 

--- a/websites/fit/docs/services/prove-changes/send-spans/index.md
+++ b/websites/fit/docs/services/prove-changes/send-spans/index.md
@@ -6,7 +6,7 @@ description: Trace spans emitted and immediately queryable — without managing 
 You need to record trace spans from within a product -- what happened, how long
 it took, whether it succeeded -- and trust that those spans are stored and
 queryable afterward. This page walks through the bounded task of connecting to
-the trace service, building a span, sending it, and querying it back to
+the span service, building a span, sending it, and querying it back to
 confirm the round trip.
 
 For the full setup including architecture context, the query interface, and
@@ -18,26 +18,26 @@ tree reconstruction, see
 - Completed the
   [Collect Trace Spans from Any Product](/docs/services/prove-changes/) guide --
   you have `@forwardimpact/librpc` and `@forwardimpact/libtype` installed, and
-  the trace service is running.
+  the span service is running.
 
 ## Connect
 
 ```js
 import { createClient } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
-import { trace } from "@forwardimpact/libtype";
+import { span } from "@forwardimpact/libtype";
 
 const logger = createLogger("my-product");
-const traceClient = await createClient("trace", logger);
+const spanClient = await createClient("span", logger);
 ```
 
 ## Send a span
 
-Build a `trace.Span` and call `RecordSpan`. Every span needs a `trace_id`
+Build a `span.SpanItem` and call `RecordSpan`. Every span needs a `trace_id`
 (grouping related spans) and a `span_id` (unique to this span):
 
 ```js
-const span = trace.Span.fromObject({
+const record = span.SpanItem.fromObject({
   trace_id: "eval-run-042",
   span_id: "step-01",
   name: "generate-output",
@@ -54,7 +54,7 @@ const span = trace.Span.fromObject({
   },
 });
 
-const result = await traceClient.RecordSpan(span);
+const result = await spanClient.RecordSpan(record);
 console.log("Sent:", result.success);
 ```
 
@@ -69,7 +69,7 @@ Sent: true
 Link a child span to its parent using `parent_span_id`:
 
 ```js
-const childSpan = trace.Span.fromObject({
+const childSpan = span.SpanItem.fromObject({
   trace_id: "eval-run-042",
   span_id: "step-02",
   parent_span_id: "step-01",
@@ -88,7 +88,7 @@ const childSpan = trace.Span.fromObject({
   },
 });
 
-await traceClient.RecordSpan(childSpan);
+await spanClient.RecordSpan(childSpan);
 ```
 
 ## Send an error span
@@ -96,7 +96,7 @@ await traceClient.RecordSpan(childSpan);
 When a step fails, set the status code to `ERROR` (2) with a message:
 
 ```js
-const errorSpan = trace.Span.fromObject({
+const errorSpan = span.SpanItem.fromObject({
   trace_id: "eval-run-042",
   span_id: "step-03",
   parent_span_id: "step-01",
@@ -113,7 +113,7 @@ const errorSpan = trace.Span.fromObject({
   },
 });
 
-await traceClient.RecordSpan(errorSpan);
+await spanClient.RecordSpan(errorSpan);
 ```
 
 ## Query to confirm
@@ -121,11 +121,11 @@ await traceClient.RecordSpan(errorSpan);
 After sending spans, query them back by trace ID to confirm storage:
 
 ```js
-const query = trace.QueryRequest.fromObject({
+const query = span.QueryRequest.fromObject({
   filter: { trace_id: "eval-run-042" },
 });
 
-const result = await traceClient.QuerySpans(query);
+const result = await spanClient.QuerySpans(query);
 console.log("Stored spans:", result.spans?.length ?? 0);
 
 for (const s of result.spans ?? []) {
@@ -150,19 +150,19 @@ either produces a gRPC error:
 
 ```js
 try {
-  const bad = trace.Span.fromObject({
+  const bad = span.SpanItem.fromObject({
     trace_id: "",
     span_id: "orphan",
     name: "missing-trace-id",
   });
-  await traceClient.RecordSpan(bad);
+  await spanClient.RecordSpan(bad);
 } catch (err) {
   console.error(err.message);
   // "trace_id is required"
 }
 ```
 
-If the trace service is unreachable, the client retries up to 10 times with
+If the span service is unreachable, the client retries up to 10 times with
 exponential backoff (1-second base delay, doubling each attempt, plus jitter)
 before surfacing the connection error.
 


### PR DESCRIPTION
Implements [spec 2200](../tree/main/specs/2200-rename-svctrace-svcspan) per its approved `plan-a.md`. Clean-break rename of the span-ingestion service `svctrace` → `svcspan`, removing the identifier collision with the unrelated `fit-trace` library.

## What changed

- **Service surface** — directory `services/trace/` → `services/span/`; package `@forwardimpact/svcspan`; bin `fit-svcspan`; class `SpanService`; proto `package span` / `service Span`; config key `span`; storage bucket `spans`.
- **Generated** — regenerated both trees: `SpanServiceDefinition`, `SpanClient`, `SpanBase`, gRPC path `/span.Span/*`, libtype `span` namespace.
- **Coupled libraries** — `librpc` `createTracer`, `libtelemetry` (tracer/span/visualizer/index), `libtype` re-export, `libmock` `createMockSpanClient`.
- **Consumers/orchestration/docs** — guide + gear deps, guide status/init, `.env` examples, `docker-compose.yml`, service-URL-drift registry, starter config, `eval-guide.yml`, `justfile`, contributor refs, service guides, and the fit-guide data-layout reference.

Shared OpenTelemetry vocabulary (`Tracer`, `TraceIndex`, `TraceVisualizer`, the `Span` wrapper class, `trace_id`) is preserved; the harness NDJSON `trace-dir` and historical `specs/**` are untouched.

## Two adaptations forced by existing code

1. **Proto message `Span` → `SpanItem`.** The plan's `service Span` in `package span` collides with the payload `message Span` (protobuf requires unique names in a package) — the reason the service was originally named `Trace`. Following the repo idiom (service = capability, message = distinct payload: `Graph`/`PatternQuery`, `Embedding`/`EmbeddingVector`, `Tenancy`/`Tenant`), the service keeps `Span` and the message becomes `SpanItem`. The gRPC wire path is still `/span.Span/` and generated symbols are still `SpanClient`/`SpanBase`.
2. **`import { span as spanType }`** in libtelemetry source + tests — a bare `import { span }` would shadow the pervasive local `span` loop/const variables there.

## Verification

- All spec success-criteria sweeps clean; `services/span` exists, `services/trace` gone.
- `just codegen` idempotent; frozen lockfile installs with no changes.
- `bun run check` clean (the sole `coaligned invariants` error is a worktree-only `.git` pointer temporal false positive, absent on a normal CI checkout).
- Suites green: span-service 20, libtelemetry 46, librpc 29, libmock 78, guide 14.
- Clean three-reviewer panel: no blocker/high/medium findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)