### PR TITLE
feat(libharness): compact per-shard benchmark summaries, full report on merge

### DIFF
--- a/.claude/skills/fit-benchmark/references/cli.md
+++ b/.claude/skills/fit-benchmark/references/cli.md
@@ -57,6 +57,7 @@ pass, `1` on fail.
 | `--input`  | no       | Run-output directory containing `results.jsonl` (default `benchmark-runs`)           |
 | `--k`      | no       | Comma-separated `k` values (default `1,3,5`)                                         |
 | `--format` | no       | Output format `json` or `text` (default `json`)                                      |
+| `--detail` | no       | Text report verbosity `full` or `compact` (default `full`); `compact` drops per-task detail for a short sharded-run summary |
 
 Records that fail schema validation are skipped with a stderr warning
 and counted under `totals.skipped`.

--- a/libraries/libharness/actions/benchmark/.github/workflows/benchmark.yml
+++ b/libraries/libharness/actions/benchmark/.github/workflows/benchmark.yml
@@ -136,6 +136,9 @@ jobs:
           shard-total: ${{ inputs.shard-total }}
           k: ${{ inputs.k }}
           format: ${{ inputs.format }}
+          # Each shard emits a short status + pass@k summary; the merge job
+          # renders the full report over the combined ledger.
+          summary-detail: compact
 
   # Merge job: no agent scaffold — only Node for the report CLI. Download every
   # shard's partial ledger and aggregate one combined pass@k report.

--- a/libraries/libharness/actions/benchmark/README.md
+++ b/libraries/libharness/actions/benchmark/README.md
@@ -44,6 +44,7 @@ Handles task-family execution, pass@k reporting, and result artifact upload.
 | `mode`             | No       | `run`              | `run` executes one shard; `merge` aggregates every shard's partial ledger |
 | `merge-input`      | No       | `benchmark-merge`  | Directory shard ledgers download into (merge mode) |
 | `summary`          | No       | `true`             | Append report to GITHUB_STEP_SUMMARY      |
+| `summary-detail`   | No       | `full`             | Run-mode summary verbosity (`full` or `compact`); `compact` renders status + pass@k only. Merge always renders full. |
 | `upload-results`   | No       | `true`             | Upload results.jsonl as artifact          |
 | `artifact-name`    | No       | `benchmark-results`| Name for the uploaded artifact (run mode with `shard-total` > 1 uploads `benchmark-shard-<i>`) |
 | `timeout-minutes`  | No       | `60`               | Max runtime for the run step (minutes)    |
@@ -63,7 +64,8 @@ The action executes three steps in sequence:
    `<output>/results.jsonl`.
 2. **Report** — runs `fit-benchmark report` and appends the output to
    `GITHUB_STEP_SUMMARY`. Fires even when the run step fails (`if: always()`).
-   Disable with `summary: "false"`.
+   Disable with `summary: "false"`. Set `summary-detail: compact` to emit a short
+   status + pass@k summary instead of the full per-task detail.
 3. **Upload** — uploads `results.jsonl` as a workflow artifact. Fires even when
    earlier steps fail. Disable with `upload-results: "false"`.
 
@@ -93,3 +95,8 @@ The workflow runs a `prepare` job (emits the shard list), `shard-total` parallel
 `benchmark-shard-<i>`), and one dependent `merge` job (no agent scaffold — only
 the report CLI) that aggregates the combined report. Calling the action directly
 with `shard-total` unset is the identity case: the whole family in one job.
+
+Each `shard` job emits a **compact** summary (status + pass@k, no per-task
+detail), so a many-shard run is quick to scan; the `merge` job emits the single
+**full** report over the combined ledger. Calling the action directly (unsharded)
+keeps the full summary by default.

--- a/libraries/libharness/actions/benchmark/action.yml
+++ b/libraries/libharness/actions/benchmark/action.yml
@@ -71,6 +71,10 @@ inputs:
     description: Append text report to GITHUB_STEP_SUMMARY after the run
     required: false
     default: "true"
+  summary-detail:
+    description: "Verbosity of the run-mode step summary (full|compact). compact renders status + pass@k only; merge mode always renders full."
+    required: false
+    default: "full"
   upload-results:
     description: Upload results.jsonl as a workflow artifact
     required: false
@@ -200,6 +204,7 @@ runs:
         OUTPUT_DIR: ${{ inputs.output }}
         K_VALUES: ${{ inputs.k }}
         FORMAT: ${{ inputs.format }}
+        SUMMARY_DETAIL: ${{ inputs.summary-detail }}
       run: |
         RESULTS="$OUTPUT_DIR/results.jsonl"
         if [ ! -s "$RESULTS" ]; then
@@ -207,10 +212,13 @@ runs:
           exit 0
         fi
 
+        # A sharded run passes summary-detail=compact so each shard emits a
+        # short status + pass@k summary; the merge job renders the full report.
         fit-benchmark report \
           --input="$OUTPUT_DIR" \
           --k="$K_VALUES" \
-          --format="$FORMAT" >> "$GITHUB_STEP_SUMMARY"
+          --format="$FORMAT" \
+          --detail="$SUMMARY_DETAIL" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload shard results
       if: always() && inputs.mode == 'run' && inputs.upload-results == 'true'

--- a/libraries/libharness/src/benchmark/report.js
+++ b/libraries/libharness/src/benchmark/report.js
@@ -143,11 +143,19 @@ export function renderTextReport(report, kValues) {
 }
 
 // ---------------------------------------------------------------------------
-// Compact report (legacy path)
+// Compact report — status line + pass@k table, no per-task detail. Selected by
+// `report --detail=compact` (aggregate without `includeRuns`); the per-shard
+// summary uses it so a sharded run stays short while the merge job renders the
+// full report over the combined ledger.
 // ---------------------------------------------------------------------------
 
 function renderCompactReport(report, kValues) {
+  const { totals } = report;
+  const passing = report.tasks.filter((t) => t.c > 0 && t.c === t.n).length;
+  const icon = statusIcon(passing === totals.tasks);
   const lines = [
+    `${icon} **${passing}/${totals.tasks} tasks passing** | ${totals.runs} runs${totals.skipped ? ` | ${totals.skipped} skipped` : ""}`,
+    "",
     renderPassAtKTable(report, kValues),
     "",
     renderTotalsLine(report),

--- a/libraries/libharness/src/commands/benchmark-definition.js
+++ b/libraries/libharness/src/commands/benchmark-definition.js
@@ -140,6 +140,11 @@ export const definition = {
           type: "string",
           description: "Output format (json|text, default: json)",
         },
+        detail: {
+          type: "string",
+          description:
+            "Text report verbosity (full|compact, default: full). compact omits per-task detail — useful for sharded run summaries.",
+        },
       },
     },
   ],

--- a/libraries/libharness/src/commands/benchmark-report.js
+++ b/libraries/libharness/src/commands/benchmark-report.js
@@ -1,7 +1,9 @@
 /**
  * `fit-benchmark report` — aggregate `results.jsonl` into pass@k via the
  * OpenAI HumanEval estimator. Output is JSON by default; pass --format=text
- * to render a markdown table.
+ * to render a markdown table. --detail=compact drops the per-task detail
+ * sections so a sharded run's per-shard summary stays short (the merge job
+ * renders the full report over the combined ledger).
  */
 
 import { resolve } from "node:path";
@@ -35,11 +37,19 @@ export async function runBenchmarkReportCommand(ctx) {
   if (format !== "json" && format !== "text") {
     return { ok: false, code: 1, error: "--format must be 'json' or 'text'" };
   }
+  const detail = values.detail ?? "full";
+  if (detail !== "full" && detail !== "compact") {
+    return {
+      ok: false,
+      code: 1,
+      error: "--detail must be 'full' or 'compact'",
+    };
+  }
 
   const report = await aggregate({
     inputDir: resolve(inputDir),
     kValues,
-    includeRuns: format === "text",
+    includeRuns: format === "text" && detail === "full",
     runtime,
   });
   if (format === "text") {

--- a/libraries/libharness/test/benchmark-report.test.js
+++ b/libraries/libharness/test/benchmark-report.test.js
@@ -387,3 +387,34 @@ describe("renderTextReport (full report)", () => {
     assert.doesNotMatch(text, /#### Invariant Checks/);
   });
 });
+
+describe("renderTextReport (compact report)", () => {
+  // Without includeRuns the report carries no per-run detail, so renderTextReport
+  // selects the compact path — the shape a sharded run's per-shard summary uses.
+  test("renders status header and pass@k table without per-task detail", async () => {
+    const records = [
+      baseRecord({ taskId: "alpha", runIndex: 0, verdict: "pass" }),
+      baseRecord({
+        taskId: "beta",
+        runIndex: 0,
+        verdict: "fail",
+        invariants: {
+          verdict: "fail",
+          details: [{ test: "t1", pass: false, message: "nope" }],
+          exitCode: 1,
+        },
+      }),
+    ];
+    const runtime = jsonlRuntime(records);
+    const report = await aggregate({
+      runtime,
+      inputDir: INPUT_DIR,
+      kValues: [1],
+    });
+    const text = renderTextReport(report, [1]);
+    assert.match(text, /❌ \*\*1\/2 tasks passing\*\* \| 2 runs/);
+    assert.match(text, /\| taskId \| n \| c \| pass@1 \|/);
+    assert.doesNotMatch(text, /## Task Details/);
+    assert.doesNotMatch(text, /#### Invariant Checks/);
+  });
+});

--- a/websites/fit/docs/libraries/prove-changes/run-benchmark/ci-workflow/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-benchmark/ci-workflow/index.md
@@ -54,7 +54,8 @@ task N times, append the pass@k report to the GitHub step summary, and upload
    `bunx`, then `npx`.
 3. **Run** — executes `fit-benchmark run` with the provided inputs.
 4. **Report** — appends the text report to `GITHUB_STEP_SUMMARY` (when
-   `summary` is `"true"`).
+   `summary` is `"true"`). Set `summary-detail` to `"compact"` for a short
+   status + pass@k summary instead of the full per-task detail.
 5. **Upload** — uploads `results.jsonl` as a workflow artifact (when
    `upload-results` is `"true"`).
 
@@ -83,6 +84,7 @@ CI-specific inputs that have no CLI equivalent:
 | `k` | `"1,3,5"` | Comma-separated k values for pass@k |
 | `format` | `"text"` | Report output format |
 | `summary` | `"true"` | Append report to `GITHUB_STEP_SUMMARY` |
+| `summary-detail` | `"full"` | Run-mode summary verbosity (`full` or `compact`); `compact` renders status + pass@k only |
 | `upload-results` | `"true"` | Upload `results.jsonl` as artifact |
 | `artifact-name` | `"benchmark-results"` | Name for the uploaded artifact (run mode with `shard-total` > `"1"` uploads `benchmark-shard-<i>`) |
 | `timeout-minutes` | `"60"` | Maximum minutes before cancellation |
@@ -196,6 +198,10 @@ it provisions only the report CLI, since `report --input` discovers and unions
 every shard's `results.jsonl` recursively. Effective parallelism is
 `shard-total` × the per-machine concurrency. Leaving `shard-total` unset runs
 the whole family in one shard job — the identity case.
+
+Each shard job emits a compact summary (status + pass@k), so a many-shard run
+stays quick to scan; the merge job emits the single full report over the
+combined ledger.
 
 ## Verify
 


### PR DESCRIPTION
## Summary

- A sharded benchmark ran `fit-benchmark report --format=text` for every shard **and** for the merge, and text always rendered the full report (summary, pass@k, and per-task detail with per-run tables, invariant checks, judge commentary, and errors). A 6-shard run produced six full summaries plus the merged one — slow and high cognitive load to read because tasks are spread across shards.
- Add a `report --detail=full|compact` flag (default `full`) that drives `includeRuns`, so `compact` renders just a status line, the pass@k table, and totals — reusing the previously unreachable compact renderer path.
- The benchmark action gains a `summary-detail` input (default `full`) wired into the run-mode "Report (run)" step; the bundled sharded workflow passes `summary-detail: compact` on the shard job. Each shard now emits a short, scannable summary while the merge job renders the single full report over the combined ledger.
- Consumers that use the action directly and unsharded (e.g. `eval-wiki.yml`, no merge job) keep the full summary by default.
- Docs updated: action README, `fit-benchmark` CLI reference, and the public CI-workflow guide.

Note: the shard/merge jobs inside `benchmark.yml` pin `forwardimpact/benchmark@v1.0.x`, and monorepo consumers SHA-pin the reusable workflow. The new `summary-detail` input takes effect in CI only after a release is cut and those pins move (Dependabot for consumers) — no regression in the interim, since an unknown input is ignored and shards keep emitting full summaries until then.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- Verified locally: `bun test` for libharness (865 pass, 0 fail, incl. golden CLI suite); `--detail=compact` renders status + pass@k only; default/`--detail=full` unchanged; `--detail=bogus` exits 1; both YAML files parse with the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtUUGSexm1pNA6qGcmBvDv)_