### PR TITLE
design(2220): consolidate RAG and codegen CLIs

### DIFF
--- a/specs/2220-consolidate-clis-librag-codegen/design-a.md
+++ b/specs/2220-consolidate-clis-librag-codegen/design-a.md
@@ -104,6 +104,7 @@ here.
 | Ground-agents guides | `websites/fit/docs/libraries/ground-agents/**` | Rewrite `npx fit-*` invocations; slugs unchanged |
 | Codegen/vectors/release docs | `typed-contracts`, `internals/{vectors,release}`, `getting-started/engineers/guide` | Update invocations |
 | Catalogs | `libraries/README.md`, library docs index | Add `librag`; drop `fit-download-bundle` |
+| Gear product page | `websites/fit/gear/index.md` | Library-count enum regenerates for `librag` (mechanical via `context`); confirm the "Ground Agents in Context" card copy fits the unified `fit-rag` surface |
 
 Skill packs are generic: the new skills name CLIs bare (`fit-rag search`), never
 `npx`/paths, per `.claude/skills/CLAUDE.md`.

--- a/specs/2220-consolidate-clis-librag-codegen/design-a.md
+++ b/specs/2220-consolidate-clis-librag-codegen/design-a.md
@@ -1,0 +1,127 @@
+# Design 2220-a: Consolidate the RAG and codegen CLIs
+
+Spec [2220](spec.md) consolidates six RAG bins into two subcommand CLIs in a new
+`librag`, folds `fit-download-bundle` into `fit-codegen download`, and makes the
+proto-compiler toolchain opt-in — a clean break with skills and docs following.
+
+## Components
+
+```mermaid
+flowchart TB
+  subgraph librag[libraries/librag NEW]
+    P[bin/fit-process.js<br/>dispatch: resources|graphs|vectors]
+    R[bin/fit-rag.js<br/>dispatch: search|query|subjects]
+  end
+  subgraph existing[unchanged processing + index libs]
+    RES[libresource<br/>ResourceProcessor]
+    GRA[libgraph<br/>GraphProcessor / GraphIndex]
+    VEC[libvector<br/>VectorProcessor / VectorIndex]
+  end
+  P -->|resources| RES
+  P -->|graphs| GRA
+  P -->|vectors| VEC
+  R -->|search| VEC
+  R -->|query,subjects| GRA
+  subgraph libcodegen[libraries/libcodegen]
+    C[bin/fit-codegen.js<br/>dispatch: generate|download]
+    G[src/commands/generate.js<br/>heavy: proto-loader,mustache]
+    D[src/commands/download.js<br/>lean: bundle fetch]
+    C -->|generate| G
+    C -->|download| D
+  end
+```
+
+`librag` depends on `libresource`, `libgraph`, `libvector` and shared
+`libcli`/`libstorage`/`libtelemetry`/`libconfig`; `librpc` is reached only
+through `libvector` for the `vectors`/`search` closures, not as a broad shared
+dep. It contains **no** processing or query logic — each handler constructs the
+same index + processor the old bin did and delegates. Dynamic `import()` defers
+*evaluation*, not *installation*: `librag` always installs all three RAG libs,
+so the isolation it buys is runtime cost, not install footprint (unlike the
+codegen case below). The `download` logic (`createBundleDownloader` +
+`execLine`, plus `createScriptConfig` from `libconfig`) moves from `libutil`
+into `libcodegen/src/commands/download.js`; `libutil` keeps the reusable
+helpers, loses only the bin. Because `download` calls `createScriptConfig`,
+`libcodegen` gains `libconfig` as a direct dependency (today it resolves only
+transitively).
+
+## Dispatch interface
+
+Each consolidated bin uses libcli's native `commands` array (the established
+pattern in `libterrain`), where each command handler does its own
+`await import()` of the command module. Top-level `--help`/`--version`/bare
+invocation stay handled by `createCli`, unchanged. A handler's heavy `import()`
+runs only when its subcommand is dispatched, so a subcommand evaluates only its
+own module closure — no sibling's dependencies load.
+
+| Bin | Subcommand | Loads (beyond shared libs) | Args / stdout preserved from |
+| --- | --- | --- | --- |
+| `fit-process` | `resources` | libresource; `--base` scoped here | `fit-process-resources` |
+| `fit-process` | `graphs` | libgraph | `fit-process-graphs` |
+| `fit-process` | `vectors` | libvector + embedding client (lazy) | `fit-process-vectors` |
+| `fit-rag` | `search` | libvector + embedding client (lazy) | `fit-search` |
+| `fit-rag` | `query` | libgraph | `fit-query` |
+| `fit-rag` | `subjects` | libgraph | `fit-subjects` |
+| `fit-codegen` | `generate` | proto-loader, mustache, protobufjs, long-init | `fit-codegen --*` |
+| `fit-codegen` | `download` | libstorage + libconfig bundle fetch, `execLine` | `fit-download-bundle` |
+
+The embedding gRPC client is constructed inside the `vectors`/`search` handlers
+only, so offline subcommands (`resources`, `graphs`, `query`, `subjects`,
+`download`) never require that service.
+
+## Packaging: the codegen toolchain
+
+`libcodegen` moves `@grpc/proto-loader`, `mustache`, and `protobufjs-cli` from
+`dependencies` to `optionalDependencies`. Default installs (npx, workspace) keep
+them, so `generate` works for external developers with no extra step. Production
+images install with optional deps omitted and get a `download`-only
+`libcodegen`. `generate.js` guards its heavy dynamic imports and prints a
+reinstall hint if they are absent. `protobufjs` stays a regular dependency — the
+telemetry chain `download` needs (`libtelemetry` → `libindex` → `libtype`, which
+`libstorage`/`libutil` also reach) pulls it regardless, so it cannot be shed
+here.
+
+## Key Decisions
+
+| Decision | Choice | Rejected alternative |
+| --- | --- | --- |
+| RAG CLI home | New `librag` aggregates the bins, delegates to existing libs | Re-home processors/queries into `librag` — churns three owners, breaks library-mandate; or add subcommands in one existing lib — arbitrary owner, cyclic deps |
+| Write vs read | Two bins (`fit-process`, `fit-rag`) | One mega-CLI — staples unlike prerequisites/audiences (embedding service vs offline reads) together |
+| One library or two | Single `librag` for both bins | `librag-write` + `librag-read` — doubles packaging for one domain, no consumer benefit |
+| Subcommand loading | libcli `commands` array + `await import()` in each handler (the `libterrain` pattern) | Hand-rolled `argv[0]` dispatch — reinvents libcli's help/version/usage handling; static top-level imports — load every dep for every subcommand, defeating the codegen footprint goal |
+| Codegen toolchain gate | `optionalDependencies` + omit-in-prod | Optional `peerDependencies` — not auto-installed, breaks `npx fit-codegen generate` for external devs; keeping in `dependencies` — no prod win |
+| `fit-codegen` surface | Explicit `generate`/`download` subcommands | Keep bare flags as implicit generate — asymmetric with `download`, and the spec frames both as subcommands |
+| Old bins & launchers | Delete six RAG bins + their launchers; add `launchers/fit-process` + `launchers/fit-rag`; delete `fit-download-bundle` bin (it has no launcher) | Deprecated alias shims — the standard forbids compat wrappers absent a spec requirement |
+| Doc slugs | Keep all ground-agents slugs; re-point the two in CLI `documentation` arrays (`search-semantically`, `query-graph`) to `fit-rag`; edit invocations only | Rename slugs to match new CLIs — breaks published URLs |
+
+## Skills and docs
+
+| Surface | WHERE | Action |
+| --- | --- | --- |
+| RAG read skills | `.claude/skills/fit-{search,query,subjects}` | Delete |
+| New RAG skills | `.claude/skills/fit-rag`, `.claude/skills/fit-process` | Add; `fit-rag`'s `## Documentation` mirrors its CLI array (`fit-process` has none) |
+| Codegen skill | `.claude/skills/fit-codegen` | Add `generate`/`download` usage |
+| Ground-agents guides | `websites/fit/docs/libraries/ground-agents/**` | Rewrite `npx fit-*` invocations; slugs unchanged |
+| Codegen/vectors/release docs | `typed-contracts`, `internals/{vectors,release}`, `getting-started/engineers/guide` | Update invocations |
+| Catalogs | `libraries/README.md`, library docs index | Add `librag`; drop `fit-download-bundle` |
+
+Skill packs are generic: the new skills name CLIs bare (`fit-rag search`), never
+`npx`/paths, per `.claude/skills/CLAUDE.md`.
+
+## Migration surface (call sites)
+
+The `justfile` codegen target, `.github/workflows/**`, the container
+`Dockerfile` entrypoint (`fit-download-bundle` → `fit-codegen download`), and
+`CLAUDE.md`'s `npx fit-codegen --all`/RAG references move to the new commands.
+Success criterion 7 (`rg` finds no removed names in live sources) is the
+completeness gate.
+
+## Risks
+
+- **Contract drift.** A subcommand that alters positional args or stdout breaks
+  downstream parsers — the plan pins per-subcommand snapshot checks against the
+  old CLIs (criterion 2).
+- **Hidden call site.** A missed invocation ships a broken command — the
+  `rg`-clean criterion is the backstop.
+- **Version coupling.** `librag` becomes a fan-in release point over three libs;
+  a downstream fix must flow through a `librag` release to reach npm consumers.

--- a/specs/2220-consolidate-clis-librag-codegen/spec.md
+++ b/specs/2220-consolidate-clis-librag-codegen/spec.md
@@ -1,0 +1,136 @@
+# Spec 2220: Consolidate the RAG and codegen CLIs
+
+**Classification:** Internal — the change lands on shared libraries
+(`libraries/`), agent skills (`.claude/skills/`), and library documentation. No
+`products/` or `services/` surface changes.
+
+**Persona / job:** Platform Builders, across two jobs. The RAG consolidation
+serves *Ground Agents in Context*
+([libraries/README.md](../../libraries/README.md)), whose Trigger is knowledge
+"scattered across files no one maintains" — the fragmented CLI surface. The
+codegen consolidation serves *Build Agent-Capable Systems* (Gear,
+[JTBD.md](../../JTBD.md)) on its typed-contracts thread.
+
+## Problem
+
+A Platform Builder who installs the knowledge stack meets six separately-named
+CLIs across three libraries, and a codegen library that forces a heavyweight
+build toolchain into every runtime image.
+
+**The RAG surface is fragmented.** One coherent Retrieval-Augmented-Generation
+domain is split across six binaries in three libraries, each a thin (~50–80
+line) wrapper over its library API:
+
+| CLI | Library | Role | Reads/Writes |
+| --- | --- | --- | --- |
+| `fit-process-resources` | libresource | write | HTML → `resources` index |
+| `fit-process-graphs` | libgraph | write | `resources` → `graphs` index |
+| `fit-process-vectors` | libvector | write | `resources` → `vectors` index |
+| `fit-search` | libvector | read | queries `vectors` index |
+| `fit-query` | libgraph | read | queries `graphs` index |
+| `fit-subjects` | libgraph | read | enumerates `graphs` subjects |
+
+The three write CLIs form one strict pipeline keyed on a shared `resources`
+intermediate (`libgraph` and `libvector` both depend on `libresource`). The
+three read CLIs are pure lookups over the two indexes the write side produces;
+`fit-query` and `fit-subjects` already share one graph handle and carry the same
+paired documentation links. The published Ground-Agents guide walks a user
+through six distinct `npx fit-*` invocations to complete one build-then-query
+workflow — a user must learn six binary names to run what is two operations.
+
+**The codegen library over-installs in production.** `fit-codegen` (libcodegen)
+generates code from proto contracts and depends on a proto-compiler toolchain
+(`@grpc/proto-loader`, `mustache`, `protobufjs-cli`). Its produced artifact —
+`generated/bundle.tar.gz` — is fetched at container startup by a *separate*
+binary, `fit-download-bundle` (libutil). Producing and consuming one artifact
+live in two libraries, and any runtime image that only needs to fetch the bundle
+must still carry `fit-codegen`'s build toolchain if the two are ever merged
+naively. Today the split avoids that cost but scatters one artifact's lifecycle
+across two homes.
+
+## Proposal
+
+Consolidate along domain boundaries, one `<subcommand>` surface per operation.
+
+**1. New `librag` library, two CLIs.** Introduce a `librag` library that
+provides the consolidated RAG CLI surface. Existing processing and index
+behavior is unchanged; where that logic lives is a design concern.
+
+| New CLI | Subcommands | Replaces |
+| --- | --- | --- |
+| `fit-process` | `resources`, `graphs`, `vectors` | the three write CLIs |
+| `fit-rag` | `search`, `query`, `subjects` | the three read CLIs |
+
+The two operations — build the knowledge, then query it — stay two binaries, not
+one: they have different runtime prerequisites (only `vectors`/`search` need the
+embedding service) and different audiences (pipeline operator vs querying
+agent). Each subcommand preserves its predecessor's positional arguments, exact
+stdout, and exit behavior so downstream parsers are unaffected.
+
+**2. `fit-codegen` gains explicit `generate` and `download` subcommands.**
+`fit-codegen` moves from bare flags to a `generate` subcommand (its existing
+flags) plus a new `download` subcommand that folds in `fit-download-bundle`'s
+bundle-fetch, co-locating produce and consume of one artifact under one binary.
+A production install that only runs `download` must not pull the proto-compiler
+toolchain (`@grpc/proto-loader`, `mustache`, `protobufjs-cli`); those become
+opt-in and are present only when generation is wanted. This is a **partial**
+footprint win: `protobufjs` remains unavoidable because the telemetry chain
+`download` needs (`libtelemetry` → `libindex` → `libtype`) pulls it regardless;
+removing it is out of scope.
+
+**3. Clean break, no shims.** The six old RAG bins and `fit-download-bundle` are
+removed, not aliased ([CONTRIBUTING.md § Clean breaks](../../CONTRIBUTING.md));
+the six RAG launcher packages are replaced by `fit-process` and `fit-rag`
+launchers. All internal call sites — `justfile`, CI workflows, the container
+`Dockerfile` entrypoint, and `CLAUDE.md` — move to the new commands in the same
+change.
+
+**4. Skills and docs follow.** Skills and library documentation are updated so a
+fresh installation learns only the consolidated surface.
+
+| Surface | Change |
+| --- | --- |
+| `.claude/skills/fit-search`, `fit-query`, `fit-subjects` | Deleted; replaced by new `fit-rag` skill |
+| new `.claude/skills/fit-rag`, `.claude/skills/fit-process` | Added |
+| `.claude/skills/fit-codegen` | Updated for `generate`/`download` subcommands |
+| `websites/fit/docs/libraries/ground-agents/**` | Command invocations updated to `fit-process`/`fit-rag`; page slugs unchanged (published URLs) |
+| `websites/fit/docs/libraries/typed-contracts/**`, `internals/release`, `internals/vectors`, `getting-started/engineers/guide` | `fit-codegen`/RAG command invocations updated |
+| `libraries/README.md` catalog, `websites/fit/docs` library index | New `librag`; `fit-download-bundle` entry removed |
+
+Doc page slugs are published URLs, kept in place (retitled at most, never
+moved). Two slugs are referenced by CLI `documentation` arrays today —
+`search-semantically` (`fit-search`) and `query-graph` (`fit-query`,
+`fit-subjects`); those references move to the `fit-rag` skill and CLI. The
+`fit-process` write CLIs carry no `documentation` array today; adding one is
+optional. Skill `## Documentation` lists stay in parity with their CLI's
+`documentation` array.
+
+## Scope
+
+**In scope:** creating `librag` with `fit-process` and `fit-rag` and their
+launcher packages; removing the six RAG bins and their launchers; adding
+`fit-codegen download` and removing `fit-download-bundle`; making the
+proto-compiler toolchain opt-in for `libcodegen`; updating all internal call
+sites (including the container `Dockerfile` entrypoint), affected `fit-*`
+skills, and library docs.
+
+**Excluded:** decoupling `protobufjs` from `libtype`/`libtelemetry` (a
+foundational re-architecture); consolidating any hard-excluded CLIs
+(`fit-harness`+`fit-trace`; `fit-rc`+`fit-svscan`+`fit-logger`); merging the
+write and read surfaces into a single binary; changing index formats, storage
+backends, or the embedding service contract; any `products/` or `services/`
+behavior.
+
+## Success Criteria
+
+| # | Criterion | Verification |
+| --- | --- | --- |
+| 1 | `fit-process <resources\|graphs\|vectors>` runs each write stage | `npx fit-process resources --base=… && npx fit-process graphs && npx fit-process vectors` produces `data/resources`, `data/graphs`, `data/vectors` |
+| 2 | `fit-rag <search\|query\|subjects>` reproduces each predecessor's exact stdout | `fit-rag query` prints bare identifiers, `fit-rag search` prints `id<TAB>score`, `fit-rag subjects` prints `subject<TAB>type` — byte-identical to the old CLIs for the same input |
+| 3 | The six old RAG bins are gone and the two new launchers exist | No `bin`/launcher named `fit-process-{resources,graphs,vectors}`, `fit-search`, `fit-query`, or `fit-subjects`; `launchers/fit-process` and `launchers/fit-rag` present |
+| 4 | `fit-codegen generate` and `fit-codegen download` both work | `npx fit-codegen generate --all` regenerates code; `npx fit-codegen download` fetches and unpacks a bundle |
+| 5 | `fit-download-bundle` no longer exists | No `fit-download-bundle` bin in any `package.json` (it never shipped a launcher) |
+| 6 | A production install of `libcodegen` omits the proto-compiler toolchain | Installing `libcodegen` with optional dependencies omitted yields a `node_modules` without `@grpc/proto-loader`, `mustache`, or `protobufjs-cli`, and `fit-codegen download` still runs |
+| 7 | No live call site references a removed CLI | `rg` for the removed bin names finds no hits in shipped source, CI, the `Dockerfile`, docs, or `CLAUDE.md` (excluding `specs/`, test fixtures, and generated/lock files) |
+| 8 | Affected skills exist and are in CLI parity | `.claude/skills/fit-rag`, `fit-process`, `fit-codegen` present; `fit-search`/`fit-query`/`fit-subjects` skills absent; each skill's `## Documentation` matches its CLI's `documentation` array |
+| 9 | Repository checks pass | `bun run check` and `bunx coaligned` are green |

--- a/specs/2220-consolidate-clis-librag-codegen/spec.md
+++ b/specs/2220-consolidate-clis-librag-codegen/spec.md
@@ -1,8 +1,9 @@
 # Spec 2220: Consolidate the RAG and codegen CLIs
 
-**Classification:** Internal — the change lands on shared libraries
-(`libraries/`), agent skills (`.claude/skills/`), and library documentation. No
-`products/` or `services/` surface changes.
+**Classification:** Product-aligned — beyond shared libraries (`libraries/`),
+agent skills (`.claude/skills/`), and library docs, the change updates the
+**Gear** product landing page (`websites/fit/gear/`) and Gear's product scope,
+which documents a product surface a persona hires.
 
 **Persona / job:** Platform Builders, across two jobs. The RAG consolidation
 serves *Ground Agents in Context*
@@ -96,6 +97,7 @@ fresh installation learns only the consolidated surface.
 | `websites/fit/docs/libraries/ground-agents/**` | Command invocations updated to `fit-process`/`fit-rag`; page slugs unchanged (published URLs) |
 | `websites/fit/docs/libraries/typed-contracts/**`, `internals/release`, `internals/vectors`, `getting-started/engineers/guide` | `fit-codegen`/RAG command invocations updated |
 | `libraries/README.md` catalog, `websites/fit/docs` library index | New `librag`; `fit-download-bundle` entry removed |
+| `websites/fit/gear/index.md` (Gear product page) + Gear product scope | Reflect `librag` in the catalog and regenerated library count; keep the "Ground Agents in Context" retrieval capability copy accurate for the unified `fit-rag` surface |
 
 Doc page slugs are published URLs, kept in place (retitled at most, never
 moved). Two slugs are referenced by CLI `documentation` arrays today —
@@ -112,7 +114,7 @@ launcher packages; removing the six RAG bins and their launchers; adding
 `fit-codegen download` and removing `fit-download-bundle`; making the
 proto-compiler toolchain opt-in for `libcodegen`; updating all internal call
 sites (including the container `Dockerfile` entrypoint), affected `fit-*`
-skills, and library docs.
+skills, library docs, and the **Gear** product landing page and product scope.
 
 **Excluded:** decoupling `protobufjs` from `libtype`/`libtelemetry` (a
 foundational re-architecture); consolidating any hard-excluded CLIs
@@ -133,4 +135,5 @@ behavior.
 | 6 | A production install of `libcodegen` omits the proto-compiler toolchain | Installing `libcodegen` with optional dependencies omitted yields a `node_modules` without `@grpc/proto-loader`, `mustache`, or `protobufjs-cli`, and `fit-codegen download` still runs |
 | 7 | No live call site references a removed CLI | `rg` for the removed bin names finds no hits in shipped source, CI, the `Dockerfile`, docs, or `CLAUDE.md` (excluding `specs/`, test fixtures, and generated/lock files) |
 | 8 | Affected skills exist and are in CLI parity | `.claude/skills/fit-rag`, `fit-process`, `fit-codegen` present; `fit-search`/`fit-query`/`fit-subjects` skills absent; each skill's `## Documentation` matches its CLI's `documentation` array |
-| 9 | Repository checks pass | `bun run check` and `bunx coaligned` are green |
+| 9 | The Gear product page reflects the consolidation | `websites/fit/gear/index.md` shows the regenerated library count including `librag`, its "Ground Agents in Context" copy stays accurate, and no removed-CLI names appear |
+| 10 | Repository checks pass | `bun run check` and `bunx coaligned` are green |


### PR DESCRIPTION
## Spec + Design 2220 (lockstep)

Consolidates the fragmented RAG CLI surface and the codegen distribution CLIs, originating from the CLI-consolidation research quorum (10/10 agents converged on the RAG merge; the codegen merge is the accepted "partial win").

Carries both `spec.md` (WHAT/WHY) and `design-a.md` (WHICH/WHERE) — no separate spec PR (lockstep co-execution).

### What changes
- **New `librag` library, two CLIs.** `fit-process <resources|graphs|vectors>` (write) and `fit-rag <search|query|subjects>` (read) replace six bins across `libresource`/`libgraph`/`libvector`, delegating to the unchanged processing/index code.
- **`fit-codegen` gains `generate`/`download` subcommands**, folding in `fit-download-bundle`; the proto-compiler toolchain (`@grpc/proto-loader`, `mustache`, `protobufjs-cli`) moves to `optionalDependencies` so production images can omit it. Partial win — `protobufjs` stays, reached transitively via the `libtelemetry → libindex → libtype` chain `download` needs.
- **Clean break**: old bins + launchers removed, new launchers added; `justfile`/CI/`Dockerfile`/`CLAUDE.md` call sites migrated; affected `fit-*` skills and `ground-agents`/`typed-contracts` docs updated (slugs kept — published URLs).
- **Gear product surface**: the **Gear** product landing page (`websites/fit/gear/`) and Gear's product scope are updated to reflect the new `librag` library and the unified retrieval surface.

### Classification
Product-aligned — in addition to `libraries/`, `.claude/skills/`, and library docs, the change updates the Gear product landing page, which documents a product surface a persona hires.

### Review
Combined 9-reviewer panel run per the kata-review caller protocol: `spec.md` product (3) + technical (3), `design-a.md` technical (3). All consensus and verified-singleton findings addressed (job attribution, doc-slug accuracy, `Dockerfile` call site, protobufjs chain, `fit-query` stdout, new launchers, `libconfig` dependency, libcli `commands` dispatch, `crit 6/7` verifiability). The panel's internal-vs-product classification flag is now resolved by the Gear-scope addition (flipped to product-aligned). Dismissed with rationale: long-init ordering / altitude (plan-level detail).

Approval is human-only; this PR does not carry an approval signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)