### PR TITLE
design(2230): native advisor consults for fit-harness sessions

### DIFF
--- a/specs/2230-libharness-advisor/design-a.md
+++ b/specs/2230-libharness-advisor/design-a.md
@@ -1,0 +1,137 @@
+# Design 2230-a — Native Advisor Consults for fit-harness Sessions
+
+Implements spec 2230. The advisor is the judge's mid-loop sibling: a solo,
+tool-restricted, one-shot `AgentRunner` session whose final text is the
+advice. The consult surface is one MCP tool closed over the caller's name, a
+consult function, and a shared budget object. Two components are genuinely
+new: the **transcript recorder** (the harness keeps no per-participant record
+today) and **run mode's advisor wiring** (run mode has no orchestration
+context, no in-process MCP server, and no lead loop — its construction is
+named explicitly below, not assumed).
+
+Surface and brain are separable: the `Advisor` tool is the surface; the
+one-shot session is the brain. Both are mode-agnostic; what differs per mode
+is only where they are constructed.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+  participant A as Agent (executor)
+  participant T as Advisor tool handler<br/>(closed over from, budget)
+  participant R as TranscriptRecorder
+  participant S as Advisor session<br/>(one-shot AgentRunner)
+  participant O as Trace output
+
+  A->>T: Advisor({question})
+  T->>T: budget check (code, not prompt)
+  alt budget exhausted
+    T-->>A: "limit reached — proceed with your best judgment"
+  else
+    T->>S: consult(question)
+    S->>R: render() → system prompt + prompts + transcript
+    S->>S: run(context + question) on advisor model
+    S->>O: every line re-emitted as source:"advisor"
+    S-->>T: final text (or timeout/error/abort)
+    T->>O: advisor_consult event {caller, question, model, durationMs, remaining}
+    T-->>A: advice text + remaining-budget footer
+  end
+```
+
+The consult is a blocking MCP tool call, so the caller pauses and resumes with
+advice in hand — the same interaction shape as Anthropic's server-side tool,
+without the bus's async Ask/Answer turn boundary. The advisor never appears on
+the message bus and holds no participants entry.
+
+## Components
+
+| Component | Where | Responsibility |
+| --- | --- | --- |
+| `TranscriptRecorder` | new `src/transcript-recorder.js` | Per-participant record, constructed only when an advisor model is configured. Seeded at wiring time with the caller's harness-composed system prompt (or its absence); fed from two taps on the caller's runner — every delivered (amended) prompt via the new `onPrompt` tap, which is how loop-mode agents receive their task as drained bus messages, and every SDK message via the existing `onLine` path. `render()` formats system prompt + prompts + messages into the advisor's context text. In-memory. The message tap arrives post-redaction; the seeded system prompt and prompt-tap text are raw, so the recorder redacts them itself via the injected redactor. |
+| `Advisor` + `createAdvisor` | new `src/advisor.js` | Judge-shaped factory, one per caller, closed over that caller's recorder: each `consult(question)` renders the record, runs one `AgentRunner` session on the advisor model with the `ADVISOR_SYSTEM_PROMPT` trailer via `composeSystemPrompt`, lines re-emitted into the parent trace as `source: "advisor"`, small turn budget (judge's default), read-only tools. Consult timeout: **5 minutes** — generous for a read-a-few-files-and-answer session, and the universal guard in modes with no stop path. Exposes the in-flight session's abort. Returns `{advice}` or `{unavailable, reason}`. |
+| `ADVISOR_SYSTEM_PROMPT` | `src/advisor.js` | Role trailer: consulted specialist, not a worker; response contract (assessment / recommendation / unsolicited findings, with a stated length ceiling); read-only inspection allowed; no follow-up questions; never modify anything. |
+| `AdvisorBudget` | `src/advisor.js` | `{maxUses, used}` object created once per session and shared by every caller's tool handler. |
+| `Advisor` tool | `src/orchestration-toolkit.js` | `advisorTool({from, consult, emit, budget})` with schema `{question: string}`. Checks the budget, invokes `consult`, emits the consult event, returns advice with a remaining-budget footer. No orchestration-context dependency. The per-role agent server factories gain an optional extra-tools parameter — SDK MCP servers take their tool list at construction, so the tool is passed at build time, not appended after. |
+| `advisor_consult` event | injected `emit` callback | `{type: "advisor_consult", caller, question, model, durationMs, remaining}` written as an orchestrator-source envelope line. |
+| Consult guidance | `src/advisor.js` constant | Advisor-usage section for agent system prompts, threaded through the prompt composer's amendment fragment (see Key Decisions for seam ownership). |
+| Runner prompt tap | `src/agent-runner.js` | `AgentRunner` gains an optional `onPrompt` callback invoked with the effective (amend-applied) prompt of each `run`/`resume`, so the recorder captures exactly what the caller received, without mode-specific code. |
+| CLI flags + docs | `src/commands/{run,supervise,facilitate,discuss}.js` | `--advisor-model` (no default — absent means off) and `--advisor-max-uses` (default 3 per spec), parsed in each mode's `parse*Options`; `--advisor-max-uses` without `--advisor-model` is a usage error. Both flags documented in each command's libcli option help; the agent-collaboration guide gains an advisor section (spec's Documentation row). |
+
+## Consult flow ownership
+
+**Loop modes (`supervise`, `facilitate`, `discuss`).** Each mode factory
+already constructs every agent participant's runner, composed system prompt,
+and orchestration MCP server in one place. When an advisor model is
+configured it additionally constructs, per agent: a recorder seeded with that
+agent's composed prompt, the runner's taps composed with the existing wiring
+(the `onLine` slot is single and already occupied by the mode's `emitLine`
+closure — the factory wraps it so one closure feeds both the trace and the
+recorder, the same composition treatment as the amendment seam), and the
+`Advisor` tool passed into that agent's orchestration-server factory, closed
+over the session's one budget object and the loop's orchestrator-event
+emitter. Leads get none of this (spec exclusion).
+
+**Run mode.** `run` builds its single runner inline with no orchestration
+machinery, so the command constructs the advisor wiring directly: the budget
+object, a dedicated in-process MCP server holding only the `Advisor` tool
+(alongside the existing optional external server entry), an emit callback that
+writes orchestrator-source envelope lines the way the command already writes
+agent-source lines, and the recorder. Prompt guidance: with `--agent-profile`,
+the guidance rides the profile composer's existing amendment parameter; with
+no profile, the command composes a preset-append prompt carrying the guidance
+as its only session-protocol fragment — the recorder is seeded with whichever
+the harness composed, and with nothing when the advisor is off and no profile
+is set (today's behavior, unchanged).
+
+In every mode the advisor session's cwd is the caller's cwd, so read-only
+inspection sees the caller's working directory. Abort: loop modes register
+the in-flight advisor session's abort with the loop's stop path, so a
+concluded or crashed session cancels a pending consult. Run mode has no stop
+path today (the command simply awaits the runner) — the 5-minute consult
+timeout is deliberately its only guard, rather than inventing signal handling
+for one tool.
+
+## Key decisions
+
+| Decision | Choice | Rejected alternative |
+| --- | --- | --- |
+| Advice channel | The advisor session's **final text** is the advice | A `Conclude`-style MCP verdict tool on the advisor session — adds a tool server and a schema for what is inherently prose; the judge needs a structured verdict, advice is text |
+| Consult statefulness | One fresh session per consult (stateless; matches the spec's whole-context-as-it-stands semantics) | Persistent per-caller advisor resumed with deltas — cheaper on long sessions but adds session state, delta bookkeeping, and stale-context risk; spec-excluded until cost data justifies it |
+| Context source | In-memory recorder fed from the runner's line and prompt taps | Re-read the trace output — output may be bare stdout (nothing to read back), and neither the composed system prompt nor a reliable per-participant ordering exists in the stream |
+| System-prompt capture | Recorder seeded at wiring time, where the composed prompt is in scope | Parse it from the SDK `system/init` event — that event carries model/tools, not the composed prompt text |
+| Prompt capture | `onPrompt` tap on the runner | Recorder takes the task at construction — loop-mode agents have no task at wiring time; their work arrives later as drained bus messages through `run`/`resume` |
+| Advisor tool policy | `Read`, `Glob`, `Grep` only | Judge's set (adds `Bash`) — `Bash` is execution, breaching contract item 3; Anthropic's advisor (no tools) — reproduces its documented cannot-read-files blind spot |
+| Budget home | Standalone shared budget object injected into every handler | A counter on the orchestration context — run mode has no context, and creating one there imports loop machinery a solo session doesn't have; prompt-level caps — the field evidence the spec cites |
+| Event emission | Injected `emit` callback into the tool factory | Emitting via the loop's orchestrator-event method directly — run mode has no loop; the callback keeps one tool implementation across all four modes |
+| Failure shape | Timeout + error + parent-abort all resolve to an in-band `{unavailable}` tool result; the advisor's abort is registered with the mode's stop path | Let the MCP handler reject or hang — a wedged consult would stall the caller's turn indefinitely and a rejection would surface as a tool crash, breaching fail-open |
+| Default advisor model | None — `--advisor-model` is explicit | Defaulting to the lead-tier constant — eval agents already run top-tier, so a silent default would pay double for nothing; the flag names the experiment |
+| Guidance placement | The prompt composer's existing amendment fragment, with the mode factory joining existing amendment + guidance | A second role trailer merged per mode — role trailers are static by design, and the amendment seam already exists for run-specific additions (though occupied: composition, not replacement) |
+
+## Interfaces
+
+- `createTranscriptRecorder({systemPrompt, redactor}) → {recordPrompt(text), recordMessage(line), render()}`
+- `createAdvisor({model, cwd, query, recorder, redactor, runtime, onLine, maxTurns?, timeoutMs?}) → {consult(question) → Promise<{advice} | {unavailable, reason}>, abort()}`
+- `createAdvisorBudget(maxUses) → {maxUses, used}`
+- `advisorTool({from, consult, emit, budget})` — passed into the agent
+  tool-server factories in loop modes (new optional extra-tools parameter);
+  sole tool of run mode's advisor server.
+- `AgentRunner`: new optional `onPrompt(text)` callback, invoked by `run` and
+  `resume`.
+- CLI: `fit-harness <mode> --advisor-model <id> --advisor-max-uses <n>`.
+- Trace: `advisor_consult` orchestrator event; advisor session lines under
+  `source: "advisor"` (its result event carries usage and cost, giving the
+  spec's cost-attribution criterion without new accounting code).
+
+## Verification surface
+
+All criteria run against the injected fake `query` seam: tool presence per
+flag and mode (including run mode's dedicated server); single advisor-model
+session per consult; forwarded context contains seeded system prompt +
+delivered prompts + full transcript + question regardless of caller input;
+statelessness across consults; shared budget exhaustion path with zero advisor
+sessions started; consult event + `source: "advisor"` lines in the envelope
+stream; timeout/error/abort resolving `{unavailable}` while the caller
+continues; guidance present iff enabled, composed alongside an existing
+amendment. No live LLM spend.
+
+— Staff Engineer 🛠️

--- a/specs/2230-libharness-advisor/spec.md
+++ b/specs/2230-libharness-advisor/spec.md
@@ -1,0 +1,180 @@
+# Spec 2230 — Native Advisor Consults for fit-harness Sessions
+
+An agent in a `fit-harness` session that hits a hard decision — an
+architectural fork, an unclear root cause, a trade-off it cannot rank — has no
+way to borrow stronger judgment mid-loop. Its choices today are to guess and
+keep building on the guess, or to burn the whole session on the most capable
+model tier. This spec adds a third option: an executor-triggered **advisor
+consult** — one bounded, read-only session on a stronger model that sees the
+caller's full context and returns a paragraph of advice, leaving the caller in
+control of the loop.
+
+Serves **Platform Builders** — the persona who hires Gear to *give humans and
+agents shared capabilities with tooling to prove changes improved outcomes*
+(see [JTBD.md](../../JTBD.md)). The advisor is exactly such a capability: a
+model-pairing primitive whose every use lands in the same trace evidence the
+harness already produces, so its value can be proven or refuted on our own
+workloads.
+
+**Classification: internal.** The change lands in `libraries/libharness` (the
+`fit-harness` CLI) — an internal tree serving a Platform Builder job.
+
+## Problem
+
+**The pattern is proven elsewhere but unmeasured here.** Anthropic's "advisor
+strategy" ([launch blog](https://claude.com/blog/the-advisor-strategy),
+2026-04-09) pairs a cheap executor holding the agent loop with a stronger
+advisor consulted only at hard decision points. Their published results:
+Sonnet + Opus advisor gained +2.7pp on SWE-bench Multilingual at −11.9% cost
+per task; Haiku + Opus advisor doubled BrowseComp accuracy at −85% of
+Sonnet-solo cost. The one independent controlled field test found (ren-ai.dev,
+2026) was **negative** — same codebase and prompts, more tokens, no quality
+gain. There is no internal incident evidence either way, and there cannot be:
+harness sessions have no advisor capability, so the harness cannot measure a
+pattern it cannot run. The pattern's value is workload-dependent, which is
+precisely the question fit-harness exists to answer.
+
+**The economics apply directly to our own benchmark.** The benchmark
+agent-under-test is pinned to a mid-tier model so pass@k stays comparable,
+while eval agents default to the top tier. A benchmark arm where the mid-tier
+executor can consult a top-tier advisor is the cheapest credible way to test
+whether model pairing beats either model solo on our tasks — but only after
+the consult capability exists.
+
+**Anthropic's server-side tool is not a fit.** The native `advisor_20260301`
+API tool
+([docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool))
+would deliver the pattern without new code, but:
+
+| Gap | Consequence for the harness |
+| --- | --- |
+| Public beta: beta header, shifting model-pairing matrix; available on the Claude API and Claude Platform on AWS only — not Bedrock, Vertex, or Foundry | Couples every harness run to a moving surface; consumers on other platforms excluded |
+| Advisor thinking is dropped; cost buried in `usage.iterations[]` | The harness's evidence chain breaks — consults would be the only agent activity invisible in NDJSON traces |
+| Budgets are per-request `max_uses`; no conversation-level cap exists, so session ceilings are prompt-level | Field data (readysolutions.ai, 159 logged consults) shows prompt-level caps are a cost hope, not a cost control |
+| Advisor sees only the transcript; cannot read files | A documented blind spot: advice about code it cannot open |
+
+**Advisor-shaped machinery mostly exists in libharness.** The judge runs a
+solo, tool-restricted, one-shot session over another agent's work and re-emits
+its lines into the parent trace under its own source tag. The orchestration
+toolkit builds per-caller tools whose handlers are closed over the caller's
+name and shared session state. Every session mode (`run`, `supervise`,
+`facilitate`, `discuss`) runs agents through the same runner with a composed
+system prompt. Two pieces are genuinely new: a code-enforced consult budget
+(the toolkit's shared counters generate message ids; none enforces a cap), and
+a per-participant transcript record — the harness writes session lines to the
+trace stream and keeps no in-memory record, so there is nothing today to
+forward to an advisor.
+
+## Goal
+
+Any agent in a `fit-harness` session can, when the operator enables it,
+consult a stronger model at its own judgment and get back bounded advice
+grounded in its full context — with the consult count enforced in code, every
+consult and its cost visible in the trace, and the advisor structurally unable
+to take over the work.
+
+## The advisor contract
+
+These properties define the capability independent of mechanism; each maps to
+a success criterion below.
+
+1. **Consulted, not commanding.** The advisor never holds the loop, never
+   modifies the working directory, and has no standing presence in the
+   session. Its output re-enters the caller's session only as advice text.
+2. **Whole context in, advice out.** The advisor sees the caller's full
+   context — the system prompt the harness composed, task, transcript so
+   far — assembled by the harness, not curated by the caller. The caller adds
+   a focused question; it cannot restrict what the advisor sees.
+3. **Read-only inspection, nothing else.** The advisor can open the files the
+   caller's transcript names — closing the server-side tool's documented
+   blind spot — but holds no write, execute, subagent, or orchestration
+   tools.
+4. **Bounded output.** A fixed response contract (assessment, recommendation,
+   unsolicited findings; short) so advice stays a paragraph, not a takeover.
+5. **Budgeted in code.** A session-level consult cap enforced in code, not in
+   the prompt. On exhaustion the caller is told to proceed with its best
+   judgment.
+6. **Evident.** Every consult is visible in the trace: who asked, what was
+   asked, the advice, and the advisor's own token usage and cost, attributed
+   to the advisor as a distinct source.
+7. **Operator-enabled, executor-triggered.** The operator turns the advisor
+   on per session; the caller's judgment decides when to consult, steered by
+   system-prompt guidance — no schedule, no forced calls.
+8. **Fail-open.** An advisor error, timeout, or abort returns an explicit
+   "proceed without advice" result to the caller; it never stalls or crashes
+   the caller's session.
+
+## Scope
+
+### In scope
+
+| Change | Detail |
+| --- | --- |
+| Advisor consult capability | An `Advisor` tool available to agent participants, taking a focused question and returning advice text. Offered only when the session is started with an advisor model; absent otherwise (default off). |
+| One-shot advisor sessions | Each consult runs a fresh, solo, tool-restricted session on the advisor model over the forwarded context. Stateless per consult — each call re-reads the caller's context as it stands. |
+| Per-participant transcript record | The harness keeps each participant's session record (composed system prompt, delivered prompts, messages so far) so consults forward the whole context. Contract item 2 is impossible without it. |
+| Consult budget | `--advisor-max-uses <n>` session-level cap, **default 3** (Anthropic's published evals all ran `max_uses: 3`), enforced in code and shared across all callers in the session; exhaustion returns a "proceed with your best judgment" result without spending advisor tokens. |
+| CLI surface | `--advisor-model <id>` and `--advisor-max-uses <n>` on `run`, `supervise`, `facilitate`, and `discuss`. Absent `--advisor-model` means no advisor tool is offered; `--advisor-max-uses` without `--advisor-model` is a usage error. |
+| Consult guidance | When the advisor is enabled, agent system prompts gain an advisor-usage section: when a consult pays off (early, before work builds on an unvalidated assumption), when it does not (routine reads, writes, searches), and the budget. Guidance steers the caller's judgment; it mandates nothing (contract 7). |
+| Trace evidence | Every consult emits an orchestrator event (caller, question, model, duration, remaining budget) and the advisor session's own lines land in the same trace attributed to the advisor as a distinct source — including its result event with token usage and cost. |
+| Failure isolation | Consult timeout (bound owned by the design), advisor session error, and session-level abort all resolve the tool call with an explicit no-advice result; an in-flight consult is aborted when the parent session stops. |
+| Documentation | The four commands' `--help` documents both flags; the fit-harness agent-collaboration guide gains an advisor section. |
+
+### Excluded
+
+- **Benchmark three-arm variant axis** (executor solo / executor + advisor /
+  advisor solo). The evidence loop that proves the pattern's value is its own
+  spec-sized change to the benchmark runner, result schema, and report; it
+  depends on this spec and is claimed as a follow-up spec once this one
+  lands.
+- **Trace analysis verbs.** New `fit-trace` facets or stats splits
+  (executor-vs-advisor token breakdowns) build on the evidence this spec
+  records; the raw evidence is in scope, the query surface is not.
+- **Persistent advisor sessions** (resume-with-delta per caller). An
+  optimization to adopt only if measured consult cost justifies it.
+- **Anthropic's server-side `advisor_20260301` tool** — rejected above; no
+  passthrough or hybrid mode.
+- **Advisor as a bus participant.** A consulted advisor is a tool call; a
+  participating advisor is just another agent, which facilitate mode already
+  supports via profiles.
+- **Advisor for lead roles.** Facilitator, supervisor, and discuss leads
+  coordinate rather than perform substantive work; only agent participants
+  get the tool. Revisit with benchmark data.
+- **Context curation knobs** (message/char budgets, tool-result filtering).
+  Whole-context forwarding is the contract; curation is a cost lever to
+  consider only with cost data.
+- **Domain-specific advisor profiles** (`--advisor-profile`). One built-in
+  advisor role first.
+
+## Success criteria
+
+Verifiable at merge time with the runner's injected-query test seam — no live
+LLM spend. Verification: `bun test` in `libraries/libharness`.
+
+| Criterion | Contract | Verification |
+| --- | --- | --- |
+| The advisor tool is offered iff `--advisor-model` is set. | 7 | A session without the flag exposes no `Advisor` tool and no advisor prompt section; with the flag, agent participants get both, in all four modes. |
+| A consult runs one fresh advisor-model session and returns its final text as advice. | 1 | With a fake query, `Advisor({question})` triggers exactly one session on the configured advisor model; the tool result is that session's final text. |
+| The advisor can inspect but not act. | 1, 3 | The advisor session's tools are exactly the read-only inspection set — no write, execute, subagent, or orchestration tools; it holds no bus presence and its output enters the caller's session only as the tool result. |
+| The forwarded context is whole and uncurated. | 2 | The advisor session's prompt contains the caller's system prompt as the harness composed it (when the harness composed one), the caller's delivered prompts, every prior message of the caller's session, and the question — regardless of what the caller passed. |
+| Consults are stateless. | 2 | A second consult from the same caller forwards the full transcript as it stands then, not a delta. |
+| The budget is enforced in code. | 5 | Consult `n+1` past the cap (flag value, or 3 unset) returns a "proceed with your best judgment" result and starts no advisor session; the counter is shared across all callers in the session. |
+| Every consult is evident in the trace. | 6 | Each consult emits an orchestrator consult event (caller, question, model, duration, remaining budget), and the advisor session's lines — including its result event with usage and cost — appear in the same trace under a distinct advisor source. |
+| Advice is bounded. | 4 | The advisor session is constructed with a single-digit turn budget, and its role prompt fixes the response contract (assessment / recommendation / unsolicited findings) with a stated length ceiling; a test asserts both. |
+| Failure is isolated. | 8 | A consult that times out, errors, or is aborted resolves with an explicit no-advice result and the caller's session continues; parent-session stop aborts an in-flight advisor session. |
+| Enabled prompts carry consult guidance. | 7 | With the advisor enabled, each agent's system prompt contains the advisor-usage section; without it, no advisor text appears. |
+
+**Outcome criterion (go-see)** — tracked after merge, not gating: the
+follow-up benchmark spec comparing executor-solo vs executor+advisor arms on a
+monorepo task family runs to verdict using only this spec's trace evidence
+(consult counts, positions, advisor cost split from executor cost).
+
+## Path to approval
+
+Approval is human-only: this spec advances when `wiki/STATUS.md` shows the
+`2230` row approved, written from a trusted human signal. This spec ships
+together with `design-a.md` under lockstep co-execution — one combined PR,
+one design-class approval subsuming both. On approval the pipeline proceeds
+to `kata-plan`.
+
+— Staff Engineer 🛠️


### PR DESCRIPTION
## Summary

Spec 2230 + design 2230-a under **lockstep co-execution** (one combined PR; no separate spec PR; `design approved` subsumes spec approval per the lockstep protocol).

**WHAT:** an executor-triggered **advisor consult** for `fit-harness` sessions — an `Advisor` tool agents can call at hard decision points, running one bounded, read-only session on a stronger model over the caller's full context and returning a paragraph of advice. Off by default; enabled via `--advisor-model` / `--advisor-max-uses` on all four modes.

**WHY:** Anthropic's advisor strategy shows executor/advisor pairing can beat solo runs at lower cost, but the only independent field test was negative — the value is workload-dependent, and the harness cannot measure a pattern it cannot run. Their server-side `advisor_20260301` tool is rejected: beta coupling, invisible advisor reasoning in traces, prompt-level budgets, and a cannot-read-files blind spot.

**WHICH/WHERE (design):** the judge's mid-loop sibling — one-shot `AgentRunner` session whose final text is the advice; a new per-participant `TranscriptRecorder` (the harness keeps no session record today); a shared `AdvisorBudget` object enforced in code; `advisor_consult` trace events plus `source: "advisor"` session lines. Run mode's wiring is named explicitly (it has no orchestration context or mode factory).

Grounded in a code-verified feasibility study of `libraries/libharness` (judge, runner, toolkit, loop, mode factories).

## Review

- Combined 9-reviewer batch (3× product + 3× technical on spec, 3× technical on design): all consensus blocker/high/medium findings addressed — citations added, budget-machinery claim corrected, defaults quantified (`--advisor-max-uses` 3), Bedrock/AWS wording fixed, contract 3/7 tightened, run-mode wiring and occupied `amend`/`onLine` seams named.
- Design re-panel (3× technical) after the substantial revision: no blockers/highs outstanding; consult timeout bound now stated (5 min), recorder redaction ownership stated, tool-server extra-tools parameter named.
- Dismissed (rationale in commit): singleton ask for internal incident evidence — none can exist before the capability does; the spec states this and the go-see criterion creates the evidence.

Follow-ups excluded by scope: benchmark three-arm variant axis (own spec once this lands), fit-trace advisor query verbs.

Approval is human-only — this PR carries no approval recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)