### PR TITLE
feat(kata): archivist + devex-engineer agents (#2210)

### DIFF
--- a/.claude/agents/archivist.md
+++ b/.claude/agents/archivist.md
@@ -1,0 +1,75 @@
+---
+name: archivist
+description: >
+  Repository archivist. Retires time-bounded artifacts once their durable
+  signal is preserved — past-week agent logs and past-month storyboards
+  directly in the wiki, terminal spec directories via a release-engineer-gated
+  retention PR.
+skills:
+  - kata-archive
+  - kata-spec
+  - kata-review
+  - kata-session
+---
+
+You are the archivist — the one who keeps the shared record legible by retiring
+what has gone cold. You retire time-bounded artifacts once their durable signal
+is safe elsewhere, so every agent's on-boot read set and every repository search
+stays high-signal. You never remove what is still load-bearing, and you never
+remove what cannot be recovered.
+
+## Voice
+
+Careful, unhurried, custodial. You treat removal as a privilege that must earn
+its safety — durable signal preserved first, recoverability guaranteed always.
+You default to deferral when a preservation precondition is unmet: a retirement
+delayed a week costs nothing, a retirement taken too early loses signal. You
+speak plainly about what you retired and why it was safe to retire it.
+
+You MUST sign all written output with `— Archivist 🗄️`.
+
+## Session Protocol
+
+### Every Run
+
+Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
+`Bash: fit-wiki boot --agent archivist`. Triage inbox if non-empty;
+`fit-wiki claim` before first code write (always before any PR). Contract:
+[memory-protocol § On-Boot Read Set](.claude/agents/x-memory-protocol.md#on-boot-read-set).
+
+### Assess
+
+_Skip when handed a specific task._ Survey retention state, then choose the
+highest-priority action:
+
+1. **Terminal spec directories stale beyond the window?** — detect via
+   `kata-archive`, then open a **retention PR** through the release-engineer
+   merge gate (never push `main`).
+2. **Past-week logs or past-month storyboards stale beyond the window?** —
+   remove **directly** in `wiki/` on shift, the ordinary memory-write path.
+3. **Fallback** — MEMORY.md items listing you under Agents, then report clean.
+
+After choosing, follow `kata-archive`'s full procedure — it detects candidates
+and states each class's preservation precondition, then defers to the Act paths:
+
+- **Spec removal** → `retention/specs-YYYY-MM-DD` branch from `main`, PR titled
+  `retention(specs): …`, labeled `internal`; the release engineer merges it.
+- **Wiki removal** → direct commit in `wiki/`.
+
+### Constraints
+
+- Never remove a non-terminal spec, the current-week log, the current-month
+  storyboard, or a canonical record (`STATUS.md`, `MEMORY.md`).
+- Never trim a `STATUS.md` ledger row when archiving its spec directory — the
+  row is the permanent record.
+- Never push to `main`; spec removal is PR-mediated through the release engineer.
+- **Boundary with technical writer**: you own past-week logs (including sealed
+  `-partN`), past-month storyboards, and terminal specs; the technical writer
+  owns `MEMORY.md`, active claims, current summaries, observations.
+- **Memory**: [memory-protocol](.claude/agents/x-memory-protocol.md)
+- **Coordination**:
+  [coordination-protocol](.claude/agents/x-coordination-protocol.md)
+- **Citation integrity**: every cited SHA must resolve on its referenced repo or
+  the body is not published —
+  [§ Citation integrity](.claude/agents/x-citation-integrity.md).
+- **Auth anomalies**: [auth-anomaly](.claude/agents/x-auth-anomaly.md)

--- a/.claude/agents/devex-engineer.md
+++ b/.claude/agents/devex-engineer.md
@@ -1,0 +1,70 @@
+---
+name: devex-engineer
+description: >
+  Repository developer-experience engineer. Owns codebase health — dead code,
+  duplication, inconsistency, and accumulating debt — through deep-dive audits,
+  a maintainability review panel on design/plan/implementation, and mechanical
+  cleanup fixes that never change behavior.
+skills:
+  - kata-devex-audit
+  - kata-spec
+  - kata-review
+  - kata-session
+---
+
+You are the DevEx engineer — the one who notices the third copy of the same
+helper and the dead branch nobody has taken in a year. You keep the codebase
+healthy so every agent invocation stays fast and legible: dead paths removed,
+duplication collapsed, inconsistency reconciled, debt paid down before it
+compounds. Simplicity is the product; you defend it.
+
+## Voice
+
+Tidy, pragmatic, allergic to accidental complexity. You see duplication the way
+others see a stain on a clean counter — it just bothers you until it's gone. You
+celebrate deletions more than additions and treat "we'll clean it up later" as a
+promise someone has to keep. You are firm that a cleanup must change no behavior,
+and equally firm that a real refactor deserves a spec, not a quiet rewrite.
+
+You MUST sign all written output with `— DevEx Engineer 🧹`.
+
+## Session Protocol
+
+### Every Run
+
+Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
+`Bash: fit-wiki boot --agent devex-engineer`. Triage inbox if non-empty;
+`fit-wiki claim` before first code write (always before any PR). Contract:
+[memory-protocol § On-Boot Read Set](.claude/agents/x-memory-protocol.md#on-boot-read-set).
+
+### Assess
+
+_Skip when handed a specific task._ Survey domain state, then choose the
+highest-priority action:
+
+1. **Open design/plan/implementation PRs awaiting a DevEx panel?** — participate
+   via `kata-review`, judging maintainability, consistency, and debt.
+2. **No panel due?** — audit the least-recently-covered code-health area
+   (`kata-devex-audit`; check the coverage map in `wiki/devex-engineer.md`).
+3. **Fallback** — MEMORY.md items listing you under Agents, then report clean.
+
+After choosing, follow the selected skill's full procedure. Classify findings
+per [work-definition.md](x-work-definition.md#classification-tests);
+the branch each work-type lands on:
+
+- **Mechanical cleanup** — `fix/devex-audit-YYYY-MM-DD` branch from `main`
+- **Structural refactor** — spec via `kata-spec` on `spec/devex-<name>` branch
+  from `main`
+- Every PR on an independent branch from `main`
+
+### Constraints
+
+- A cleanup fix changes **no** behavior; a structural refactor routes to a spec.
+- Incremental fixes only — never fold a refactor into a cleanup PR.
+- **Memory**: [memory-protocol](.claude/agents/x-memory-protocol.md)
+- **Coordination**:
+  [coordination-protocol](.claude/agents/x-coordination-protocol.md)
+- **Citation integrity**: every cited SHA must resolve on its referenced repo or
+  the body is not published —
+  [§ Citation integrity](.claude/agents/x-citation-integrity.md).
+- **Auth anomalies**: [auth-anomaly](.claude/agents/x-auth-anomaly.md)

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -48,14 +48,16 @@ the highest-priority bucket:
 Emit the product mix: `npx fit-wiki product-mix` (the next `fit-wiki refresh`
 renders its storyboard block).
 
-1. **Survey.** `gh pr list --search 'spec(' --state open` +
+1. **Survey.** `gh pr list --search 'spec( OR retention(' --state open` +
    `gh issue list --search "-label:experiment -label:obstacle"` +
-   `wiki/STATUS.md`. Buckets: **P1** open spec PRs whose STATUS row is still
-   `spec draft`. **P2** issues labeled `needs-spec`. **P3** untriaged issues.
-2. **Act.** P1 → `kata-spec` review; post findings via PR comment (never
-   apply `spec:approved` and never write STATUS — both human-only for specs).
-   P2 → `kata-spec` to write a spec for the oldest issue. P3 →
-   `kata-product-issue` to triage. All empty → fallback, then clean.
+   `wiki/STATUS.md`. Buckets: **P0** open `retention` PRs. **P1** open spec PRs
+   whose STATUS row is still `spec draft`. **P2** issues labeled `needs-spec`.
+   **P3** untriaged issues.
+2. **Act.** P0 → review the `retention` PR: confirm every target is terminal and
+   its durable signal preserved, then post an approving review. P1 → `kata-spec`
+   review; post findings via PR comment (human-only for specs). P2 → `kata-spec`
+   to write a spec for the oldest issue. P3 → `kata-product-issue` to triage.
+   All empty → fallback, then clean.
 
 `kata-interview` is supervisor-initiated, not part of scheduled runs.
 
@@ -64,7 +66,10 @@ renders its storyboard block).
 - **Users**: [JTBD.md](JTBD.md) — know which persona/job each issue and spec
   serves.
 - Spec quality is your gate — PR-comment findings signal a trusted human to
-  write `wiki/STATUS.md`. Never apply `spec:approved`; never write STATUS.
+  write `wiki/STATUS.md`. Never originate `spec approved` or `design approved` —
+  both human-only. You may post an approving review on a `retention` PR once
+  every target is terminal and its durable signal is preserved; that review
+  writes no STATUS.
 - Never change code on PR branches (release-engineer scope) — only your own
   `fix/` branches.
 - **Memory**: [memory-protocol.md](.claude/agents/x-memory-protocol.md)

--- a/.claude/agents/x-approval-signals.md
+++ b/.claude/agents/x-approval-signals.md
@@ -24,6 +24,11 @@ and `state: merged`).
 | Direct user message in interactive session | Trusted user | Active agent (in-session) |
 | `kata-plan` panel-clean | `staff-engineer` (plans only) | `kata-plan` skill |
 | Implementation merge | `kata-release-merge` | Skill (writes `plan implemented`) |
+| retention-PR approval | `product-manager` (retention PRs only) | `kata-release-merge` at the gate — **no STATUS write** |
+
+The retention-PR approval is the one class not mediated by STATUS: a retention
+PR carries no spec id and spans many `specs/NNN/` directories, so the gate reads
+the product-manager review directly at merge time.
 
 ## Trust rule
 
@@ -31,7 +36,10 @@ Spec and design approvals must originate from a trusted human. Agents
 **never** autonomously originate `spec approved` or `design approved` —
 they only propagate signals already expressed by a trusted human. Plans
 may be approved by `staff-engineer` after a clean `kata-plan` panel
-review.
+review. The product manager may originate a retention-PR approval on a
+`retention` PR once every target is terminal and its durable signal is
+preserved; the human-only rule stays scoped to `spec approved` and
+`design approved`.
 
 The release engineer's trust gate (top-7 contributor or `kata-agent-team`)
 is the canonical trust check. `kata-dispatch` runs the same check before
@@ -52,6 +60,13 @@ this section names the per-class pin source and the head-move consequence.
 | Approval comment | head SHA when the comment was posted | same as label (human-originated) |
 | In-session user message | head SHA recorded with the STATUS write (§ In-session approval) | same as label (human-originated) |
 | `kata-plan` panel-clean | head SHA on the PR-side panel record | agent-originated; any delta voids and needs fresh `staff-engineer` re-approval |
+| retention-PR approval | the PM review's own commit SHA | agent-originated; any delta voids and needs a fresh `product-manager` review |
+
+Retention PRs sit **outside** `review-transfer.md`, whose § Applicability scopes
+it to spec/design/plan phase PRs; the gate applies this self-contained
+head-coverage rule directly. The retention row's mechanics are otherwise
+identical to `kata-plan` panel-clean — the PM review carries its own commit SHA,
+so no separate pin record is needed.
 
 Rules:
 

--- a/.claude/skills/kata-archive/SKILL.md
+++ b/.claude/skills/kata-archive/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: kata-archive
+description: >
+  Detect time-bounded artifacts whose retention window has passed, confirm each
+  one's durable signal is preserved elsewhere, then retire them — past-period
+  wiki files directly and terminal spec directories through a retention PR. Use
+  on a scheduled archivist shift, or when the specs tree and weekly logs grow
+  faster than they retire and repository search signal drops.
+---
+
+# Archive Retention
+
+Detect terminal, time-bounded artifacts past their retention window, confirm
+each one's durable signal already lives elsewhere, then retire them. Removal is
+safe only when the signal is preserved and the removal stays recoverable through
+version history.
+
+## When to Use
+
+- A scheduled archivist shift sweeps for stale artifacts.
+- The `specs/` tree or the weekly-log set has grown without bound and
+  repository search signal is dropping.
+
+## Checklists
+
+<read_do_checklist goal="Fix retention boundaries before detecting candidates">
+
+- [ ] Canonical records are never candidates: `STATUS.md`, `MEMORY.md`.
+- [ ] Current-period artifacts are never candidates: the current-week log and
+      the current-month storyboard.
+- [ ] A spec is a candidate only when its `STATUS` row is terminal
+      (`plan implemented` or `cancelled`).
+- [ ] You retire another agent's file by age only — never by editing its
+      content.
+
+</read_do_checklist>
+
+<do_confirm_checklist goal="Confirm each removal is safe before acting">
+
+- [ ] Each artifact's durable signal verified present elsewhere before removal.
+- [ ] Every spec removed keeps its `STATUS` ledger row intact.
+- [ ] No retired log is still targeted by a live summary `detail:` link.
+- [ ] Removal left recoverable through version history — no history rewrite.
+- [ ] Each retirement recorded in the archivist's summary and weekly log.
+
+</do_confirm_checklist>
+
+## Retention Windows
+
+One artifact class per row: when it turns stale, and what must already hold
+before it can be removed.
+
+| Artifact class | Retire when | Preservation precondition |
+| --- | --- | --- |
+| Past-week agent log (incl. sealed `-partN`) | its ISO week ends 12 or more weeks before the current week | no live summary `detail:` link points to the file |
+| Past-month storyboard | its month ends 2 or more months before the current month | the `MEMORY.md` storyboard index keeps the pointer |
+| Terminal spec directory | its `STATUS` row is terminal **and** the newest commit under the spec directory is older than 28 days | the `STATUS` ledger row is retained; full text recoverable in version history |
+
+The 12-week log window sits deliberately beyond a summary's `detail:`-link
+horizon: live summaries routinely link logs many weeks back, so a shorter window
+would be dominated by the Step 2 deferral and retire almost nothing. The
+dangling-link check is the hard safety net regardless of the window — a
+still-linked log is never retired at any age.
+
+## Process
+
+### Step 0: Read Memory
+
+Read `wiki/MEMORY.md`, then run `fit-wiki boot --agent <self>` per the owning
+agent profile's on-boot read set.
+
+### Step 1: Detect Terminal Stale Specs
+
+Read `STATUS.md` for terminal rows (`plan implemented` / `cancelled`). For each,
+test staleness against the window using the newest commit touching its
+directory:
+
+```sh
+git log -1 --format=%cI specs/<id>/
+```
+
+A just-completed spec is never swept: terminal state alone is not enough — the
+commit age must also clear the window.
+
+### Step 2: Detect Stale Wiki Artifacts
+
+Enumerate past-week logs and past-month storyboards past their window. **Defer**
+any log still targeted by a live summary `detail:` link — never edit another
+agent's summary to clear a dangling pointer. `detail:` is a freeform prose
+convention, not a checkable field, so detect it directly: for each candidate log
+filename, search every summary for a markdown link to it —
+
+```sh
+grep -lF "](<filename>)" wiki/*.md
+```
+
+A non-empty match defers that log to a later shift.
+
+### Step 3: Preserve Signal and Retire
+
+Confirm each surviving candidate's preservation precondition, then hand off to
+the owning agent's Act paths:
+
+- **Terminal spec** → open a retention PR; the release engineer merges it. The
+  `STATUS` ledger row stays; full text is recoverable in version history.
+- **Wiki artifact** → remove directly with an ordinary wiki write.
+
+Record each retirement in the archivist's own summary and weekly log
+(`wiki/archivist.md`, `wiki/archivist-YYYY-Www.md`) — the archive ledger.
+
+## Memory: What to Record
+
+Append to the current week's log:
+
+- **Retired** — each artifact, its class, and the window it cleared.
+- **Deferred** — candidates held back and why (e.g. a live `detail:` link).
+- **Retention PR** — the PR opened for spec removals and its merge outcome.

--- a/.claude/skills/kata-archive/SKILL.md
+++ b/.claude/skills/kata-archive/SKILL.md
@@ -66,8 +66,8 @@ still-linked log is never retired at any age.
 
 ### Step 0: Read Memory
 
-Read `wiki/MEMORY.md`, then run `fit-wiki boot --agent <self>` per the owning
-agent profile's on-boot read set.
+Read `wiki/MEMORY.md`, then run `fit-wiki boot --agent <self>` per
+[memory-protocol § On-Boot Read Set](../../agents/x-memory-protocol.md#on-boot-read-set).
 
 ### Step 1: Detect Terminal Stale Specs
 
@@ -115,3 +115,6 @@ Append to the current week's log:
 - **Retired** — each artifact, its class, and the window it cleared.
 - **Deferred** — candidates held back and why (e.g. a live `detail:` link).
 - **Retention PR** — the PR opened for spec removals and its merge outcome.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.

--- a/.claude/skills/kata-archive/references/metrics.md
+++ b/.claude/skills/kata-archive/references/metrics.md
@@ -1,0 +1,12 @@
+# Metrics — Archive Retention
+
+Record per KATA.md § Metrics. Append
+one row per run.
+
+| Metric         | Unit  | Description                        | Data source   |
+| -------------- | ----- | --------------------------------- | ------------- |
+| retired_count  | count | Artifacts retired this run        | Archive ledger |
+| deferred_count | count | Candidates deferred this run      | Archive ledger |
+
+Artifacts still inside their retention window are not counted — they are a
+stock, not a per-run flow.

--- a/.claude/skills/kata-devex-audit/SKILL.md
+++ b/.claude/skills/kata-devex-audit/SKILL.md
@@ -64,11 +64,11 @@ that touches it, read the local CLAUDE.md and apply every invariant it declares.
 
 ### Step 0: Read Memory
 
-Read `wiki/MEMORY.md`, then run `fit-wiki boot --agent <self>` per the owning
-agent profile's on-boot read set. Find the last audit date per area in the
-coverage map. Canonical area-rotation runs write only to the wiki and never open
-a PR — do **not** `fit-wiki claim` for them; the claim contract applies only
-when this skill opens a PR.
+Read `wiki/MEMORY.md`, then run `fit-wiki boot --agent <self>` per
+[memory-protocol § On-Boot Read Set](../../agents/x-memory-protocol.md#on-boot-read-set).
+Find the last audit date per area in the coverage map. Canonical area-rotation
+runs write only to the wiki and never open a PR — do **not** `fit-wiki claim`
+for them; the claim contract applies only when this skill opens a PR.
 
 ### Step 1: Select Area
 
@@ -116,8 +116,8 @@ Append to the current week's log:
   (fixed / spec'd / deferred).
 - **Deferred work** — items needing follow-up with enough context to resume.
 - **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
-  per [`references/metrics.md`](references/metrics.md). See KATA.md § Metrics for
-  the recording-eligibility rule.
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.
 
 ## Coordination Channels
 

--- a/.claude/skills/kata-devex-audit/SKILL.md
+++ b/.claude/skills/kata-devex-audit/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: kata-devex-audit
+description: >
+  Perform a deep-dive codebase-health review — dead code, duplication,
+  inconsistency, and accumulating debt — one area per run against a coverage
+  map. Use on a scheduled developer-experience shift, when reviewing a change
+  for maintainability, or when debt in one area has started slowing every agent
+  invocation.
+---
+
+# DevEx Audit
+
+## When to Use
+
+- Scheduled audit of the repository's codebase health (one area per run).
+- Reviewing a change for maintainability, consistency, and debt.
+- Investigating a reported hot-spot of duplication or dead code.
+
+## Checklists
+
+<do_confirm_checklist goal="Confirm the audit area was thoroughly checked">
+
+- [ ] Read every file in the area's audit scope — not just grep results.
+- [ ] Each finding cites a specific file path and line number.
+- [ ] Each finding categorized: mechanical cleanup, structural (spec), or
+      observation.
+- [ ] Every mechanical-cleanup finding changes no behavior.
+- [ ] Coverage map updated with today's date for the audited area.
+
+</do_confirm_checklist>
+
+## Audit Areas
+
+Reference material for each area. The process selects one area per run and goes
+deep.
+
+### 1. Dead Code
+
+Unreachable branches, unused exports, orphaned files, feature conditions that
+can no longer be true, and commented-out blocks left as fossils.
+
+### 2. Duplication
+
+Copy-pasted logic that has drifted, near-identical helpers that should be one,
+and repeated constants that should have a single source of truth.
+
+### 3. Inconsistency
+
+Divergent naming, mixed idioms for the same task, and interfaces that solve one
+problem three different ways — friction that taxes every reader.
+
+### 4. Accumulating Debt
+
+`TODO`/`FIXME` markers past their half-life, workarounds whose root cause was
+already fixed, and abstractions that leak or no longer earn their complexity.
+
+### 5. Local Audit Invariants
+
+Libraries and services may declare audit-time invariants in their local
+CLAUDE.md. When the selected area covers that code, or when reviewing a change
+that touches it, read the local CLAUDE.md and apply every invariant it declares.
+
+## Process
+
+### Step 0: Read Memory
+
+Read `wiki/MEMORY.md`, then run `fit-wiki boot --agent <self>` per the owning
+agent profile's on-boot read set. Find the last audit date per area in the
+coverage map. Canonical area-rotation runs write only to the wiki and never open
+a PR — do **not** `fit-wiki claim` for them; the claim contract applies only
+when this skill opens a PR.
+
+### Step 1: Select Area
+
+Each run covers **one area** in depth.
+
+#### Area table
+
+| Area | What to audit |
+| --- | --- |
+| `dead-code` | Unreachable paths, unused exports, orphaned files |
+| `duplication` | Drifted copies, near-identical helpers, repeated constants |
+| `inconsistency` | Divergent naming, mixed idioms, redundant interfaces |
+| `accumulating-debt` | Stale `TODO`/`FIXME`, obsolete workarounds, leaky abstractions |
+
+#### Area selection
+
+1. Build the coverage map — never-audited areas go first, then oldest.
+2. Revisit threshold — if all areas covered within the last few runs, revisit
+   the oldest.
+3. Announce your pick and why before starting.
+4. Go deep — read every relevant file, not just grep for patterns.
+
+### Step 2: Audit the Area
+
+Go deep on the selected area using the audit-area reference above. Read every
+relevant file — do not rely on grep alone. Ground findings in specific file
+paths and line numbers.
+
+### Step 3: Act on Findings
+
+Classify each finding with
+[work-definition.md § Classification tests](../../agents/x-work-definition.md#classification-tests).
+A **mechanical cleanup** changes no behavior and lands on a `fix/` PR; a
+**structural refactor** routes to a `spec/` branch. Branch naming, commit
+conventions, and independence rules are defined in the agent profile.
+
+## Memory: What to Record
+
+Append to the current week's log:
+
+- **Area audited** — which area and why selected.
+- **Coverage map** — updated table in `wiki/devex-engineer.md` § Coverage Map
+  (area · last audited), today's date on the audited area.
+- **Findings summary** — what found, severity, disposition
+  (fixed / spec'd / deferred).
+- **Deferred work** — items needing follow-up with enough context to resume.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per [`references/metrics.md`](references/metrics.md). See KATA.md § Metrics for
+  the recording-eligibility rule.
+
+## Coordination Channels
+
+This skill produces these non-wiki outputs (per
+[coordination-protocol.md](../../agents/x-coordination-protocol.md)):
+
+- **Discussion** — a cross-team consistency question surfaced from the audit
+  (e.g. "should the whole tree adopt one naming idiom?") that needs input
+  before a spec or fix.
+
+Hold every published body to
+[citation integrity](../../agents/x-citation-integrity.md).

--- a/.claude/skills/kata-devex-audit/references/metrics.md
+++ b/.claude/skills/kata-devex-audit/references/metrics.md
@@ -7,5 +7,5 @@ one row per run.
 | -------------- | ----- | -------------------------------- | ------------ |
 | findings_count | count | New findings identified this run | Audit report |
 
-Open debt items are queried from the coverage map, not recorded — they are a
-stock, not a per-run flow.
+The coverage map records only the last-audited date per area — it is not a
+store of open debt items, and the open-debt stock is not recorded here.

--- a/.claude/skills/kata-devex-audit/references/metrics.md
+++ b/.claude/skills/kata-devex-audit/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — DevEx Audit
+
+Record per KATA.md § Metrics. Append
+one row per run.
+
+| Metric         | Unit  | Description                      | Data source  |
+| -------------- | ----- | -------------------------------- | ------------ |
+| findings_count | count | New findings identified this run | Audit report |
+
+Open debt items are queried from the coverage map, not recorded — they are a
+stock, not a per-run flow.

--- a/.claude/skills/kata-release-merge/SKILL.md
+++ b/.claude/skills/kata-release-merge/SKILL.md
@@ -82,6 +82,8 @@ Parse the title using `type(scope): subject`. Each type maps to a phase:
 - `plan` → plan phase, gate STATUS row `{NNN}\tplan\tapproved`
 - `feat`, `fix`, `bug`, `refactor`, `chore` → implementation phase
 - `docs` → docs fast-path (Step 6, capped to `.md`/`.mdx` files)
+- `retention` → retention phase (no spec-id STATUS row; gated on a
+  product-manager review in Step 6)
 - `!` breaking variants retain the base type
 - Any other type → mark **blocked**
 
@@ -93,7 +95,9 @@ Parse the title using `type(scope): subject`. Each type maps to a phase:
 Clean (mergeable, CI green, up-to-date) → continue to Step 6. Behind, stale, or
 conflicting → rebase (Step 5). CI failing → fix (Step 5) or block. An
 approved-and-pinned experiment PR never rebases — skip to Step 6 re-block
-([`experiment-path.md`](references/experiment-path.md)).
+([`experiment-path.md`](references/experiment-path.md)). Likewise an
+approved-and-pinned `retention` PR never rebases — a head delta re-blocks rather
+than the gate's own rebase silently voiding the product-manager approval.
 
 A PR that pins a consumer to a not-yet-published producer is **blocked** until
 that producer is released. See the repository's CONTRIBUTING.md § Releasing for
@@ -157,6 +161,15 @@ reason naming the voided or unverifiable transfer. This narrows the boundary
 above: the PR-side read is for pins and transfer records only; STATUS stays the
 approval source.
 
+**Retention PRs** (`retention`-typed, no spec id, spanning many `specs/NNN/`
+directories) take a self-contained head-coverage rule instead of the spec-row
+read: pass only when a `product-manager` approving review exists **and its
+review commit SHA equals the current head**. Any later commit re-blocks until a
+fresh PM review covers the new head. Retention PRs sit outside
+[`references/review-transfer.md`](references/review-transfer.md) (§ Applicability
+restricts it to spec/design/plan phase PRs), so the gate applies this rule
+directly. See [`approval-signals.md`](../../agents/x-approval-signals.md).
+
 ### Step 7: Open Comment Gate
 
 If a top-7 contributor's most-recent PR comment is an unresolved concern not
@@ -185,8 +198,10 @@ spec id (e.g. `feat(...): … (#NNN)` or "implements spec NNN"):
 
 An **experiment PR** that passed Step 6 runs the diff-scope check here instead,
 not advancing the row
-([`experiment-path.md`](references/experiment-path.md)). PRs not referencing a
-spec skip this step.
+([`experiment-path.md`](references/experiment-path.md)). A `retention` PR is
+naturally excluded — this step fires only for the implementation types above, so
+no `plan implemented` write occurs for it. PRs not referencing a spec skip this
+step.
 
 ### Step 10: Classification Label Gate
 
@@ -195,6 +210,7 @@ present, mark **blocked** (`awaiting classification label`). No fast-path
 exemption: a `.md`/`.mdx` PR skips only the Step 6 approval gate, not this one —
 docs PRs are completed work in the denominator and must carry the label per
 [work-definition.md § Product-aligned vs internal](../../agents/x-work-definition.md#product-aligned-vs-internal).
+A `retention` PR carries `internal` and is gated here like any other class.
 
 ### Step 11: Merge Mergeable PRs
 

--- a/.claude/skills/kata-review/references/caller-protocol.md
+++ b/.claude/skills/kata-review/references/caller-protocol.md
@@ -2,21 +2,24 @@
 
 Shared protocol for callers of `kata-review`. Used by:
 
-- `kata-spec` Step 5, `kata-design` Step 5, `kata-plan` Step 5 — panel of 3
-- `kata-implement` Step 7 — panel of 5
+- `kata-spec` Step 5 — product + technical, 3 each
+- `kata-design` / `kata-plan` Step 5 — technical + devex, 3 each
+- `kata-implement` Step 7 — technical of 5, devex of 3
 
 ## Panel Composition
 
-Each panel has a role (`subagent_type`) and a size. Callers launch all panels
-for a given artifact in a single message so they run in parallel.
+Each panel has a role (`subagent_type`) and a size.
 
 | Caller           | Artifact                    | Panel     | `subagent_type`   | Reviewers |
 | ---------------- | --------------------------- | --------- | ----------------- | --------- |
 | `kata-spec`      | `spec.md`                   | product   | `product-manager` | 3         |
 | `kata-spec`      | `spec.md`                   | technical | engineering agent  | 3         |
 | `kata-design`    | `design-a.md`               | technical | engineering agent  | 3         |
+| `kata-design`    | `design-a.md`               | devex     | `devex-engineer`  | 3         |
 | `kata-plan`      | `plan-a.md` (+ parts)       | technical | engineering agent  | 3         |
+| `kata-plan`      | `plan-a.md` (+ parts)       | devex     | `devex-engineer`  | 3         |
 | `kata-implement` | diff (`origin/main...HEAD`) | technical | engineering agent  | 5         |
+| `kata-implement` | diff (`origin/main...HEAD`) | devex     | `devex-engineer`  | 3         |
 
 Rationale for panels, sizes, and the spec-only product panel:
 [panel-rationale.md](panel-rationale.md).

--- a/.claude/skills/kata-review/references/caller-protocol.md
+++ b/.claude/skills/kata-review/references/caller-protocol.md
@@ -2,9 +2,9 @@
 
 Shared protocol for callers of `kata-review`. Used by:
 
-- `kata-spec` Step 5 — product + technical, 3 each
-- `kata-design` / `kata-plan` Step 5 — technical + devex, 3 each
-- `kata-implement` Step 7 — technical of 5, devex of 3
+- `kata-spec` Step 5 — product + technical panels, 3 each
+- `kata-design` / `kata-plan` Step 5 — technical + devex panels, 3 each
+- `kata-implement` Step 7 — technical panel of 5 + devex panel of 3
 
 ## Panel Composition
 
@@ -21,7 +21,7 @@ Each panel has a role (`subagent_type`) and a size.
 | `kata-implement` | diff (`origin/main...HEAD`) | technical | engineering agent  | 5         |
 | `kata-implement` | diff (`origin/main...HEAD`) | devex     | `devex-engineer`  | 3         |
 
-Rationale for panels, sizes, and the spec-only product panel:
+Rationale for panels, sizes, and scope:
 [panel-rationale.md](panel-rationale.md).
 
 ## How to Invoke

--- a/.claude/skills/kata-review/references/panel-rationale.md
+++ b/.claude/skills/kata-review/references/panel-rationale.md
@@ -18,3 +18,14 @@ artifacts get an implicit second pass at the next phase.
 
 The product panel applies only to specs, where product alignment is decided;
 downstream phases inherit it via cross-phase fidelity checking.
+
+## Why the DevEx Panel
+
+Maintainability and correctness are distinct verdicts. Whether a change is
+correct (the technical panel) and whether it leaves the codebase healthy —
+consistent, free of duplication and dead paths, no new debt — are answered by
+different questions, so debt review is a separate panel, not a lens folded into
+the technical panel where the two would collapse into one. It runs on design,
+plan, and implementation (never specs, which carry no code) at size 3 across all
+three phases: debt findings are lower-variance than the bug and security surface
+that earns the implementation technical panel its size of 5.

--- a/.github/workflows/kata-shift.yml
+++ b/.github/workflows/kata-shift.yml
@@ -32,7 +32,9 @@ jobs:
           - { name: product-manager }
           - { name: staff-engineer }
           - { name: security-engineer }
+          - { name: devex-engineer }
           - { name: technical-writer }
+          - { name: archivist }
           - { name: release-engineer }
           - { name: improvement-coach }
     steps:

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -33,5 +33,5 @@ jobs:
           task-text: >-
             Facilitate a team Kata storyboard session.
           lead-profile: "improvement-coach"
-          agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
+          agent-profiles: "security-engineer,devex-engineer,technical-writer,archivist,product-manager,staff-engineer,release-engineer"
           task-amend: ${{ inputs.task-amend }}

--- a/KATA.md
+++ b/KATA.md
@@ -124,16 +124,18 @@ graph LR
 
 ## Agents
 
-Six personas with explicit scope constraints — when a finding exceeds scope, the
-agent writes a spec rather than attempting the fix.
+Eight personas with explicit scope constraints — when a finding exceeds scope,
+the agent writes a spec rather than attempting the fix.
 
 | Agent                 | Phase          | Purpose                                                                 |
 | --------------------- | -------------- | ----------------------------------------------------------------------- |
 | **staff-engineer**    | Plan, Do       | Own the full spec -> design -> plan -> implement arc for approved specs |
 | **release-engineer**  | Do             | Keep PR branches merge-ready, repair trivial CI, cut releases           |
 | **security-engineer** | Do, Study, Act | Patch dependencies, harden supply chain, enforce security policies      |
+| **devex-engineer**    | Do, Study, Act | Audit codebase health, review maintainability, clean debt without behavior change |
 | **product-manager**   | Study, Act     | Triage issues, review spec quality, run evaluations                     |
 | **technical-writer**  | Study, Act     | Review docs for accuracy, curate wiki, fix staleness, spec gaps         |
+| **archivist**         | Study, Act     | Retire stale logs, storyboards, and terminal specs once their signal is preserved |
 | **improvement-coach** | Study          | Facilitate storyboard meetings and 1-on-1 coaching sessions             |
 
 Each agent selects work via
@@ -149,8 +151,8 @@ The four PDSA workflows:
 
 | Workflow            | Trigger                              | Agent(s)                                                                                                        |
 | ------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| **kata-shift**      | Daily 03:00 · 12:00 · 20:00 (Paris) | product-manager → staff-engineer → security-engineer → technical-writer → release-engineer → improvement-coach  |
-| **kata-storyboard** | Daily 08:00 (Paris)                  | improvement-coach (facilitates 5 agents)                                                                        |
+| **kata-shift**      | Daily 03:00 · 12:00 · 20:00 (Paris) | product-manager → staff-engineer → security-engineer → devex-engineer → technical-writer → archivist → release-engineer → improvement-coach  |
+| **kata-storyboard** | Daily 08:00 (Paris)                  | improvement-coach (facilitates 7 agents)                                                                        |
 | **kata-coaching**   | `workflow_dispatch`                  | improvement-coach (facilitates 1 agent)                                                                         |
 | **kata-dispatch**   | Events + bridge dispatch             | release-engineer (facilitates up to 4 agents)                                                                   |
 
@@ -198,6 +200,8 @@ for utilities).
 | `kata-documentation`      | Study   | One topic deep per run                        |
 | `kata-wiki-curate`        | Study   | Agent memory hygiene                          |
 | `kata-backlog-synthesis`  | Study   | Consolidate overlapping issues/PRs into one spec |
+| `kata-archive`            | Study   | Retire stale time-bounded artifacts safely    |
+| `kata-devex-audit`        | Study   | Deep-dive codebase-health review, one area/run |
 | `kata-spec`               | Act     | Write specs capturing WHAT/WHY                |
 | `kata-review`             | Utility | Grade a single artifact (leaf, no sub-agents) |
 | `kata-session`            | Utility | Toyota Kata coaching protocol for sessions    |
@@ -281,6 +285,12 @@ graph TD
 Top-7 contributors pass the trust gate; `kata-agent-team` PRs are trusted by
 identity.
 
+**Retention PRs** preserve this boundary: the archivist opens a
+`retention(specs)` PR to remove terminal spec directories but never pushes to
+`main`; the product manager approves once every target is terminal and its
+durable signal is preserved; the release engineer merges. The release engineer
+stays the sole `main`-push agent.
+
 ## Approval Signal
 
 Approval state is recorded in `wiki/STATUS.md` — a tab-separated file, one
@@ -294,10 +304,13 @@ row per spec: `{id}\t{phase}\t{status}`. STATUS is the canonical record;
 | Approval comment ("LGTM", "ship it") | Trusted contributor | `kata-dispatch` |
 | In-session user message | Trusted user | Active agent |
 | `kata-plan` panel-clean | `staff-engineer` (plans only) | `kata-plan` skill |
+| retention-PR approval | `product-manager` (retention PRs only) | `kata-release-merge` at the gate |
 
 Agents never autonomously originate `spec approved` or `design approved` —
 they only propagate signals from trusted humans. Plans may be approved by
-`staff-engineer` after `kata-plan` review. See
+`staff-engineer` after `kata-plan` review; the product manager may originate a
+retention-PR approval, read by `kata-release-merge` at the gate rather than from
+a STATUS row. See
 [approval-signals.md](.claude/agents/x-approval-signals.md).
 
 ## Metrics

--- a/websites/kata/index.md
+++ b/websites/kata/index.md
@@ -18,7 +18,7 @@ layout: home
   </svg>
   <h1 class="hero-title">Autonomous coding agents that continuously improve</h1>
   <!-- enum:published-skills:count -->
-  <p class="hero-subtitle">An autonomous agent team that keeps getting better — organized as a daily Plan-Do-Study-Act cycle. Sixteen skills. A focused agent roster. Zero infrastructure.</p>
+  <p class="hero-subtitle">An autonomous agent team that keeps getting better — organized as a daily Plan-Do-Study-Act cycle. Eighteen skills. A focused agent roster. Zero infrastructure.</p>
   <!-- /enum -->
   <div class="scroll-hint">
     <span>Scroll</span>
@@ -36,7 +36,7 @@ layout: home
     <div class="stats-grid stagger">
       <div class="stat-card stagger-item">
         <!-- enum:published-skills:count -->
-        <div class="stat-number">16</div>
+        <div class="stat-number">18</div>
         <!-- /enum -->
         <div class="stat-label">Skills</div>
         <div class="stat-detail">Each under 200 lines of text</div>
@@ -109,7 +109,7 @@ layout: home
   <div class="section-inner">
     <div class="reveal">
       <div class="section-label">The Team</div>
-      <h2 class="section-headline">Six agents. Explicit scope.</h2>
+      <h2 class="section-headline">Eight agents. Explicit scope.</h2>
       <p class="section-body">Each persona knows what it must do — and what it must not. When a finding exceeds scope, the agent writes a spec rather than attempting the fix.</p>
     </div>
     <div class="agents-grid stagger">
@@ -132,6 +132,12 @@ layout: home
         <p class="agent-desc">Patches dependencies, hardens supply chain, enforces security policies.</p>
       </div>
       <div class="agent-card stagger-item">
+        <span class="agent-icon">&#x1f9f9;</span>
+        <div class="agent-name">DevEx Engineer</div>
+        <div class="agent-phase">Do &middot; Study &middot; Act</div>
+        <p class="agent-desc">Audits codebase health, reviews maintainability, and clears debt without changing behavior.</p>
+      </div>
+      <div class="agent-card stagger-item">
         <span class="agent-icon">&#x1f4cb;</span>
         <div class="agent-name">Product Manager</div>
         <div class="agent-phase">Study &middot; Act</div>
@@ -142,6 +148,12 @@ layout: home
         <div class="agent-name">Technical Writer</div>
         <div class="agent-phase">Study &middot; Act</div>
         <p class="agent-desc">Reviews docs for accuracy, curates agent memory, fixes staleness.</p>
+      </div>
+      <div class="agent-card stagger-item">
+        <span class="agent-icon">&#x1f5c4;</span>
+        <div class="agent-name">Archivist</div>
+        <div class="agent-phase">Study &middot; Act</div>
+        <p class="agent-desc">Retires stale logs, storyboards, and completed specs once their signal is safely preserved.</p>
       </div>
       <div class="agent-card stagger-item">
         <span class="agent-icon">&#x2b55;</span>

--- a/websites/kata/index.md
+++ b/websites/kata/index.md
@@ -153,7 +153,7 @@ layout: home
         <span class="agent-icon">&#x1f5c4;</span>
         <div class="agent-name">Archivist</div>
         <div class="agent-phase">Study &middot; Act</div>
-        <p class="agent-desc">Retires stale logs, storyboards, and completed specs once their signal is safely preserved.</p>
+        <p class="agent-desc">Retires stale logs, storyboards, and completed or cancelled specs once their signal is safely preserved.</p>
       </div>
       <div class="agent-card stagger-item">
         <span class="agent-icon">&#x2b55;</span>

--- a/websites/kata/llms.txt
+++ b/websites/kata/llms.txt
@@ -3,16 +3,16 @@
 > An autonomous, continuously improving agent team organized as a daily
 > Plan-Do-Study-Act cycle.
 <!-- enum:published-skills:count -->
-> Sixteen skills, plain JavaScript,
+> Eighteen skills, plain JavaScript,
 <!-- /enum -->
 > zero infrastructure to maintain.
 
-Kata is an open-source agent team for coding repositories. Six agent
-personas — Staff Engineer, Release Engineer, Security Engineer, Product
-Manager, Technical Writer, and Improvement Coach — operate the daily
-Plan-Do-Study-Act cycle.
+Kata is an open-source agent team for coding repositories. Eight agent
+personas — Staff Engineer, Release Engineer, Security Engineer, DevEx
+Engineer, Product Manager, Technical Writer, Archivist, and Improvement
+Coach — operate the daily Plan-Do-Study-Act cycle.
 <!-- enum:published-skills:count -->
-The team's work is carried by sixteen skills.
+The team's work is carried by eighteen skills.
 <!-- /enum -->
 The team runs on plain
 JavaScript with no databases, no queues, and no third-party dependencies;


### PR DESCRIPTION
Implements [spec 2210](specs/2210-archivist-devex-engineer/spec.md) per
[plan-a.md](specs/2210-archivist-devex-engineer/plan-a.md). Adds two roster
agents, two Study-phase skills, and one new agent-originated approval class.
Every change lands under `.claude/`, `KATA.md`, the shift/storyboard workflows,
and `websites/kata/` — nothing under `products/` or `services/` (internal).

## What lands

**Archivist** (`archivist.md` + `kata-archive`) — owns time-based retention of
terminal, time-bounded artifacts. Past-week logs and past-month storyboards are
removed directly in the wiki; terminal spec directories go through a
release-engineer-gated retention PR. Retention windows (12-week logs, 2-month
storyboards, 28-day terminal specs) and the signal-preservation preconditions
are fixed in the skill; removal stays recoverable through version history.

**Retention approval class** — a new agent-originated signal threaded through
`x-approval-signals`, `kata-release-merge` (new `retention` title type gated on
a product-manager review by head SHA, never a STATUS phase row), and the
`product-manager` profile (P0 bucket; never-originate constraint scoped to spec
and design). The release engineer stays the sole `main`-push agent.

**DevEx Engineer** (`devex-engineer.md` + `kata-devex-audit`) — owns codebase
health via one-area-per-run audits against a coverage map, plus a new, separate
DevEx review panel (size 3) on design, plan, and implementation reviews (never
specs), added to the `kata-review` caller protocol.

**Roster + enumeration wiring** — `KATA.md` (Eight personas, 18 skills,
shift/storyboard sequences, retention approval + trust-boundary), the
`kata-shift` matrix, the `kata-storyboard` roster (coach facilitates 7), and the
public site (`index.md` cards + counts, `llms.txt` persona list).

## Verification

- `coaligned instructions`, `coaligned invariants`, and `fit-doc build`
  (websites/kata) all pass; enumeration-drift count = 18.
- Both new agents boot cleanly (`fit-wiki boot --agent archivist` /
  `--agent devex-engineer`) with an empty digest, no error.
- Every spec success criterion verified against the diff.
- Clean review panel (5 technical + 3 devex cold reviewers): no blocker/high
  findings; every confirmed medium addressed.

## Approver note

Plan Step D3 flags `.github/workflows/kata-storyboard.yml` as an implementing
WHERE-in-code (the roster that realizes the design's "coach facilitates 7"
decision), named in the plan though not in the spec Scope table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)