### PR TITLE
feat(libharness): native advisor consults for fit-harness sessions (#2230)

### DIFF
--- a/libraries/libharness/bin/fit-harness.js
+++ b/libraries/libharness/bin/fit-harness.js
@@ -27,6 +27,20 @@ const LEAD_OPTIONS = {
   },
 };
 
+// Advisor consult flags, shared by all four session modes.
+const ADVISOR_OPTIONS = {
+  "advisor-model": {
+    type: "string",
+    description:
+      "Claude model for advisor consults; omitting the flag disables the Advisor tool (default: off)",
+  },
+  "advisor-max-uses": {
+    type: "string",
+    description:
+      "Session-wide consult budget shared by all participants (default: 3; requires --advisor-model)",
+  },
+};
+
 // Shared task-input flags: --task-file (path), --task-text (inline), and
 // --task-event (path to native GitHub event JSON composed into a task via
 // libharness/src/events/github.js). Exactly one of the three is required.
@@ -94,6 +108,7 @@ const definition = {
           description:
             "Connect to the MCP service (e.g. --mcp-server=guide); adds mcp__<name>__* to allowed tools",
         },
+        ...ADVISOR_OPTIONS,
       },
     },
     {
@@ -143,6 +158,7 @@ const definition = {
           description:
             "Connect to the MCP service (e.g. --mcp-server=guide); adds mcp__<name>__* to allowed tools",
         },
+        ...ADVISOR_OPTIONS,
       },
     },
     {
@@ -185,6 +201,7 @@ const definition = {
           description:
             "Active work-item tracker (github|filesystem, default: github)",
         },
+        ...ADVISOR_OPTIONS,
       },
     },
     {
@@ -231,6 +248,7 @@ const definition = {
           description:
             "Active work-item tracker (github|filesystem, default: github)",
         },
+        ...ADVISOR_OPTIONS,
       },
     },
     {

--- a/libraries/libharness/src/advisor.js
+++ b/libraries/libharness/src/advisor.js
@@ -80,15 +80,22 @@ const ADVISOR_ALLOWED_TOOLS = ["Read", "Glob", "Grep"];
 
 // Under the harness's always-on bypassPermissions, `allowedTools` alone is
 // not structural — `disallowedTools` is what removes tools from the model's
-// context, the same treatment the lead runners get.
+// context, the same treatment the lead runners get. The advisor's contract
+// is stricter than the leads' (read-only inspection, nothing else), so the
+// list also removes the write-capable and non-inspection built-ins the
+// lead convention leaves in.
 const ADVISOR_DISALLOWED_TOOLS = [
   "Bash",
   "Write",
   "Edit",
+  "NotebookEdit",
   "Agent",
   "Task",
   "TaskOutput",
   "TaskStop",
+  "TodoWrite",
+  "WebFetch",
+  "WebSearch",
 ];
 
 const devNull = new Writable({

--- a/libraries/libharness/src/advisor.js
+++ b/libraries/libharness/src/advisor.js
@@ -1,0 +1,198 @@
+/**
+ * Advisor — the judge's mid-loop sibling: a solo, tool-restricted, one-shot
+ * `AgentRunner` session on a stronger model whose final text is the advice.
+ * Each consult forwards the caller's whole recorded context (system prompt,
+ * delivered prompts, transcript so far) plus a focused question; the advisor
+ * can inspect files read-only but holds no write, execute, subagent, or
+ * orchestration tools and never appears on the message bus.
+ *
+ * Consults are stateless — one fresh session per call, re-reading the
+ * caller's context as it stands — and fail-open: timeout, error, and abort
+ * all resolve to an in-band `{unavailable}` result so the caller's session
+ * never stalls or crashes on a consult.
+ *
+ * Follows OO+DI: factory function, tests inject a fake `query`.
+ */
+
+import { Writable } from "node:stream";
+
+import { createAgentRunner } from "./agent-runner.js";
+import { composeSystemPrompt } from "./profile-prompt.js";
+
+/**
+ * System-prompt trailer for the advisor session. Fixes the response
+ * contract (spec criterion "Advice is bounded"): assessment,
+ * recommendation, unsolicited findings, with a stated length ceiling.
+ */
+export const ADVISOR_SYSTEM_PROMPT =
+  "You are a consulted specialist, not a worker. " +
+  "Another agent paused its work to ask you one question; its full session context and the question are in the task. " +
+  "You may Read, Glob, and Grep the files the transcript names to ground your advice; never modify anything. " +
+  "Respond in one turn of prose — your final text is delivered to the caller verbatim. " +
+  "Structure the response as: assessment (what you see), recommendation (what to do and why), and unsolicited findings (anything important the caller did not ask about). " +
+  "Keep the whole response to at most three short paragraphs. " +
+  "Do not ask follow-up questions — the caller cannot reply.";
+
+/**
+ * Consult-guidance fragment for caller system prompts, present only when
+ * the session runs with an advisor model. Steers the caller's judgment; it
+ * mandates nothing.
+ * @param {number} maxUses - The session-wide consult budget.
+ * @returns {string}
+ */
+export function advisorGuidance(maxUses) {
+  return (
+    "An `Advisor` tool is available: one focused question per call, answered by a stronger model that sees your full session context. " +
+    "A consult pays off at hard decision points — architectural forks, unclear root causes, trade-offs you cannot rank — and early, before work builds on an unvalidated assumption. " +
+    "It does not pay off for routine reads, writes, or searches. " +
+    `The session-wide budget is ${maxUses} consult${maxUses === 1 ? "" : "s"}, shared across all participants. ` +
+    "Consulting is your judgment, never mandatory."
+  );
+}
+
+/**
+ * Create the session-wide consult budget, shared by every caller's tool
+ * handler. Enforced in code by the tool handler, not in the prompt.
+ * @param {number} maxUses
+ * @returns {{maxUses: number, used: number}}
+ */
+export function createAdvisorBudget(maxUses) {
+  return { maxUses, used: 0 };
+}
+
+/** Consult timeout — generous for a read-a-few-files-and-answer session, and the universal guard in modes with no stop path. */
+export const DEFAULT_CONSULT_TIMEOUT_MS = 300_000;
+
+const ADVISOR_ALLOWED_TOOLS = ["Read", "Glob", "Grep"];
+
+// Under the harness's always-on bypassPermissions, `allowedTools` alone is
+// not structural — `disallowedTools` is what removes tools from the model's
+// context, the same treatment the lead runners get.
+const ADVISOR_DISALLOWED_TOOLS = [
+  "Bash",
+  "Write",
+  "Edit",
+  "Agent",
+  "Task",
+  "TaskOutput",
+  "TaskStop",
+];
+
+const devNull = new Writable({
+  write(_chunk, _enc, cb) {
+    cb();
+  },
+});
+
+/**
+ * Create a per-caller advisor closed over that caller's transcript
+ * recorder.
+ *
+ * @param {object} deps
+ * @param {string} deps.model - Advisor model id.
+ * @param {string} deps.cwd - The caller's working directory, so read-only inspection sees the caller's files.
+ * @param {function} deps.query - SDK query function (injected for testing).
+ * @param {{render: () => string}} deps.recorder - The caller's transcript recorder.
+ * @param {import("./redaction.js").Redactor} deps.redactor
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} deps.runtime - Clock surface for timeout and duration.
+ * @param {function} deps.onLine - Re-emitter for the advisor session's NDJSON lines (tagged `source: "advisor"` by the caller).
+ * @param {number} [deps.maxTurns] - Default 5 — single-digit per the spec criterion.
+ * @param {number} [deps.timeoutMs] - Default `DEFAULT_CONSULT_TIMEOUT_MS`.
+ * @returns {{consult: (question: string) => Promise<{advice?: string, unavailable?: boolean, reason?: string, durationMs: number}>, abort: () => void}}
+ */
+export function createAdvisor({
+  model,
+  cwd,
+  query,
+  recorder,
+  redactor,
+  runtime,
+  onLine,
+  maxTurns,
+  timeoutMs,
+}) {
+  if (!model) throw new Error("model is required");
+  if (!cwd) throw new Error("cwd is required");
+  if (!query) throw new Error("query is required");
+  if (!recorder) throw new Error("recorder is required");
+  if (!redactor) throw new Error("redactor is required");
+  if (!runtime) throw new Error("runtime is required");
+  if (!onLine) throw new Error("onLine is required");
+  const resolvedMaxTurns = maxTurns ?? 5;
+  const resolvedTimeoutMs = timeoutMs ?? DEFAULT_CONSULT_TIMEOUT_MS;
+
+  /** @type {import("./agent-runner.js").AgentRunner|null} */
+  let currentRunner = null;
+
+  return {
+    /**
+     * Run one fresh advisor session over the caller's context as it
+     * stands plus the question. Never rejects — every failure shape
+     * resolves to `{unavailable, reason}` (fail-open).
+     * @param {string} question
+     */
+    async consult(question) {
+      const started = runtime.clock.now();
+      const runner = createAgentRunner({
+        cwd,
+        query,
+        output: devNull,
+        model,
+        maxTurns: resolvedMaxTurns,
+        allowedTools: ADVISOR_ALLOWED_TOOLS,
+        disallowedTools: ADVISOR_DISALLOWED_TOOLS,
+        onLine,
+        settingSources: ["project"],
+        systemPrompt: composeSystemPrompt({
+          role: "agent",
+          trailer: ADVISOR_SYSTEM_PROMPT,
+          runtime,
+        }),
+        redactor,
+      });
+      currentRunner = runner;
+      const task = `${recorder.render()}\n\n<consult_question>\n${question}\n</consult_question>`;
+      const timer = runtime.clock.setTimeout(
+        () => runner.currentAbortController?.abort(),
+        resolvedTimeoutMs,
+      );
+      try {
+        const result = await runner.run(task);
+        const durationMs = runtime.clock.now() - started;
+        if (result.aborted) {
+          return {
+            unavailable: true,
+            reason: "timed out or aborted",
+            durationMs,
+          };
+        }
+        if (!result.success) {
+          return {
+            unavailable: true,
+            reason: result.error?.message ?? "advisor session failed",
+            durationMs,
+          };
+        }
+        return { advice: result.text, durationMs };
+      } catch (err) {
+        return {
+          unavailable: true,
+          reason: err?.message ?? "advisor session failed",
+          durationMs: runtime.clock.now() - started,
+        };
+      } finally {
+        runtime.clock.clearTimeout(timer);
+        currentRunner = null;
+      }
+    },
+
+    /**
+     * Abort the in-flight consult, if any. A consult is a blocking tool
+     * call, so one caller cannot overlap its own consults; advisors are
+     * per-caller, so at most one runner is ever tracked.
+     */
+    abort() {
+      currentRunner?.currentAbortController?.abort();
+    },
+  };
+}

--- a/libraries/libharness/src/advisor.js
+++ b/libraries/libharness/src/advisor.js
@@ -60,6 +60,19 @@ export function createAdvisorBudget(maxUses) {
   return { maxUses, used: 0 };
 }
 
+/**
+ * Fold the consult guidance into an existing run-specific amendment when
+ * the advisor is enabled (budget present); return the amendment unchanged
+ * otherwise, so advisor-off prompts stay byte-identical.
+ * @param {string|undefined} amend - The existing amendment, if any.
+ * @param {{maxUses: number}|null} budget
+ * @returns {string|undefined}
+ */
+export function withAdvisorGuidance(amend, budget) {
+  if (!budget) return amend;
+  return [amend, advisorGuidance(budget.maxUses)].filter(Boolean).join("\n\n");
+}
+
 /** Consult timeout — generous for a read-a-few-files-and-answer session, and the universal guard in modes with no stop path. */
 export const DEFAULT_CONSULT_TIMEOUT_MS = 300_000;
 

--- a/libraries/libharness/src/agent-runner.js
+++ b/libraries/libharness/src/agent-runner.js
@@ -53,6 +53,7 @@ export class AgentRunner {
    * @param {number} [deps.maxTurns] - Maximum agentic turns; 0 means unlimited
    * @param {string[]} [deps.allowedTools] - Tools the agent may use
    * @param {function} [deps.onLine] - Callback invoked with each NDJSON line as it's produced
+   * @param {function} [deps.onPrompt] - Callback invoked with the effective (amend-applied) prompt of each run/resume
    * @param {string[]} [deps.settingSources] - SDK setting sources (e.g. ['project'] to load CLAUDE.md)
    * @param {string|object} [deps.systemPrompt] - SDK system prompt (string replaces default; {type:'preset', preset:'claude_code', append} appends)
    * @param {string[]} [deps.disallowedTools] - Tools to explicitly remove from the model's context
@@ -80,6 +81,7 @@ export class AgentRunner {
     this.maxTurns = deps.maxTurns ?? 50;
     this.allowedTools = deps.allowedTools ?? DEFAULT_ALLOWED_TOOLS;
     this.onLine = deps.onLine ?? null;
+    this.onPrompt = deps.onPrompt ?? null;
     this.settingSources = deps.settingSources ?? [];
     this.systemPrompt = deps.systemPrompt ?? null;
     this.disallowedTools = deps.disallowedTools ?? [];
@@ -106,6 +108,7 @@ export class AgentRunner {
         ? `${task}\n\n${this.taskAmend}`
         : this.taskAmend
       : task;
+    if (this.onPrompt) this.onPrompt(effectiveTask);
     try {
       const iterator = this.query({
         prompt: effectiveTask,
@@ -125,6 +128,7 @@ export class AgentRunner {
   async resume(prompt) {
     const abortController = new AbortController();
     this.currentAbortController = abortController;
+    if (this.onPrompt) this.onPrompt(prompt);
     try {
       const iterator = this.query({
         prompt,

--- a/libraries/libharness/src/agent-runner.js
+++ b/libraries/libharness/src/agent-runner.js
@@ -81,7 +81,9 @@ export class AgentRunner {
     this.maxTurns = deps.maxTurns ?? 50;
     this.allowedTools = deps.allowedTools ?? DEFAULT_ALLOWED_TOOLS;
     this.onLine = deps.onLine ?? null;
-    this.onPrompt = deps.onPrompt ?? null;
+    // Optional; read only through a truthy guard in run()/resume(), so an
+    // absent value stays undefined rather than needing a `?? null` default.
+    this.onPrompt = deps.onPrompt;
     this.settingSources = deps.settingSources ?? [];
     this.systemPrompt = deps.systemPrompt ?? null;
     this.disallowedTools = deps.disallowedTools ?? [];

--- a/libraries/libharness/src/commands/advisor-flags.js
+++ b/libraries/libharness/src/commands/advisor-flags.js
@@ -1,0 +1,21 @@
+/**
+ * Shared advisor-flag parsing for the four session-mode commands. The two
+ * flags are identical everywhere: `--advisor-model` (no default — absent
+ * means the Advisor tool is not offered) and `--advisor-max-uses`
+ * (default 3), which is a usage error without the model flag.
+ */
+
+/**
+ * Parse `--advisor-model` / `--advisor-max-uses` from parsed option values.
+ * @param {object} values - Parsed option values from cli.parse()
+ * @returns {{advisorModel: string|undefined, advisorMaxUses: number}}
+ */
+export function parseAdvisorOptions(values) {
+  if (values["advisor-max-uses"] && !values["advisor-model"]) {
+    throw new Error("--advisor-max-uses requires --advisor-model");
+  }
+  return {
+    advisorModel: values["advisor-model"] || undefined,
+    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
+  };
+}

--- a/libraries/libharness/src/commands/advisor-flags.js
+++ b/libraries/libharness/src/commands/advisor-flags.js
@@ -7,6 +7,9 @@
 
 /**
  * Parse `--advisor-model` / `--advisor-max-uses` from parsed option values.
+ * A malformed max-uses is a usage error, not a silent fallback: NaN would
+ * make the budget check (`used >= maxUses`) permanently false and disable
+ * the code-enforced cap the flag exists to guarantee.
  * @param {object} values - Parsed option values from cli.parse()
  * @returns {{advisorModel: string|undefined, advisorMaxUses: number}}
  */
@@ -14,8 +17,12 @@ export function parseAdvisorOptions(values) {
   if (values["advisor-max-uses"] && !values["advisor-model"]) {
     throw new Error("--advisor-max-uses requires --advisor-model");
   }
+  const advisorMaxUses = parseInt(values["advisor-max-uses"] || "3", 10);
+  if (Number.isNaN(advisorMaxUses) || advisorMaxUses < 1) {
+    throw new Error("--advisor-max-uses must be a positive integer");
+  }
   return {
     advisorModel: values["advisor-model"] || undefined,
-    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
+    advisorMaxUses,
   };
 }

--- a/libraries/libharness/src/commands/discuss.js
+++ b/libraries/libharness/src/commands/discuss.js
@@ -3,6 +3,7 @@ import { isoTimestamp } from "@forwardimpact/libutil";
 import { createDiscusser } from "../discusser.js";
 import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
+import { parseAdvisorOptions } from "./advisor-flags.js";
 import { resolveTaskContent } from "./task-input.js";
 import { resolveWorkTracker } from "./work-tracker.js";
 import { AGENT_MODEL, LEAD_MODEL } from "@forwardimpact/libutil/models";
@@ -51,10 +52,6 @@ export function parseDiscussOptions(values, runtime) {
   const maxLeadTurnsRaw = values["max-lead-turns"] || "200";
   const maxLeadTurns = parseInt(maxLeadTurnsRaw, 10);
 
-  if (values["advisor-max-uses"] && !values["advisor-model"]) {
-    throw new Error("--advisor-max-uses requires --advisor-model");
-  }
-
   return {
     taskContent,
     taskAmend,
@@ -71,8 +68,7 @@ export function parseDiscussOptions(values, runtime) {
     callbackUrl: runtime.proc.env.CALLBACK_URL ?? null,
     inboxUrl: runtime.proc.env.INBOX_URL ?? null,
     correlationId: runtime.proc.env.CORRELATION_ID ?? null,
-    advisorModel: values["advisor-model"] || undefined,
-    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
+    ...parseAdvisorOptions(values),
   };
 }
 

--- a/libraries/libharness/src/commands/discuss.js
+++ b/libraries/libharness/src/commands/discuss.js
@@ -51,6 +51,10 @@ export function parseDiscussOptions(values, runtime) {
   const maxLeadTurnsRaw = values["max-lead-turns"] || "200";
   const maxLeadTurns = parseInt(maxLeadTurnsRaw, 10);
 
+  if (values["advisor-max-uses"] && !values["advisor-model"]) {
+    throw new Error("--advisor-max-uses requires --advisor-model");
+  }
+
   return {
     taskContent,
     taskAmend,
@@ -67,6 +71,8 @@ export function parseDiscussOptions(values, runtime) {
     callbackUrl: runtime.proc.env.CALLBACK_URL ?? null,
     inboxUrl: runtime.proc.env.INBOX_URL ?? null,
     correlationId: runtime.proc.env.CORRELATION_ID ?? null,
+    advisorModel: values["advisor-model"] || undefined,
+    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
   };
 }
 
@@ -121,6 +127,8 @@ export async function runDiscussCommand(ctx) {
     inboxUrl: opts.inboxUrl,
     correlationId: opts.correlationId,
     runtime,
+    advisorModel: opts.advisorModel,
+    advisorMaxUses: opts.advisorMaxUses,
   });
 
   const result = await discusser.run(opts.taskContent);

--- a/libraries/libharness/src/commands/facilitate.js
+++ b/libraries/libharness/src/commands/facilitate.js
@@ -3,6 +3,7 @@ import { isoTimestamp } from "@forwardimpact/libutil";
 import { createFacilitator } from "../facilitator.js";
 import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
+import { parseAdvisorOptions } from "./advisor-flags.js";
 import { resolveTaskContent } from "./task-input.js";
 import { resolveWorkTracker } from "./work-tracker.js";
 import { AGENT_MODEL, LEAD_MODEL } from "@forwardimpact/libutil/models";
@@ -36,9 +37,6 @@ export function parseFacilitateOptions(values, runtime) {
 
   const profilesRaw = values["agent-profiles"];
   if (!profilesRaw) throw new Error("--agent-profiles is required");
-  if (values["advisor-max-uses"] && !values["advisor-model"]) {
-    throw new Error("--advisor-max-uses requires --advisor-model");
-  }
   // `||` (not `??`) so an empty-string flag from a CI forwarder falls back to
   // the default rather than overriding it with "".
   const agentCwd = resolve(values["agent-cwd"] || ".");
@@ -63,8 +61,7 @@ export function parseFacilitateOptions(values, runtime) {
     outputPath: values.output,
     facilitatorProfile: values["lead-profile"] || undefined,
     workTracker: resolveWorkTracker(values, runtime?.proc?.env),
-    advisorModel: values["advisor-model"] || undefined,
-    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
+    ...parseAdvisorOptions(values),
   };
 }
 

--- a/libraries/libharness/src/commands/facilitate.js
+++ b/libraries/libharness/src/commands/facilitate.js
@@ -36,6 +36,9 @@ export function parseFacilitateOptions(values, runtime) {
 
   const profilesRaw = values["agent-profiles"];
   if (!profilesRaw) throw new Error("--agent-profiles is required");
+  if (values["advisor-max-uses"] && !values["advisor-model"]) {
+    throw new Error("--advisor-max-uses requires --advisor-model");
+  }
   // `||` (not `??`) so an empty-string flag from a CI forwarder falls back to
   // the default rather than overriding it with "".
   const agentCwd = resolve(values["agent-cwd"] || ".");
@@ -60,6 +63,8 @@ export function parseFacilitateOptions(values, runtime) {
     outputPath: values.output,
     facilitatorProfile: values["lead-profile"] || undefined,
     workTracker: resolveWorkTracker(values, runtime?.proc?.env),
+    advisorModel: values["advisor-model"] || undefined,
+    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
   };
 }
 
@@ -112,6 +117,8 @@ export async function runFacilitateCommand(ctx) {
     taskAmend: opts.taskAmend,
     redactor,
     runtime,
+    advisorModel: opts.advisorModel,
+    advisorMaxUses: opts.advisorMaxUses,
   });
 
   const result = await facilitator.run(opts.taskContent);

--- a/libraries/libharness/src/commands/run.js
+++ b/libraries/libharness/src/commands/run.js
@@ -27,7 +27,7 @@ import { AGENT_MODEL } from "@forwardimpact/libutil/models";
  * Parse and validate run command options from parsed values.
  * @param {object} values - Parsed option values from cli.parse()
  * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
- * @returns {{ taskContent: string, cwd: string, model: string, maxTurns: number, outputPath: string|undefined, agentProfile: string|undefined, workTracker: string, allowedTools: string[], advisorModel: string|undefined, advisorMaxUses: number }}
+ * @returns {{ taskContent: string, taskAmend: string|undefined, cwd: string, agentModel: string, maxTurns: number, outputPath: string|undefined, agentProfile: string|undefined, workTracker: string, allowedTools: string[], mcpServer: string|undefined, advisorModel: string|undefined, advisorMaxUses: number }}
  */
 export function parseRunOptions(values, runtime) {
   const { task: taskContent, amend: taskAmend } = resolveTaskContent(

--- a/libraries/libharness/src/commands/run.js
+++ b/libraries/libharness/src/commands/run.js
@@ -1,10 +1,21 @@
 import { Writable } from "node:stream";
 import { resolve } from "node:path";
 import { isoTimestamp } from "@forwardimpact/libutil";
+import { createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
 import { createAgentRunner } from "../agent-runner.js";
-import { composeProfilePrompt } from "../profile-prompt.js";
+import {
+  advisorGuidance,
+  createAdvisor,
+  createAdvisorBudget,
+} from "../advisor.js";
+import { advisorTool } from "../orchestration-toolkit.js";
+import {
+  composeProfilePrompt,
+  composeSystemPrompt,
+} from "../profile-prompt.js";
 import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
+import { createTranscriptRecorder } from "../transcript-recorder.js";
 import { SequenceCounter } from "../sequence-counter.js";
 import { resolveWorkTracker } from "./work-tracker.js";
 import { resolveTaskContent } from "./task-input.js";
@@ -15,7 +26,7 @@ import { AGENT_MODEL } from "@forwardimpact/libutil/models";
  * Parse and validate run command options from parsed values.
  * @param {object} values - Parsed option values from cli.parse()
  * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
- * @returns {{ taskContent: string, cwd: string, model: string, maxTurns: number, outputPath: string|undefined, agentProfile: string|undefined, workTracker: string, allowedTools: string[] }}
+ * @returns {{ taskContent: string, cwd: string, model: string, maxTurns: number, outputPath: string|undefined, agentProfile: string|undefined, workTracker: string, allowedTools: string[], advisorModel: string|undefined, advisorMaxUses: number }}
  */
 export function parseRunOptions(values, runtime) {
   const { task: taskContent, amend: taskAmend } = resolveTaskContent(
@@ -25,6 +36,10 @@ export function parseRunOptions(values, runtime) {
   // `||` (not `??`) so an empty-string flag from a CI forwarder falls back to
   // the default, rather than overriding it with "".
   const maxTurnsRaw = values["max-turns"] || "50";
+
+  if (values["advisor-max-uses"] && !values["advisor-model"]) {
+    throw new Error("--advisor-max-uses requires --advisor-model");
+  }
 
   return {
     taskContent,
@@ -40,7 +55,147 @@ export function parseRunOptions(values, runtime) {
       "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"
     ).split(","),
     mcpServer: values["mcp-server"] || undefined,
+    advisorModel: values["advisor-model"] || undefined,
+    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
   };
+}
+
+const devNull = new Writable({
+  write(_chunk, _enc, cb) {
+    cb();
+  },
+});
+
+/**
+ * Wire the run-mode agent session: external MCP entry, `LIBHARNESS_*` env
+ * writes, system-prompt composition, and — when an advisor model is set —
+ * the advisor wiring (budget, recorder, advisor session, dedicated MCP
+ * server holding only the `Advisor` tool). Extracted from `runRunCommand`
+ * so tests can inject a fake `query`.
+ *
+ * Run mode has no stop path (the command simply awaits the runner), so the
+ * consult timeout is deliberately the advisor's only guard.
+ *
+ * @param {object} deps
+ * @param {ReturnType<typeof parseRunOptions>} deps.opts
+ * @param {import("../redaction.js").Redactor} deps.redactor
+ * @param {import("stream").Writable} deps.output - Envelope NDJSON sink.
+ * @param {SequenceCounter} deps.counter
+ * @param {function} deps.query - SDK query function.
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} deps.runtime
+ * @returns {Promise<{runner: import("../agent-runner.js").AgentRunner, advisor: object|null}>}
+ */
+export async function wireRunSession({
+  opts,
+  redactor,
+  output,
+  counter,
+  query,
+  runtime,
+}) {
+  const emitEnvelope = (source, event) => {
+    output.write(
+      JSON.stringify(
+        redactor.redactValue({ source, seq: counter.next(), event }),
+      ) + "\n",
+    );
+  };
+  const onLine = (line) => emitEnvelope("agent", JSON.parse(line));
+
+  let mcpServers = null;
+  const allowedTools = opts.allowedTools;
+  if (opts.mcpServer) {
+    const mcpConfig = await createServiceConfig("mcp");
+    mcpServers = {
+      [opts.mcpServer]: {
+        type: "http",
+        url: mcpConfig.url,
+        headers: { Authorization: `Bearer ${mcpConfig.mcpToken()}` },
+      },
+    };
+    allowedTools.push(`mcp__${opts.mcpServer}__*`);
+  }
+
+  if (opts.agentProfile) {
+    runtime.proc.env.LIBHARNESS_AGENT_PROFILE = opts.agentProfile;
+  }
+  // Unconditional so the default "github" is observable to the agent's
+  // active-tracker resolution, mirroring --agent-profile's env write above.
+  runtime.proc.env.LIBHARNESS_WORK_TRACKER = opts.workTracker;
+
+  // With a profile, the consult guidance rides the profile composer's
+  // amendment parameter; with no profile, a preset-append prompt carries
+  // the guidance as its only session-protocol fragment. Advisor off and no
+  // profile means no system prompt — today's behavior, unchanged.
+  let systemPrompt;
+  if (opts.agentProfile) {
+    systemPrompt = composeProfilePrompt(opts.agentProfile, {
+      profilesDir: resolve(opts.cwd, ".claude/agents"),
+      runtime,
+      ...(opts.advisorModel && {
+        amend: advisorGuidance(opts.advisorMaxUses),
+      }),
+    });
+  } else if (opts.advisorModel) {
+    systemPrompt = composeSystemPrompt({
+      role: "agent",
+      trailer: advisorGuidance(opts.advisorMaxUses),
+      runtime,
+    });
+  }
+
+  let advisor = null;
+  let recorder = null;
+  if (opts.advisorModel) {
+    const budget = createAdvisorBudget(opts.advisorMaxUses);
+    recorder = createTranscriptRecorder({ systemPrompt, redactor });
+    advisor = createAdvisor({
+      model: opts.advisorModel,
+      cwd: opts.cwd,
+      query,
+      recorder,
+      redactor,
+      runtime,
+      onLine: (line) => emitEnvelope("advisor", JSON.parse(line)),
+    });
+    const advTool = advisorTool({
+      from: "agent",
+      consult: (q) => advisor.consult(q),
+      emit: (event) => emitEnvelope("orchestrator", event),
+      budget,
+      model: opts.advisorModel,
+    });
+    // No allowlist push: in-process SDK MCP servers work under
+    // bypassPermissions without allowlist entries (loop-mode precedent).
+    mcpServers = {
+      ...mcpServers,
+      advisor: createSdkMcpServer({ name: "advisor", tools: [advTool] }),
+    };
+  }
+
+  const runner = createAgentRunner({
+    cwd: opts.cwd,
+    query,
+    output: devNull,
+    model: opts.agentModel,
+    maxTurns: opts.maxTurns,
+    allowedTools,
+    onLine: recorder
+      ? (line) => {
+          onLine(line);
+          recorder.recordMessage(line);
+        }
+      : onLine,
+    ...(recorder && { onPrompt: (text) => recorder.recordPrompt(text) }),
+    settingSources: ["project"],
+    systemPrompt,
+    taskAmend: opts.taskAmend,
+    mcpServers,
+    redactor,
+    runtime,
+  });
+
+  return { runner, advisor };
 }
 
 /**
@@ -53,18 +208,7 @@ export function parseRunOptions(values, runtime) {
  */
 export async function runRunCommand(ctx) {
   const runtime = ctx.deps.runtime;
-  const {
-    taskContent,
-    taskAmend,
-    cwd,
-    agentModel,
-    maxTurns,
-    outputPath,
-    agentProfile,
-    workTracker,
-    allowedTools,
-    mcpServer,
-  } = parseRunOptions(ctx.options, runtime);
+  const opts = parseRunOptions(ctx.options, runtime);
 
   // Build the redactor as the first observable side-effect after option
   // parsing — the env snapshot must freeze BEFORE any in-process
@@ -73,8 +217,8 @@ export async function runRunCommand(ctx) {
 
   // When --output is specified, stream text to stdout while writing NDJSON to file.
   // Otherwise, write NDJSON directly to stdout (backwards-compatible).
-  const fileStream = outputPath
-    ? runtime.fs.createWriteStream(outputPath)
+  const fileStream = opts.outputPath
+    ? runtime.fs.createWriteStream(opts.outputPath)
     : null;
   const output = fileStream
     ? createTeeWriter({
@@ -86,62 +230,17 @@ export async function runRunCommand(ctx) {
     : runtime.proc.stdout;
 
   const counter = new SequenceCounter();
-  const devNull = new Writable({
-    write(_chunk, _enc, cb) {
-      cb();
-    },
-  });
-  const onLine = (line) => {
-    const event = JSON.parse(line);
-    const tagged = { source: "agent", seq: counter.next(), event };
-    output.write(JSON.stringify(redactor.redactValue(tagged)) + "\n");
-  };
-
-  let mcpServers = null;
-  if (mcpServer) {
-    const mcpConfig = await createServiceConfig("mcp");
-    mcpServers = {
-      [mcpServer]: {
-        type: "http",
-        url: mcpConfig.url,
-        headers: { Authorization: `Bearer ${mcpConfig.mcpToken()}` },
-      },
-    };
-    allowedTools.push(`mcp__${mcpServer}__*`);
-  }
-
-  if (agentProfile) {
-    runtime.proc.env.LIBHARNESS_AGENT_PROFILE = agentProfile;
-  }
-  // Unconditional so the default "github" is observable to the agent's
-  // active-tracker resolution, mirroring --agent-profile's env write above.
-  runtime.proc.env.LIBHARNESS_WORK_TRACKER = workTracker;
-
-  const systemPrompt = agentProfile
-    ? composeProfilePrompt(agentProfile, {
-        profilesDir: resolve(cwd, ".claude/agents"),
-        runtime,
-      })
-    : undefined;
-
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
-  const runner = createAgentRunner({
-    cwd,
-    query,
-    output: devNull,
-    model: agentModel,
-    maxTurns,
-    allowedTools,
-    onLine,
-    settingSources: ["project"],
-    systemPrompt,
-    taskAmend,
-    mcpServers,
+  const { runner } = await wireRunSession({
+    opts,
     redactor,
+    output,
+    counter,
+    query,
     runtime,
   });
 
-  const result = await runner.run(taskContent);
+  const result = await runner.run(opts.taskContent);
 
   if (fileStream) {
     await new Promise((r) => output.end(r));

--- a/libraries/libharness/src/commands/run.js
+++ b/libraries/libharness/src/commands/run.js
@@ -17,6 +17,7 @@ import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
 import { createTranscriptRecorder } from "../transcript-recorder.js";
 import { SequenceCounter } from "../sequence-counter.js";
+import { parseAdvisorOptions } from "./advisor-flags.js";
 import { resolveWorkTracker } from "./work-tracker.js";
 import { resolveTaskContent } from "./task-input.js";
 import { createServiceConfig } from "@forwardimpact/libconfig";
@@ -37,10 +38,6 @@ export function parseRunOptions(values, runtime) {
   // the default, rather than overriding it with "".
   const maxTurnsRaw = values["max-turns"] || "50";
 
-  if (values["advisor-max-uses"] && !values["advisor-model"]) {
-    throw new Error("--advisor-max-uses requires --advisor-model");
-  }
-
   return {
     taskContent,
     taskAmend,
@@ -55,8 +52,7 @@ export function parseRunOptions(values, runtime) {
       "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"
     ).split(","),
     mcpServer: values["mcp-server"] || undefined,
-    advisorModel: values["advisor-model"] || undefined,
-    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
+    ...parseAdvisorOptions(values),
   };
 }
 

--- a/libraries/libharness/src/commands/supervise.js
+++ b/libraries/libharness/src/commands/supervise.js
@@ -3,6 +3,7 @@ import { isoTimestamp } from "@forwardimpact/libutil";
 import { createSupervisor } from "../supervisor.js";
 import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
+import { parseAdvisorOptions } from "./advisor-flags.js";
 import { resolveTaskContent } from "./task-input.js";
 import { resolveWorkTracker } from "./work-tracker.js";
 import { createServiceConfig } from "@forwardimpact/libconfig";
@@ -20,10 +21,6 @@ export async function parseSuperviseOptions(values, runtime) {
     runtime,
   );
   const supervisorAllowedToolsRaw = values["supervisor-allowed-tools"];
-
-  if (values["advisor-max-uses"] && !values["advisor-model"]) {
-    throw new Error("--advisor-max-uses requires --advisor-model");
-  }
 
   // `||` (not `??`) throughout so an empty-string flag from a CI forwarder
   // falls back to the default rather than overriding it with "".
@@ -56,8 +53,7 @@ export async function parseSuperviseOptions(values, runtime) {
       ? supervisorAllowedToolsRaw.split(",")
       : undefined,
     mcpServer: values["mcp-server"] || undefined,
-    advisorModel: values["advisor-model"] || undefined,
-    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
+    ...parseAdvisorOptions(values),
   };
 }
 

--- a/libraries/libharness/src/commands/supervise.js
+++ b/libraries/libharness/src/commands/supervise.js
@@ -21,6 +21,10 @@ export async function parseSuperviseOptions(values, runtime) {
   );
   const supervisorAllowedToolsRaw = values["supervisor-allowed-tools"];
 
+  if (values["advisor-max-uses"] && !values["advisor-model"]) {
+    throw new Error("--advisor-max-uses requires --advisor-model");
+  }
+
   // `||` (not `??`) throughout so an empty-string flag from a CI forwarder
   // falls back to the default rather than overriding it with "".
   const tmpRoot = runtime.proc.env.TMPDIR ?? "/tmp";
@@ -52,6 +56,8 @@ export async function parseSuperviseOptions(values, runtime) {
       ? supervisorAllowedToolsRaw.split(",")
       : undefined,
     mcpServer: values["mcp-server"] || undefined,
+    advisorModel: values["advisor-model"] || undefined,
+    advisorMaxUses: parseInt(values["advisor-max-uses"] || "3", 10),
   };
 }
 
@@ -125,6 +131,8 @@ export async function runSuperviseCommand(ctx) {
     agentMcpServers,
     redactor,
     runtime,
+    advisorModel: opts.advisorModel,
+    advisorMaxUses: opts.advisorMaxUses,
   });
 
   const result = await supervisor.run(opts.taskContent);

--- a/libraries/libharness/src/discuss-tools.js
+++ b/libraries/libharness/src/discuss-tools.js
@@ -107,7 +107,7 @@ const ACKNOWLEDGE_DESC =
   "Acknowledge an Ask before starting work. Posts a visible comment on the thread. Does not discharge the Ask — you still owe an Answer.";
 
 /** Discuss-mode agent tool server. */
-export function createDiscussAgentToolServer(ctx, { from }) {
+export function createDiscussAgentToolServer(ctx, { from, extraTools = [] }) {
   return orchestrationServer([
     ...baseTools(ctx, { from, defaultTo: "lead", broadcast: true }),
     requestForCommentTool(ctx),
@@ -133,6 +133,7 @@ export function createDiscussAgentToolServer(ctx, { from }) {
         return { content: [{ type: "text", text: "Acknowledged." }] };
       },
     ),
+    ...extraTools,
   ]);
 }
 

--- a/libraries/libharness/src/discusser.js
+++ b/libraries/libharness/src/discusser.js
@@ -22,7 +22,12 @@ import { ReplyEmitter } from "./reply-emitter.js";
 import { composeSystemPrompt } from "./profile-prompt.js";
 import { SequenceCounter } from "./sequence-counter.js";
 import { createMessageBus } from "./message-bus.js";
-import { createOrchestrationContext } from "./orchestration-toolkit.js";
+import {
+  advisorTool,
+  createOrchestrationContext,
+} from "./orchestration-toolkit.js";
+import { advisorGuidance, createAdvisor, createAdvisorBudget } from "./advisor.js";
+import { createTranscriptRecorder } from "./transcript-recorder.js";
 import {
   createDiscussLeadToolServer,
   createDiscussAgentToolServer,
@@ -206,6 +211,8 @@ export class Discusser {
  * @param {string|null} [deps.callbackUrl]
  * @param {string|null} [deps.inboxUrl]
  * @param {string|null} [deps.correlationId]
+ * @param {string} [deps.advisorModel] - Claude model for advisor consults; absent means no Advisor tool is offered.
+ * @param {number} [deps.advisorMaxUses] - Session-wide consult budget shared by all agent participants (default 3).
  * @returns {Discusser}
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: factory wires N runners + resume hydration paths
@@ -228,6 +235,8 @@ export function createDiscusser({
   inboxUrl,
   correlationId,
   runtime,
+  advisorModel,
+  advisorMaxUses,
 }) {
   if (!redactor) throw new Error("redactor is required");
   if (!runtime) throw new Error("runtime is required");
@@ -306,11 +315,58 @@ export function createDiscusser({
   let discusser;
   const leadServer = createDiscussLeadToolServer(ctx);
 
+  // One budget per session, shared by every agent's Advisor handler.
+  const budget = advisorModel ? createAdvisorBudget(advisorMaxUses ?? 3) : null;
+
   const agents = resolvedConfigs.map((config) => {
-    const agentServer = createDiscussAgentToolServer(ctx, {
-      from: config.name,
+    // Everything advisor-shaped is gated on advisorModel; with it unset the
+    // composed prompt and tool surface are byte-identical to today's.
+    const systemPrompt = composeSystemPrompt({
+      role: "agent",
+      profile: config.agentProfile,
+      profilesDir: resolvedProfilesDir,
+      trailer: DISCUSS_AGENT_SYSTEM_PROMPT,
+      amend: advisorModel
+        ? [config.systemPromptAmend, advisorGuidance(budget.maxUses)]
+            .filter(Boolean)
+            .join("\n\n")
+        : config.systemPromptAmend,
+      runtime,
     });
 
+    let recorder = null;
+    let extraTools;
+    if (advisorModel) {
+      recorder = createTranscriptRecorder({ systemPrompt, redactor });
+      // Late-bound through the `let discusser` closure — the instance does
+      // not exist yet when the advisor and tool are built.
+      const advisor = createAdvisor({
+        model: advisorModel,
+        cwd: config.cwd ?? resolvedLeadCwd,
+        query,
+        recorder,
+        redactor,
+        runtime,
+        onLine: (line) => discusser.loop.emitLine("advisor", line),
+      });
+      abortController.signal.addEventListener("abort", () => advisor.abort());
+      extraTools = [
+        advisorTool({
+          from: config.name,
+          consult: (q) => advisor.consult(q),
+          emit: (e) => discusser.loop.emitOrchestratorEvent(e),
+          budget,
+          model: advisorModel,
+        }),
+      ];
+    }
+
+    const agentServer = createDiscussAgentToolServer(ctx, {
+      from: config.name,
+      ...(extraTools && { extraTools }),
+    });
+
+    const emitAgentLine = (line) => discusser.loop.emitLine(config.name, line);
     const runner = createAgentRunner({
       cwd: config.cwd ?? resolvedLeadCwd,
       query,
@@ -318,17 +374,16 @@ export function createDiscusser({
       model: agentModel ?? AGENT_MODEL,
       maxTurns: config.maxTurns ?? 50,
       allowedTools: config.allowedTools,
-      onLine: (line) => discusser.loop.emitLine(config.name, line),
+      onLine: recorder
+        ? (line) => {
+            emitAgentLine(line);
+            recorder.recordMessage(line);
+          }
+        : emitAgentLine,
+      ...(recorder && { onPrompt: (text) => recorder.recordPrompt(text) }),
       mcpServers: { orchestration: agentServer },
       settingSources: ["project"],
-      systemPrompt: composeSystemPrompt({
-        role: "agent",
-        profile: config.agentProfile,
-        profilesDir: resolvedProfilesDir,
-        trailer: DISCUSS_AGENT_SYSTEM_PROMPT,
-        amend: config.systemPromptAmend,
-        runtime,
-      }),
+      systemPrompt,
       redactor,
     });
 

--- a/libraries/libharness/src/discusser.js
+++ b/libraries/libharness/src/discusser.js
@@ -26,7 +26,11 @@ import {
   advisorTool,
   createOrchestrationContext,
 } from "./orchestration-toolkit.js";
-import { advisorGuidance, createAdvisor, createAdvisorBudget } from "./advisor.js";
+import {
+  createAdvisor,
+  createAdvisorBudget,
+  withAdvisorGuidance,
+} from "./advisor.js";
 import { createTranscriptRecorder } from "./transcript-recorder.js";
 import {
   createDiscussLeadToolServer,
@@ -326,11 +330,7 @@ export function createDiscusser({
       profile: config.agentProfile,
       profilesDir: resolvedProfilesDir,
       trailer: DISCUSS_AGENT_SYSTEM_PROMPT,
-      amend: advisorModel
-        ? [config.systemPromptAmend, advisorGuidance(budget.maxUses)]
-            .filter(Boolean)
-            .join("\n\n")
-        : config.systemPromptAmend,
+      amend: withAdvisorGuidance(config.systemPromptAmend, budget),
       runtime,
     });
 

--- a/libraries/libharness/src/facilitator.js
+++ b/libraries/libharness/src/facilitator.js
@@ -12,11 +12,14 @@ import { createAgentRunner } from "./agent-runner.js";
 import { composeSystemPrompt } from "./profile-prompt.js";
 import { createMessageBus } from "./message-bus.js";
 import {
+  advisorTool,
   createOrchestrationContext,
   createFacilitatorToolServer,
   createFacilitatedAgentToolServer,
 } from "./orchestration-toolkit.js";
 import { OrchestrationLoop } from "./orchestration-loop.js";
+import { advisorGuidance, createAdvisor, createAdvisorBudget } from "./advisor.js";
+import { createTranscriptRecorder } from "./transcript-recorder.js";
 
 /** System prompt for the facilitator lead. L0 mechanics only per COALIGNED. */
 export const FACILITATOR_SYSTEM_PROMPT =
@@ -92,6 +95,8 @@ const devNull = new Writable({
  * @param {string} [deps.facilitatorProfile]
  * @param {string} [deps.profilesDir]
  * @param {string} [deps.taskAmend]
+ * @param {string} [deps.advisorModel] - Claude model for advisor consults; absent means no Advisor tool is offered.
+ * @param {number} [deps.advisorMaxUses] - Session-wide consult budget shared by all agent participants (default 3).
  * @returns {Facilitator}
  */
 export function createFacilitator({
@@ -110,6 +115,8 @@ export function createFacilitator({
   taskAmend,
   redactor,
   runtime,
+  advisorModel,
+  advisorMaxUses,
 }) {
   if (!redactor) throw new Error("redactor is required");
   if (!runtime) throw new Error("runtime is required");
@@ -129,11 +136,59 @@ export function createFacilitator({
 
   const facilitatorServer = createFacilitatorToolServer(ctx);
 
+  const abortController = new AbortController();
+  // One budget per session, shared by every agent's Advisor handler.
+  const budget = advisorModel ? createAdvisorBudget(advisorMaxUses ?? 3) : null;
+
   const agents = agentConfigs.map((config) => {
-    const agentServer = createFacilitatedAgentToolServer(ctx, {
-      from: config.name,
+    // Everything advisor-shaped is gated on advisorModel; with it unset the
+    // composed prompt and tool surface are byte-identical to today's.
+    const systemPrompt = composeSystemPrompt({
+      role: "agent",
+      profile: config.agentProfile,
+      profilesDir: resolvedProfilesDir,
+      trailer: FACILITATED_AGENT_SYSTEM_PROMPT,
+      amend: advisorModel
+        ? [config.systemPromptAmend, advisorGuidance(budget.maxUses)]
+            .filter(Boolean)
+            .join("\n\n")
+        : config.systemPromptAmend,
+      runtime,
     });
 
+    let recorder = null;
+    let extraTools;
+    if (advisorModel) {
+      recorder = createTranscriptRecorder({ systemPrompt, redactor });
+      // Late-bound through the `let facilitator` closure — the instance
+      // does not exist yet when the advisor and tool are built.
+      const advisor = createAdvisor({
+        model: advisorModel,
+        cwd: config.cwd ?? facilitatorCwd,
+        query,
+        recorder,
+        redactor,
+        runtime,
+        onLine: (line) => facilitator.emitLine("advisor", line),
+      });
+      abortController.signal.addEventListener("abort", () => advisor.abort());
+      extraTools = [
+        advisorTool({
+          from: config.name,
+          consult: (q) => advisor.consult(q),
+          emit: (e) => facilitator.emitOrchestratorEvent(e),
+          budget,
+          model: advisorModel,
+        }),
+      ];
+    }
+
+    const agentServer = createFacilitatedAgentToolServer(ctx, {
+      from: config.name,
+      ...(extraTools && { extraTools }),
+    });
+
+    const emitAgentLine = (line) => facilitator.emitLine(config.name, line);
     const runner = createAgentRunner({
       cwd: config.cwd ?? facilitatorCwd,
       query,
@@ -141,17 +196,16 @@ export function createFacilitator({
       model: agentModel ?? model,
       maxTurns: config.maxTurns ?? 50,
       allowedTools: config.allowedTools,
-      onLine: (line) => facilitator.emitLine(config.name, line),
+      onLine: recorder
+        ? (line) => {
+            emitAgentLine(line);
+            recorder.recordMessage(line);
+          }
+        : emitAgentLine,
+      ...(recorder && { onPrompt: (text) => recorder.recordPrompt(text) }),
       mcpServers: { orchestration: agentServer },
       settingSources: ["project"],
-      systemPrompt: composeSystemPrompt({
-        role: "agent",
-        profile: config.agentProfile,
-        profilesDir: resolvedProfilesDir,
-        trailer: FACILITATED_AGENT_SYSTEM_PROMPT,
-        amend: config.systemPromptAmend,
-        runtime,
-      }),
+      systemPrompt,
       redactor,
     });
 
@@ -200,6 +254,7 @@ export function createFacilitator({
     ctx,
     taskAmend,
     redactor,
+    abortController,
   });
   return facilitator;
 }

--- a/libraries/libharness/src/facilitator.js
+++ b/libraries/libharness/src/facilitator.js
@@ -18,7 +18,11 @@ import {
   createFacilitatedAgentToolServer,
 } from "./orchestration-toolkit.js";
 import { OrchestrationLoop } from "./orchestration-loop.js";
-import { advisorGuidance, createAdvisor, createAdvisorBudget } from "./advisor.js";
+import {
+  createAdvisor,
+  createAdvisorBudget,
+  withAdvisorGuidance,
+} from "./advisor.js";
 import { createTranscriptRecorder } from "./transcript-recorder.js";
 
 /** System prompt for the facilitator lead. L0 mechanics only per COALIGNED. */
@@ -148,11 +152,7 @@ export function createFacilitator({
       profile: config.agentProfile,
       profilesDir: resolvedProfilesDir,
       trailer: FACILITATED_AGENT_SYSTEM_PROMPT,
-      amend: advisorModel
-        ? [config.systemPromptAmend, advisorGuidance(budget.maxUses)]
-            .filter(Boolean)
-            .join("\n\n")
-        : config.systemPromptAmend,
+      amend: withAdvisorGuidance(config.systemPromptAmend, budget),
       runtime,
     });
 

--- a/libraries/libharness/src/index.js
+++ b/libraries/libharness/src/index.js
@@ -26,6 +26,7 @@ export {
 export { TeeWriter, createTeeWriter } from "./tee-writer.js";
 export { SequenceCounter, createSequenceCounter } from "./sequence-counter.js";
 export {
+  advisorTool,
   createOrchestrationContext,
   createRequestForCommentHandler,
   createSupervisorToolServer,
@@ -34,6 +35,14 @@ export {
   createFacilitatedAgentToolServer,
   createJudgeToolServer,
 } from "./orchestration-toolkit.js";
+export {
+  ADVISOR_SYSTEM_PROMPT,
+  advisorGuidance,
+  createAdvisor,
+  createAdvisorBudget,
+  DEFAULT_CONSULT_TIMEOUT_MS,
+} from "./advisor.js";
+export { createTranscriptRecorder } from "./transcript-recorder.js";
 export { MessageBus, createMessageBus } from "./message-bus.js";
 export { OrchestrationLoop } from "./orchestration-loop.js";
 export {

--- a/libraries/libharness/src/orchestration-toolkit.js
+++ b/libraries/libharness/src/orchestration-toolkit.js
@@ -337,6 +337,59 @@ function concludeTool(ctx) {
   );
 }
 
+const ADVISOR_DESC =
+  "Consult a stronger model on one focused question. Your full session context (system prompt, prompts, transcript so far) is forwarded automatically — you cannot restrict it. The advice returns in the tool result. The consult budget is shared session-wide across all participants.";
+
+/**
+ * Build the `Advisor` consult tool for one caller. Mode-agnostic: loop
+ * modes pass it into the agent tool-server factories via `extraTools`;
+ * run mode gives it a dedicated server. No orchestration-context
+ * dependency — the budget object and emit callback are injected.
+ *
+ * @param {object} deps
+ * @param {string} deps.from - Caller's canonical name (event attribution).
+ * @param {(question: string) => Promise<{advice?: string, unavailable?: boolean, reason?: string, durationMs: number}>} deps.consult
+ * @param {(event: object) => void} deps.emit - Orchestrator-event emitter for the `advisor_consult` event.
+ * @param {{maxUses: number, used: number}} deps.budget - Session-wide budget shared by every caller's handler.
+ * @param {string} deps.model - Advisor model id, carried on the consult event.
+ */
+export function advisorTool({ from, consult, emit, budget, model }) {
+  return tool(
+    "Advisor",
+    ADVISOR_DESC,
+    { question: z.string() },
+    async ({ question }) => {
+      if (budget.used >= budget.maxUses) {
+        return textResult(
+          `Consult limit reached (${budget.maxUses}/${budget.maxUses} used) — proceed with your best judgment.`,
+        );
+      }
+      // Increment before the first await so two concurrent callers cannot
+      // both pass a last-slot check.
+      budget.used++;
+      const r = await consult(question);
+      const remaining = budget.maxUses - budget.used;
+      emit({
+        type: "advisor_consult",
+        caller: from,
+        question,
+        model,
+        durationMs: r.durationMs,
+        remaining,
+      });
+      if (r.unavailable) {
+        // Not isError: fail-open, the caller continues normally.
+        return textResult(
+          `The advisor is unavailable (${r.reason}) — proceed with your best judgment.`,
+        );
+      }
+      return textResult(
+        `${r.advice}\n\n[advisor consults remaining: ${remaining}]`,
+      );
+    },
+  );
+}
+
 const orchestrationServer = (tools) =>
   createSdkMcpServer({ name: "orchestration", tools });
 
@@ -354,15 +407,16 @@ export function createSupervisorToolServer(ctx) {
   ]);
 }
 
-/** Supervised agent tools: Ask + Answer + Announce + RollCall. */
-export function createSupervisedAgentToolServer(ctx) {
-  return orchestrationServer(
-    baseTools(ctx, {
+/** Supervised agent tools: Ask + Answer + Announce + RollCall (+ extras). */
+export function createSupervisedAgentToolServer(ctx, { extraTools = [] } = {}) {
+  return orchestrationServer([
+    ...baseTools(ctx, {
       from: "agent",
       defaultTo: "supervisor",
       broadcast: false,
     }),
-  );
+    ...extraTools,
+  ]);
 }
 
 /** Facilitator tools: Ask + Answer + Announce + RollCall + Conclude. */
@@ -377,11 +431,12 @@ export function createFacilitatorToolServer(ctx) {
   ]);
 }
 
-/** Facilitated agent tools: Ask + Answer + Announce + RollCall + RequestForComment. */
-export function createFacilitatedAgentToolServer(ctx, { from }) {
+/** Facilitated agent tools: Ask + Answer + Announce + RollCall + RequestForComment (+ extras). */
+export function createFacilitatedAgentToolServer(ctx, { from, extraTools = [] }) {
   return orchestrationServer([
     ...baseTools(ctx, { from, defaultTo: "facilitator", broadcast: true }),
     requestForCommentTool(ctx),
+    ...extraTools,
   ]);
 }
 

--- a/libraries/libharness/src/orchestration-toolkit.js
+++ b/libraries/libharness/src/orchestration-toolkit.js
@@ -432,7 +432,10 @@ export function createFacilitatorToolServer(ctx) {
 }
 
 /** Facilitated agent tools: Ask + Answer + Announce + RollCall + RequestForComment (+ extras). */
-export function createFacilitatedAgentToolServer(ctx, { from, extraTools = [] }) {
+export function createFacilitatedAgentToolServer(
+  ctx,
+  { from, extraTools = [] },
+) {
   return orchestrationServer([
     ...baseTools(ctx, { from, defaultTo: "facilitator", broadcast: true }),
     requestForCommentTool(ctx),

--- a/libraries/libharness/src/supervisor.js
+++ b/libraries/libharness/src/supervisor.js
@@ -21,11 +21,14 @@ import { createAgentRunner } from "./agent-runner.js";
 import { composeSystemPrompt } from "./profile-prompt.js";
 import { createMessageBus } from "./message-bus.js";
 import {
+  advisorTool,
   createOrchestrationContext,
   createSupervisedAgentToolServer,
   createSupervisorToolServer,
 } from "./orchestration-toolkit.js";
 import { OrchestrationLoop } from "./orchestration-loop.js";
+import { advisorGuidance, createAdvisor, createAdvisorBudget } from "./advisor.js";
+import { createTranscriptRecorder } from "./transcript-recorder.js";
 
 /** System prompt for the supervisor lead. L0 mechanics only per COALIGNED. */
 export const SUPERVISOR_SYSTEM_PROMPT =
@@ -59,6 +62,7 @@ export class Supervisor extends OrchestrationLoop {
    * @param {object} deps.ctx
    * @param {object} deps.redactor
    * @param {string} [deps.taskAmend]
+   * @param {AbortController} [deps.abortController]
    */
   constructor({
     supervisorRunner,
@@ -68,6 +72,7 @@ export class Supervisor extends OrchestrationLoop {
     ctx,
     taskAmend,
     redactor,
+    abortController,
   }) {
     if (!agentRunner) throw new Error("agentRunner is required");
     if (!supervisorRunner) throw new Error("supervisorRunner is required");
@@ -82,6 +87,7 @@ export class Supervisor extends OrchestrationLoop {
       ctx,
       taskAmend,
       redactor,
+      abortController,
     });
   }
 
@@ -125,6 +131,8 @@ const devNull = new Writable({
  * @param {string} [deps.profilesDir]
  * @param {string} [deps.taskAmend]
  * @param {Record<string, object>} [deps.agentMcpServers]
+ * @param {string} [deps.advisorModel] - Claude model for advisor consults; absent means no Advisor tool is offered.
+ * @param {number} [deps.advisorMaxUses] - Session-wide consult budget (default 3).
  * @returns {Supervisor}
  */
 export function createSupervisor({
@@ -147,6 +155,8 @@ export function createSupervisor({
   agentMcpServers,
   redactor,
   runtime,
+  advisorModel,
+  advisorMaxUses,
 }) {
   if (!redactor) throw new Error("redactor is required");
   if (!runtime) throw new Error("runtime is required");
@@ -165,10 +175,62 @@ export function createSupervisor({
 
   let supervisor;
   const perRunBudget = maxTurns ?? 200;
+  const abortController = new AbortController();
 
-  const agentServer = createSupervisedAgentToolServer(ctx);
+  // Advisor wiring — everything below is gated on advisorModel being set;
+  // with it unset the composed prompt and tool surface are byte-identical
+  // to today's.
+  const budget = advisorModel ? createAdvisorBudget(advisorMaxUses ?? 3) : null;
+  const agentSystemPrompt = composeSystemPrompt({
+    role: "agent",
+    profile: agentProfile,
+    profilesDir: resolvedProfilesDir,
+    trailer: AGENT_SYSTEM_PROMPT,
+    amend: advisorModel
+      ? [agentSystemPromptAmend, advisorGuidance(budget.maxUses)]
+          .filter(Boolean)
+          .join("\n\n")
+      : agentSystemPromptAmend,
+    runtime,
+  });
+
+  let recorder = null;
+  let extraTools;
+  if (advisorModel) {
+    recorder = createTranscriptRecorder({
+      systemPrompt: agentSystemPrompt,
+      redactor,
+    });
+    // Late-bound through the `let supervisor` closure — the instance does
+    // not exist yet when the advisor and tool are built.
+    const advisor = createAdvisor({
+      model: advisorModel,
+      cwd: agentCwd,
+      query,
+      recorder,
+      redactor,
+      runtime,
+      onLine: (line) => supervisor.emitLine("advisor", line),
+    });
+    abortController.signal.addEventListener("abort", () => advisor.abort());
+    extraTools = [
+      advisorTool({
+        from: "agent",
+        consult: (q) => advisor.consult(q),
+        emit: (e) => supervisor.emitOrchestratorEvent(e),
+        budget,
+        model: advisorModel,
+      }),
+    ];
+  }
+
+  const agentServer = createSupervisedAgentToolServer(
+    ctx,
+    extraTools ? { extraTools } : {},
+  );
   const supervisorServer = createSupervisorToolServer(ctx);
 
+  const emitAgentLine = (line) => supervisor.emitLine("agent", line);
   const agentRunner = createAgentRunner({
     cwd: agentCwd,
     query,
@@ -176,16 +238,15 @@ export function createSupervisor({
     model: agentModel ?? model,
     maxTurns: perRunBudget,
     allowedTools,
-    onLine: (line) => supervisor.emitLine("agent", line),
+    onLine: recorder
+      ? (line) => {
+          emitAgentLine(line);
+          recorder.recordMessage(line);
+        }
+      : emitAgentLine,
+    ...(recorder && { onPrompt: (text) => recorder.recordPrompt(text) }),
     settingSources: ["project"],
-    systemPrompt: composeSystemPrompt({
-      role: "agent",
-      profile: agentProfile,
-      profilesDir: resolvedProfilesDir,
-      trailer: AGENT_SYSTEM_PROMPT,
-      amend: agentSystemPromptAmend,
-      runtime,
-    }),
+    systemPrompt: agentSystemPrompt,
     mcpServers: { orchestration: agentServer, ...agentMcpServers },
     redactor,
   });
@@ -231,6 +292,7 @@ export function createSupervisor({
     ctx,
     taskAmend,
     redactor,
+    abortController,
   });
   return supervisor;
 }

--- a/libraries/libharness/src/supervisor.js
+++ b/libraries/libharness/src/supervisor.js
@@ -27,7 +27,11 @@ import {
   createSupervisorToolServer,
 } from "./orchestration-toolkit.js";
 import { OrchestrationLoop } from "./orchestration-loop.js";
-import { advisorGuidance, createAdvisor, createAdvisorBudget } from "./advisor.js";
+import {
+  createAdvisor,
+  createAdvisorBudget,
+  withAdvisorGuidance,
+} from "./advisor.js";
 import { createTranscriptRecorder } from "./transcript-recorder.js";
 
 /** System prompt for the supervisor lead. L0 mechanics only per COALIGNED. */
@@ -186,11 +190,7 @@ export function createSupervisor({
     profile: agentProfile,
     profilesDir: resolvedProfilesDir,
     trailer: AGENT_SYSTEM_PROMPT,
-    amend: advisorModel
-      ? [agentSystemPromptAmend, advisorGuidance(budget.maxUses)]
-          .filter(Boolean)
-          .join("\n\n")
-      : agentSystemPromptAmend,
+    amend: withAdvisorGuidance(agentSystemPromptAmend, budget),
     runtime,
   });
 

--- a/libraries/libharness/src/transcript-recorder.js
+++ b/libraries/libharness/src/transcript-recorder.js
@@ -1,0 +1,94 @@
+/**
+ * TranscriptRecorder — per-participant in-memory record of the composed
+ * system prompt, delivered prompts, and session messages, rendered into the
+ * context text an advisor consult forwards. Constructed only when a session
+ * runs with an advisor model; the harness otherwise keeps no per-participant
+ * record (session lines go straight to the trace stream).
+ *
+ * Redaction split: the message tap arrives post-redaction (fed from
+ * `AgentRunner.#recordLine`), but the seeded system prompt and the prompt
+ * tap are raw, so the recorder redacts those itself via the injected
+ * redactor.
+ */
+
+/**
+ * Normalize whatever the harness composed as a system prompt into plain
+ * text. In practice always a `{type:"preset", preset:"claude_code", append}`
+ * object (every recorded participant is an agent; leads are spec-excluded);
+ * a plain string is tolerated and `undefined` accepted.
+ * @param {string|{type: string, preset?: string, append?: string}|undefined} systemPrompt
+ * @returns {string|undefined}
+ */
+function normalizeSystemPrompt(systemPrompt) {
+  if (!systemPrompt) return undefined;
+  if (typeof systemPrompt === "string") return systemPrompt;
+  if (systemPrompt.append) {
+    return `(claude_code preset)\n${systemPrompt.append}`;
+  }
+  return undefined;
+}
+
+/** Wrap content in a tagged section, each tag on its own line. */
+function wrapSection(tag, content) {
+  return `<${tag}>\n${content}\n</${tag}>`;
+}
+
+/**
+ * Create a per-participant transcript recorder.
+ *
+ * @param {object} deps
+ * @param {string|object} [deps.systemPrompt] - The system prompt the harness
+ *   composed for the participant, as passed to its runner. Raw — redacted at
+ *   construction.
+ * @param {import("./redaction.js").Redactor} deps.redactor
+ * @returns {{recordPrompt: (text: string) => void, recordMessage: (line: string) => void, render: () => string}}
+ */
+export function createTranscriptRecorder({ systemPrompt, redactor }) {
+  if (!redactor) throw new Error("redactor is required");
+  const normalized = normalizeSystemPrompt(systemPrompt);
+  const seededPrompt = normalized
+    ? redactor.redactValue(normalized)
+    : undefined;
+  /** @type {string[]} */
+  const prompts = [];
+  /** @type {string[]} */
+  const messages = [];
+
+  return {
+    /**
+     * Record a delivered (amend-applied) prompt. Raw — redacted here.
+     * @param {string} text
+     */
+    recordPrompt(text) {
+      prompts.push(redactor.redactValue(text));
+    },
+    /**
+     * Record one NDJSON session line as-is (it arrives already redacted
+     * from the runner's line path).
+     * @param {string} line
+     */
+    recordMessage(line) {
+      messages.push(line);
+    },
+    /**
+     * Render the record as the advisor's context text: three tagged
+     * sections joined by blank lines, each present only when non-empty.
+     * NDJSON lines are verbatim — the forwarded context is uncurated by
+     * construction (context-size curation is spec-excluded).
+     * @returns {string}
+     */
+    render() {
+      const sections = [];
+      if (seededPrompt) {
+        sections.push(wrapSection("caller_system_prompt", seededPrompt));
+      }
+      if (prompts.length > 0) {
+        sections.push(wrapSection("caller_prompts", prompts.join("\n\n")));
+      }
+      if (messages.length > 0) {
+        sections.push(wrapSection("caller_transcript", messages.join("\n")));
+      }
+      return sections.join("\n\n");
+    },
+  };
+}

--- a/libraries/libharness/test/advisor-tool.test.js
+++ b/libraries/libharness/test/advisor-tool.test.js
@@ -10,7 +10,8 @@ import {
 import { createDiscussAgentToolServer } from "../src/discuss-tools.js";
 import { createAdvisorBudget } from "../src/advisor.js";
 
-const registeredTools = (server) => Object.keys(server.instance._registeredTools);
+const registeredTools = (server) =>
+  Object.keys(server.instance._registeredTools);
 
 function makeTool({ budget, consultResult, from = "agent-1" } = {}) {
   const consults = [];
@@ -122,12 +123,10 @@ describe("agent tool-server extraTools seam", () => {
       "RollCall",
       "Advisor",
     ]);
-    assert.deepStrictEqual(registeredTools(createSupervisedAgentToolServer(ctx())), [
-      "Ask",
-      "Answer",
-      "Announce",
-      "RollCall",
-    ]);
+    assert.deepStrictEqual(
+      registeredTools(createSupervisedAgentToolServer(ctx())),
+      ["Ask", "Answer", "Announce", "RollCall"],
+    );
   });
 
   test("facilitated agent server includes an injected extra tool and defaults to the unchanged surface", () => {
@@ -144,7 +143,9 @@ describe("agent tool-server extraTools seam", () => {
       "Advisor",
     ]);
     assert.deepStrictEqual(
-      registeredTools(createFacilitatedAgentToolServer(ctx(), { from: "agent-1" })),
+      registeredTools(
+        createFacilitatedAgentToolServer(ctx(), { from: "agent-1" }),
+      ),
       ["Ask", "Answer", "Announce", "RollCall", "RequestForComment"],
     );
   });
@@ -165,7 +166,14 @@ describe("agent tool-server extraTools seam", () => {
     ]);
     assert.deepStrictEqual(
       registeredTools(createDiscussAgentToolServer(ctx(), { from: "agent-1" })),
-      ["Ask", "Answer", "Announce", "RollCall", "RequestForComment", "Acknowledge"],
+      [
+        "Ask",
+        "Answer",
+        "Announce",
+        "RollCall",
+        "RequestForComment",
+        "Acknowledge",
+      ],
     );
   });
 });

--- a/libraries/libharness/test/advisor-tool.test.js
+++ b/libraries/libharness/test/advisor-tool.test.js
@@ -1,0 +1,171 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+
+import {
+  advisorTool,
+  createFacilitatedAgentToolServer,
+  createOrchestrationContext,
+  createSupervisedAgentToolServer,
+} from "../src/orchestration-toolkit.js";
+import { createDiscussAgentToolServer } from "../src/discuss-tools.js";
+import { createAdvisorBudget } from "../src/advisor.js";
+
+const registeredTools = (server) => Object.keys(server.instance._registeredTools);
+
+function makeTool({ budget, consultResult, from = "agent-1" } = {}) {
+  const consults = [];
+  const events = [];
+  const t = advisorTool({
+    from,
+    consult: async (question) => {
+      consults.push(question);
+      return consultResult ?? { advice: "Do X.", durationMs: 42 };
+    },
+    emit: (e) => events.push(e),
+    budget: budget ?? createAdvisorBudget(3),
+    model: "claude-fable-5",
+  });
+  return { t, consults, events };
+}
+
+describe("advisorTool", () => {
+  test("a consult returns the advice with a remaining-budget footer and emits the consult event", async () => {
+    const budget = createAdvisorBudget(3);
+    const { t, events } = makeTool({ budget });
+
+    const result = await t.handler({ question: "Which fork?" }, {});
+
+    assert.ok(!result.isError);
+    assert.strictEqual(
+      result.content[0].text,
+      "Do X.\n\n[advisor consults remaining: 2]",
+    );
+    assert.deepStrictEqual(events, [
+      {
+        type: "advisor_consult",
+        caller: "agent-1",
+        question: "Which fork?",
+        model: "claude-fable-5",
+        durationMs: 42,
+        remaining: 2,
+      },
+    ]);
+    assert.strictEqual(budget.used, 1);
+  });
+
+  test("an unavailable consult returns a fail-open text result (not isError) and still emits the event", async () => {
+    const { t, events } = makeTool({
+      consultResult: { unavailable: true, reason: "timed out", durationMs: 7 },
+    });
+
+    const result = await t.handler({ question: "Q" }, {});
+
+    assert.ok(!result.isError);
+    assert.strictEqual(
+      result.content[0].text,
+      "The advisor is unavailable (timed out) — proceed with your best judgment.",
+    );
+    assert.strictEqual(events.length, 1);
+    assert.strictEqual(events[0].type, "advisor_consult");
+    assert.strictEqual(events[0].durationMs, 7);
+  });
+
+  test("the cap is enforced in code: consult n+1 starts no session and emits no event", async () => {
+    const budget = createAdvisorBudget(2);
+    const { t, consults, events } = makeTool({ budget });
+
+    await t.handler({ question: "1" }, {});
+    await t.handler({ question: "2" }, {});
+    const denied = await t.handler({ question: "3" }, {});
+
+    assert.strictEqual(consults.length, 2);
+    assert.strictEqual(events.length, 2);
+    assert.strictEqual(
+      denied.content[0].text,
+      "Consult limit reached (2/2 used) — proceed with your best judgment.",
+    );
+    assert.strictEqual(budget.used, 2);
+  });
+
+  test("the counter is shared across two handlers built over one budget object", async () => {
+    const budget = createAdvisorBudget(1);
+    const a = makeTool({ budget, from: "agent-a" });
+    const b = makeTool({ budget, from: "agent-b" });
+
+    await a.t.handler({ question: "from a" }, {});
+    const denied = await b.t.handler({ question: "from b" }, {});
+
+    assert.strictEqual(b.consults.length, 0);
+    assert.match(denied.content[0].text, /Consult limit reached \(1\/1 used\)/);
+  });
+});
+
+describe("agent tool-server extraTools seam", () => {
+  const ctx = () => {
+    const c = createOrchestrationContext();
+    c.rfcs = [];
+    return c;
+  };
+  const extra = () => {
+    const { t } = makeTool();
+    return t;
+  };
+
+  test("supervised agent server includes an injected extra tool and defaults to the unchanged surface", () => {
+    const withExtra = createSupervisedAgentToolServer(ctx(), {
+      extraTools: [extra()],
+    });
+    assert.deepStrictEqual(registeredTools(withExtra), [
+      "Ask",
+      "Answer",
+      "Announce",
+      "RollCall",
+      "Advisor",
+    ]);
+    assert.deepStrictEqual(registeredTools(createSupervisedAgentToolServer(ctx())), [
+      "Ask",
+      "Answer",
+      "Announce",
+      "RollCall",
+    ]);
+  });
+
+  test("facilitated agent server includes an injected extra tool and defaults to the unchanged surface", () => {
+    const withExtra = createFacilitatedAgentToolServer(ctx(), {
+      from: "agent-1",
+      extraTools: [extra()],
+    });
+    assert.deepStrictEqual(registeredTools(withExtra), [
+      "Ask",
+      "Answer",
+      "Announce",
+      "RollCall",
+      "RequestForComment",
+      "Advisor",
+    ]);
+    assert.deepStrictEqual(
+      registeredTools(createFacilitatedAgentToolServer(ctx(), { from: "agent-1" })),
+      ["Ask", "Answer", "Announce", "RollCall", "RequestForComment"],
+    );
+  });
+
+  test("discuss agent server includes an injected extra tool and defaults to the unchanged surface", () => {
+    const withExtra = createDiscussAgentToolServer(ctx(), {
+      from: "agent-1",
+      extraTools: [extra()],
+    });
+    assert.deepStrictEqual(registeredTools(withExtra), [
+      "Ask",
+      "Answer",
+      "Announce",
+      "RollCall",
+      "RequestForComment",
+      "Acknowledge",
+      "Advisor",
+    ]);
+    assert.deepStrictEqual(
+      registeredTools(createDiscussAgentToolServer(ctx(), { from: "agent-1" })),
+      ["Ask", "Answer", "Announce", "RollCall", "RequestForComment", "Acknowledge"],
+    );
+  });
+});

--- a/libraries/libharness/test/advisor.test.js
+++ b/libraries/libharness/test/advisor.test.js
@@ -93,11 +93,17 @@ describe("createAdvisor", () => {
       "Bash",
       "Write",
       "Edit",
+      "NotebookEdit",
       "Agent",
       "Task",
       "TaskOutput",
       "TaskStop",
+      "TodoWrite",
+      "WebFetch",
+      "WebSearch",
     ]);
+    // No bus presence: the advisor session carries no MCP servers at all.
+    assert.ok(!("mcpServers" in opts));
     assert.ok(opts.systemPrompt.append.includes(ADVISOR_SYSTEM_PROMPT));
     assert.strictEqual(result.advice, "Take the smaller refactor.");
     assert.strictEqual(typeof result.durationMs, "number");

--- a/libraries/libharness/test/advisor.test.js
+++ b/libraries/libharness/test/advisor.test.js
@@ -1,7 +1,10 @@
 import { describe, test } from "node:test";
 import assert from "node:assert";
 
-import { createTestRuntime, createMockAgentQuery } from "@forwardimpact/libmock";
+import {
+  createTestRuntime,
+  createMockAgentQuery,
+} from "@forwardimpact/libmock";
 
 import {
   ADVISOR_SYSTEM_PROMPT,
@@ -114,7 +117,10 @@ describe("createAdvisor", () => {
     assert.match(prompt, /You are the caller agent\./);
     assert.match(prompt, /<caller_prompts>\nThe delivered task/);
     assert.match(prompt, /<caller_transcript>\n\{"type":"assistant","seq":1\}/);
-    assert.match(prompt, /<consult_question>\nWhich approach\?\n<\/consult_question>/);
+    assert.match(
+      prompt,
+      /<consult_question>\nWhich approach\?\n<\/consult_question>/,
+    );
   });
 
   test("a second consult re-renders the record as it stands (stateless)", async () => {
@@ -156,6 +162,7 @@ describe("createAdvisor", () => {
   test("a throwing query yields {unavailable} with the error reason", async () => {
     const query = () =>
       (async function* () {
+        yield { type: "system", subtype: "init", session_id: "sess-boom" };
         throw new Error("model exploded");
       })();
     const advisor = createAdvisor(baseDeps({ query }));

--- a/libraries/libharness/test/advisor.test.js
+++ b/libraries/libharness/test/advisor.test.js
@@ -1,0 +1,223 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+
+import { createTestRuntime, createMockAgentQuery } from "@forwardimpact/libmock";
+
+import {
+  ADVISOR_SYSTEM_PROMPT,
+  advisorGuidance,
+  createAdvisor,
+  createAdvisorBudget,
+  DEFAULT_CONSULT_TIMEOUT_MS,
+} from "../src/advisor.js";
+import { createTranscriptRecorder } from "../src/transcript-recorder.js";
+import { createNoopRedactor } from "../src/redaction.js";
+
+const adviceMessages = [
+  { type: "system", subtype: "init", session_id: "sess-adv" },
+  {
+    type: "result",
+    subtype: "success",
+    result: "Take the smaller refactor.",
+    total_cost_usd: 0.01,
+    usage: { input_tokens: 100, output_tokens: 10 },
+  },
+];
+
+function makeRecorder() {
+  const recorder = createTranscriptRecorder({
+    systemPrompt: {
+      type: "preset",
+      preset: "claude_code",
+      append: "You are the caller agent.",
+    },
+    redactor: createNoopRedactor(),
+  });
+  recorder.recordPrompt("The delivered task");
+  recorder.recordMessage('{"type":"assistant","seq":1}');
+  return recorder;
+}
+
+function baseDeps(overrides = {}) {
+  return {
+    model: "claude-fable-5",
+    cwd: "/tmp/caller",
+    query: createMockAgentQuery(adviceMessages),
+    recorder: makeRecorder(),
+    redactor: createNoopRedactor(),
+    runtime: createTestRuntime(),
+    onLine: () => {},
+    ...overrides,
+  };
+}
+
+describe("createAdvisor", () => {
+  for (const missing of [
+    "model",
+    "cwd",
+    "query",
+    "recorder",
+    "redactor",
+    "runtime",
+    "onLine",
+  ]) {
+    test(`throws on missing ${missing}`, () => {
+      const deps = baseDeps();
+      delete deps[missing];
+      assert.throws(
+        () => createAdvisor(deps),
+        new RegExp(`${missing} is required`),
+      );
+    });
+  }
+
+  test("one consult runs exactly one session on the advisor model with the restricted tool surface", async () => {
+    const captured = [];
+    const query = createMockAgentQuery(adviceMessages, (params) =>
+      captured.push(params),
+    );
+    const advisor = createAdvisor(baseDeps({ query }));
+
+    const result = await advisor.consult("Which approach?");
+
+    assert.strictEqual(captured.length, 1);
+    const opts = captured[0].options;
+    assert.strictEqual(opts.model, "claude-fable-5");
+    assert.strictEqual(opts.cwd, "/tmp/caller");
+    assert.strictEqual(opts.maxTurns, 5);
+    assert.deepStrictEqual(opts.allowedTools, ["Read", "Glob", "Grep"]);
+    assert.deepStrictEqual(opts.disallowedTools, [
+      "Bash",
+      "Write",
+      "Edit",
+      "Agent",
+      "Task",
+      "TaskOutput",
+      "TaskStop",
+    ]);
+    assert.ok(opts.systemPrompt.append.includes(ADVISOR_SYSTEM_PROMPT));
+    assert.strictEqual(result.advice, "Take the smaller refactor.");
+    assert.strictEqual(typeof result.durationMs, "number");
+  });
+
+  test("the forwarded prompt carries the whole recorded context and the question", async () => {
+    const captured = [];
+    const query = createMockAgentQuery(adviceMessages, (params) =>
+      captured.push(params),
+    );
+    const advisor = createAdvisor(baseDeps({ query }));
+
+    await advisor.consult("Which approach?");
+
+    const prompt = captured[0].prompt;
+    assert.match(prompt, /<caller_system_prompt>/);
+    assert.match(prompt, /You are the caller agent\./);
+    assert.match(prompt, /<caller_prompts>\nThe delivered task/);
+    assert.match(prompt, /<caller_transcript>\n\{"type":"assistant","seq":1\}/);
+    assert.match(prompt, /<consult_question>\nWhich approach\?\n<\/consult_question>/);
+  });
+
+  test("a second consult re-renders the record as it stands (stateless)", async () => {
+    const captured = [];
+    const query = createMockAgentQuery(adviceMessages, (params) =>
+      captured.push(params),
+    );
+    const recorder = makeRecorder();
+    const advisor = createAdvisor(baseDeps({ query, recorder }));
+
+    await advisor.consult("First?");
+    recorder.recordMessage('{"type":"assistant","seq":2}');
+    await advisor.consult("Second?");
+
+    assert.strictEqual(captured.length, 2);
+    assert.ok(!captured[0].prompt.includes('"seq":2'));
+    assert.ok(captured[1].prompt.includes('"seq":1'));
+    assert.ok(captured[1].prompt.includes('"seq":2'));
+  });
+
+  test("a hanging query times out to {unavailable}", async () => {
+    const hangingQuery = (params) =>
+      (async function* () {
+        await new Promise((_, reject) => {
+          params.options.abortController.signal.addEventListener("abort", () =>
+            reject(new Error("aborted by signal")),
+          );
+        });
+      })();
+    const advisor = createAdvisor(
+      baseDeps({ query: hangingQuery, timeoutMs: 20 }),
+    );
+
+    const result = await advisor.consult("Anyone there?");
+    assert.strictEqual(result.unavailable, true);
+    assert.match(result.reason, /timed out or aborted/);
+  });
+
+  test("a throwing query yields {unavailable} with the error reason", async () => {
+    const query = () =>
+      (async function* () {
+        throw new Error("model exploded");
+      })();
+    const advisor = createAdvisor(baseDeps({ query }));
+
+    const result = await advisor.consult("Q");
+    assert.strictEqual(result.unavailable, true);
+    assert.match(result.reason, /model exploded/);
+  });
+
+  test("abort() during a pending consult yields {unavailable}", async () => {
+    const hangingQuery = (params) =>
+      (async function* () {
+        await new Promise((_, reject) => {
+          params.options.abortController.signal.addEventListener("abort", () =>
+            reject(new Error("aborted by signal")),
+          );
+        });
+      })();
+    const advisor = createAdvisor(baseDeps({ query: hangingQuery }));
+
+    const pending = advisor.consult("Q");
+    advisor.abort();
+    const result = await pending;
+    assert.strictEqual(result.unavailable, true);
+    assert.match(result.reason, /timed out or aborted/);
+  });
+
+  test("a non-success session resolves {unavailable}, never rejects", async () => {
+    const query = createMockAgentQuery([
+      { type: "result", subtype: "error", result: "" },
+    ]);
+    const advisor = createAdvisor(baseDeps({ query }));
+
+    const result = await advisor.consult("Q");
+    assert.strictEqual(result.unavailable, true);
+    assert.match(result.reason, /advisor session failed/);
+  });
+});
+
+describe("advisor prompts and budget", () => {
+  test("ADVISOR_SYSTEM_PROMPT fixes the response contract and a length ceiling", () => {
+    assert.match(ADVISOR_SYSTEM_PROMPT, /assessment/);
+    assert.match(ADVISOR_SYSTEM_PROMPT, /recommendation/);
+    assert.match(ADVISOR_SYSTEM_PROMPT, /unsolicited findings/);
+    assert.match(ADVISOR_SYSTEM_PROMPT, /at most three short paragraphs/);
+    assert.match(ADVISOR_SYSTEM_PROMPT, /never modify/);
+  });
+
+  test("advisorGuidance names the tool, the judgment call, and the budget", () => {
+    const guidance = advisorGuidance(3);
+    assert.match(guidance, /`Advisor` tool/);
+    assert.match(guidance, /hard decision points/);
+    assert.match(guidance, /budget is 3 consults/);
+    assert.match(guidance, /never mandatory/);
+    assert.match(advisorGuidance(1), /budget is 1 consult,/);
+  });
+
+  test("createAdvisorBudget starts at zero used", () => {
+    assert.deepStrictEqual(createAdvisorBudget(3), { maxUses: 3, used: 0 });
+  });
+
+  test("default consult timeout is five minutes", () => {
+    assert.strictEqual(DEFAULT_CONSULT_TIMEOUT_MS, 300_000);
+  });
+});

--- a/libraries/libharness/test/agent-runner.test.js
+++ b/libraries/libharness/test/agent-runner.test.js
@@ -573,6 +573,46 @@ describe("AgentRunner", () => {
     assert.ok(!("pathToClaudeCodeExecutable" in captured.options));
   });
 
+  test("onPrompt receives the amended task on run()", async () => {
+    const prompts = [];
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: mockQuery([{ type: "result", subtype: "success", result: "OK" }]),
+      output: new PassThrough(),
+      taskAmend: "Amendment.",
+      onPrompt: (text) => prompts.push(text),
+      redactor: noop(),
+    });
+
+    await runner.run("Do the task");
+    assert.deepStrictEqual(prompts, ["Do the task\n\nAmendment."]);
+  });
+
+  test("onPrompt receives the raw prompt on resume()", async () => {
+    const prompts = [];
+    let callCount = 0;
+    const query = async function* () {
+      callCount++;
+      if (callCount === 1) {
+        yield { type: "system", subtype: "init", session_id: "sess-p" };
+        yield { type: "result", subtype: "success", result: "OK" };
+      } else {
+        yield { type: "result", subtype: "success", result: "Resumed" };
+      }
+    };
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query,
+      output: new PassThrough(),
+      onPrompt: (text) => prompts.push(text),
+      redactor: noop(),
+    });
+
+    await runner.run("Initial");
+    await runner.resume("Follow up");
+    assert.deepStrictEqual(prompts, ["Initial", "Follow up"]);
+  });
+
   test("createAgentRunner factory returns an AgentRunner instance", () => {
     const runner = createAgentRunner({
       cwd: "/tmp",

--- a/libraries/libharness/test/agent-runner.test.js
+++ b/libraries/libharness/test/agent-runner.test.js
@@ -573,22 +573,7 @@ describe("AgentRunner", () => {
     assert.ok(!("pathToClaudeCodeExecutable" in captured.options));
   });
 
-  test("onPrompt receives the amended task on run()", async () => {
-    const prompts = [];
-    const runner = new AgentRunner({
-      cwd: "/tmp",
-      query: mockQuery([{ type: "result", subtype: "success", result: "OK" }]),
-      output: new PassThrough(),
-      taskAmend: "Amendment.",
-      onPrompt: (text) => prompts.push(text),
-      redactor: noop(),
-    });
-
-    await runner.run("Do the task");
-    assert.deepStrictEqual(prompts, ["Do the task\n\nAmendment."]);
-  });
-
-  test("onPrompt receives the raw prompt on resume()", async () => {
+  test("onPrompt receives the amended task on run() and the raw prompt on resume()", async () => {
     const prompts = [];
     let callCount = 0;
     const query = async function* () {
@@ -604,13 +589,14 @@ describe("AgentRunner", () => {
       cwd: "/tmp",
       query,
       output: new PassThrough(),
+      taskAmend: "Amendment.",
       onPrompt: (text) => prompts.push(text),
       redactor: noop(),
     });
 
-    await runner.run("Initial");
+    await runner.run("Do the task");
     await runner.resume("Follow up");
-    assert.deepStrictEqual(prompts, ["Initial", "Follow up"]);
+    assert.deepStrictEqual(prompts, ["Do the task\n\nAmendment.", "Follow up"]);
   });
 
   test("createAgentRunner factory returns an AgentRunner instance", () => {

--- a/libraries/libharness/test/discusser.test.js
+++ b/libraries/libharness/test/discusser.test.js
@@ -241,4 +241,27 @@ describe("createDiscusser - advisor wiring", () => {
     assert.ok(!registeredTools(agent.runner).includes("Advisor"));
     assert.ok(!agent.runner.systemPrompt.append.includes("Advisor"));
   });
+
+  test("loop stop aborts a discuss agent's pending consult, which resolves fail-open", async () => {
+    const hangingQuery = (params) =>
+      (async function* () {
+        await new Promise((_, reject) => {
+          params.options.abortController.signal.addEventListener("abort", () =>
+            reject(new Error("aborted by signal")),
+          );
+        });
+      })();
+    const d = createDiscusser(
+      factoryOpts({ query: hangingQuery, advisorModel: "adv-model" }),
+    );
+
+    const advisor =
+      d.loop.agents[0].runner.mcpServers.orchestration.instance._registeredTools
+        .Advisor;
+    const pending = advisor.handler({ question: "Q" }, {});
+    // #stop() aborts this controller; trigger the same path directly.
+    d.loop.abortController.abort();
+    const result = await pending;
+    assert.match(result.content[0].text, /advisor is unavailable/);
+  });
 });

--- a/libraries/libharness/test/discusser.test.js
+++ b/libraries/libharness/test/discusser.test.js
@@ -2,9 +2,14 @@ import { test, describe } from "node:test";
 import assert from "node:assert";
 import { PassThrough } from "node:stream";
 
-import { Discusser, augmentContextForDiscuss } from "../src/discusser.js";
+import {
+  Discusser,
+  augmentContextForDiscuss,
+  createDiscusser,
+} from "../src/discusser.js";
 import { createOrchestrationContext } from "../src/orchestration-toolkit.js";
 import { createNoopRedactor } from "../src/redaction.js";
+import { createTestRuntime } from "@forwardimpact/libmock";
 
 function readLines(stream) {
   let buffer = "";
@@ -196,5 +201,44 @@ describe("Discusser - summary shape", () => {
       !("pending_asks" in last.event),
       "summary must not include pending_asks under the sync-Ask model",
     );
+  });
+});
+
+describe("createDiscusser - advisor wiring", () => {
+  const factoryOpts = (overrides = {}) => ({
+    agentConfigs: [
+      {
+        name: "agent-1",
+        role: "worker",
+        cwd: "/tmp/agent-1",
+        systemPromptAmend: "<EXISTING_AMEND>",
+      },
+    ],
+    query: async function* () {},
+    output: new PassThrough(),
+    redactor: createNoopRedactor(),
+    runtime: createTestRuntime(),
+    ...overrides,
+  });
+  const registeredTools = (runner) =>
+    Object.keys(runner.mcpServers.orchestration.instance._registeredTools);
+
+  test("with advisorModel the agent carries the Advisor tool and guidance; the lead carries neither", () => {
+    const d = createDiscusser(factoryOpts({ advisorModel: "adv-model" }));
+    const agent = d.loop.agents[0];
+    assert.ok(registeredTools(agent.runner).includes("Advisor"));
+    const append = agent.runner.systemPrompt.append;
+    const amendAt = append.indexOf("<EXISTING_AMEND>");
+    const guidanceAt = append.indexOf("`Advisor` tool is available");
+    assert.ok(amendAt !== -1 && guidanceAt !== -1 && amendAt < guidanceAt);
+    assert.ok(!registeredTools(d.loop.leadRunner).includes("Advisor"));
+    assert.ok(!d.loop.leadRunner.systemPrompt.includes("`Advisor` tool"));
+  });
+
+  test("without advisorModel the agent surface is unchanged", () => {
+    const d = createDiscusser(factoryOpts());
+    const agent = d.loop.agents[0];
+    assert.ok(!registeredTools(agent.runner).includes("Advisor"));
+    assert.ok(!agent.runner.systemPrompt.append.includes("Advisor"));
   });
 });

--- a/libraries/libharness/test/facilitator-factory.test.js
+++ b/libraries/libharness/test/facilitator-factory.test.js
@@ -8,7 +8,7 @@ import {
   FACILITATOR_SYSTEM_PROMPT,
   FACILITATED_AGENT_SYSTEM_PROMPT,
 } from "@forwardimpact/libharness";
-import { createTestRuntime } from "@forwardimpact/libmock";
+import { createMockAgentQuery, createTestRuntime } from "@forwardimpact/libmock";
 import { createNoopRedactor } from "../src/redaction.js";
 
 const baseOpts = () => ({
@@ -127,6 +127,65 @@ describe("Facilitator - createFacilitator factory", () => {
       assert.ok(agent.runner.mcpServers);
       assert.strictEqual(agent.runner.mcpServers.orchestration.type, "sdk");
     }
+  });
+
+  test("two facilitated agents share one advisor budget", async () => {
+    const adviceMessages = [
+      { type: "system", subtype: "init", session_id: "sess-adv" },
+      {
+        type: "result",
+        subtype: "success",
+        result: "Advice.",
+        total_cost_usd: 0.01,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    ];
+    const f = createFacilitator({
+      ...baseOpts(),
+      query: createMockAgentQuery(adviceMessages),
+      advisorModel: "adv-model",
+      advisorMaxUses: 1,
+    });
+
+    const tools = (name) =>
+      findAgent(f, name).runner.mcpServers.orchestration.instance
+        ._registeredTools;
+    const first = await tools("agent-1").Advisor.handler({ question: "A?" }, {});
+    const denied = await tools("agent-2").Advisor.handler({ question: "B?" }, {});
+
+    assert.match(first.content[0].text, /Advice\./);
+    assert.match(denied.content[0].text, /Consult limit reached \(1\/1 used\)/);
+  });
+
+  test("with advisorModel every agent carries the Advisor tool and guidance; the lead carries neither", () => {
+    const f = createFacilitator({
+      ...baseOpts(),
+      agentConfigs: [
+        {
+          name: "agent-1",
+          role: "worker",
+          cwd: "/tmp/agent-1",
+          systemPromptAmend: "<EXISTING_AMEND>",
+        },
+      ],
+      advisorModel: "adv-model",
+    });
+    const a = findAgent(f, "agent-1");
+    const append = a.runner.systemPrompt.append;
+    const amendAt = append.indexOf("<EXISTING_AMEND>");
+    const guidanceAt = append.indexOf("`Advisor` tool is available");
+    assert.ok(amendAt !== -1 && guidanceAt !== -1 && amendAt < guidanceAt);
+    assert.ok(
+      Object.keys(
+        a.runner.mcpServers.orchestration.instance._registeredTools,
+      ).includes("Advisor"),
+    );
+    assert.ok(
+      !Object.keys(
+        f.facilitatorRunner.mcpServers.orchestration.instance._registeredTools,
+      ).includes("Advisor"),
+    );
+    assert.ok(!f.facilitatorRunner.systemPrompt.includes("`Advisor` tool"));
   });
 
   test("per-agent allowedTools and maxTurns propagate", () => {

--- a/libraries/libharness/test/facilitator-factory.test.js
+++ b/libraries/libharness/test/facilitator-factory.test.js
@@ -8,7 +8,10 @@ import {
   FACILITATOR_SYSTEM_PROMPT,
   FACILITATED_AGENT_SYSTEM_PROMPT,
 } from "@forwardimpact/libharness";
-import { createMockAgentQuery, createTestRuntime } from "@forwardimpact/libmock";
+import {
+  createMockAgentQuery,
+  createTestRuntime,
+} from "@forwardimpact/libmock";
 import { createNoopRedactor } from "../src/redaction.js";
 
 const baseOpts = () => ({
@@ -150,8 +153,14 @@ describe("Facilitator - createFacilitator factory", () => {
     const tools = (name) =>
       findAgent(f, name).runner.mcpServers.orchestration.instance
         ._registeredTools;
-    const first = await tools("agent-1").Advisor.handler({ question: "A?" }, {});
-    const denied = await tools("agent-2").Advisor.handler({ question: "B?" }, {});
+    const first = await tools("agent-1").Advisor.handler(
+      { question: "A?" },
+      {},
+    );
+    const denied = await tools("agent-2").Advisor.handler(
+      { question: "B?" },
+      {},
+    );
 
     assert.match(first.content[0].text, /Advice\./);
     assert.match(denied.content[0].text, /Consult limit reached \(1\/1 used\)/);

--- a/libraries/libharness/test/facilitator-factory.test.js
+++ b/libraries/libharness/test/facilitator-factory.test.js
@@ -197,6 +197,30 @@ describe("Facilitator - createFacilitator factory", () => {
     assert.ok(!f.facilitatorRunner.systemPrompt.includes("`Advisor` tool"));
   });
 
+  test("loop stop aborts a facilitated agent's pending consult, which resolves fail-open", async () => {
+    const hangingQuery = (params) =>
+      (async function* () {
+        await new Promise((_, reject) => {
+          params.options.abortController.signal.addEventListener("abort", () =>
+            reject(new Error("aborted by signal")),
+          );
+        });
+      })();
+    const f = createFacilitator({
+      ...baseOpts(),
+      query: hangingQuery,
+      advisorModel: "adv-model",
+    });
+
+    const advisor = findAgent(f, "agent-1").runner.mcpServers.orchestration
+      .instance._registeredTools.Advisor;
+    const pending = advisor.handler({ question: "Q" }, {});
+    // #stop() aborts this controller; trigger the same path directly.
+    f.abortController.abort();
+    const result = await pending;
+    assert.match(result.content[0].text, /advisor is unavailable/);
+  });
+
   test("per-agent allowedTools and maxTurns propagate", () => {
     const f = createFacilitator({
       ...baseOpts(),

--- a/libraries/libharness/test/golden/fit-harness/help.stdout.txt
+++ b/libraries/libharness/test/golden/fit-harness/help.stdout.txt
@@ -1,4 +1,4 @@
-fit-harness 1.0.0 — Run agents and capture NDJSON traces — for agent evaluations or multi-agent collaboration
+fit-harness 1.3.0 — Run agents and capture NDJSON traces — for agent evaluations or multi-agent collaboration
 
 Usage: fit-harness <command> [options]
 
@@ -10,6 +10,7 @@ Commands:
   output               Read NDJSON from stdin and emit a structured or readable form
   tee [output.ndjson]  Stream readable text to stdout while saving raw NDJSON to a file
   callback             Extract the terminal summary from an NDJSON trace and POST it to a callback URL
+  scan-logs            Scan a run's log archive for secret literals; exit non-zero on any hit, fail closed on an unreadable archive
 
 Options:
   --format=<string>  Output format (json|text)
@@ -26,6 +27,9 @@ Examples:
   fit-harness output --format=text < trace.ndjson
 
 Documentation:
+  Coordinate an Agent Team
+    https://www.forwardimpact.team/docs/libraries/coordinate-team/index.md
+    Run a lead and N participant agents in one async session — supervise, facilitate, or discuss — with Ask/Answer/Announce and a single NDJSON trace.
   Run an Eval
     https://www.forwardimpact.team/docs/libraries/prove-changes/run-eval/index.md
     Author a judge profile, run an eval locally, wire it into CI, and inspect the resulting trace.

--- a/libraries/libharness/test/golden/fit-harness/run-help.stdout.txt
+++ b/libraries/libharness/test/golden/fit-harness/run-help.stdout.txt
@@ -3,18 +3,20 @@ fit-harness run — Run a single agent autonomously on a defined task
 Usage: fit-harness run [options]
 
 Options:
-  --task-file=<string>      Path to a markdown task file
-  --task-text=<string>      Inline task text (alternative to --task-file)
-  --task-event=<string>     Path to a native GitHub event payload JSON, composed into the task via libharness/src/events/github.js (reads $GITHUB_EVENT_NAME)
-  --task-amend=<string>     Additional text appended to the task
-  --agent-model=<string>    Claude model for the agent (default: claude-opus-4-8[1m])
-  --max-turns=<string>      Max agentic turns (default: 50, 0 = unlimited)
-  --output=<string>         Write the NDJSON trace to a file
-  --cwd=<string>            Working directory for the agent
-  --agent-profile=<string>  Agent profile name to load
-  --work-tracker=<string>   Active work-item tracker (github|filesystem, default: github)
-  --allowed-tools=<string>  Comma-separated tool allowlist
-  --mcp-server=<string>     Connect to the MCP service (e.g. --mcp-server=guide); adds mcp__<name>__* to allowed tools
+  --task-file=<string>         Path to a markdown task file
+  --task-text=<string>         Inline task text (alternative to --task-file)
+  --task-event=<string>        Path to a native GitHub event payload JSON, composed into the task via libharness/src/events/github.js (reads $GITHUB_EVENT_NAME)
+  --task-amend=<string>        Additional text appended to the task
+  --agent-model=<string>       Claude model for the agent (default: claude-opus-4-8[1m])
+  --max-turns=<string>         Max agentic turns (default: 50, 0 = unlimited)
+  --output=<string>            Write the NDJSON trace to a file
+  --cwd=<string>               Working directory for the agent
+  --agent-profile=<string>     Agent profile name to load
+  --work-tracker=<string>      Active work-item tracker (github|filesystem, default: github)
+  --allowed-tools=<string>     Comma-separated tool allowlist
+  --mcp-server=<string>        Connect to the MCP service (e.g. --mcp-server=guide); adds mcp__<name>__* to allowed tools
+  --advisor-model=<string>     Claude model for advisor consults; omitting the flag disables the Advisor tool (default: off)
+  --advisor-max-uses=<string>  Session-wide consult budget shared by all participants (default: 3; requires --advisor-model)
 
 Global options:
   --format=<string>  Output format (json|text)

--- a/libraries/libharness/test/lead-flags.test.js
+++ b/libraries/libharness/test/lead-flags.test.js
@@ -128,6 +128,80 @@ describe("--lead-profile / --lead-model consolidation across modes", () => {
   });
 });
 
+describe("--advisor-model / --advisor-max-uses across lead modes", () => {
+  // run's parser is covered in run-advisor.test.js.
+  test("supervise surfaces the advisor options with max-uses defaulting to 3", async () => {
+    const defaults = await parseSuperviseOptions(
+      { "task-text": "x", "agent-cwd": "." },
+      makeRuntime(),
+    );
+    assert.strictEqual(defaults.advisorModel, undefined);
+    assert.strictEqual(defaults.advisorMaxUses, 3);
+
+    const opts = await parseSuperviseOptions(
+      {
+        "task-text": "x",
+        "agent-cwd": ".",
+        "advisor-model": "adv-m",
+        "advisor-max-uses": "5",
+      },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.advisorModel, "adv-m");
+    assert.strictEqual(opts.advisorMaxUses, 5);
+
+    await assert.rejects(
+      parseSuperviseOptions(
+        { "task-text": "x", "agent-cwd": ".", "advisor-max-uses": "5" },
+        makeRuntime(),
+      ),
+      /--advisor-max-uses requires --advisor-model/,
+    );
+  });
+
+  test("facilitate surfaces the advisor options with max-uses defaulting to 3", () => {
+    const base = { "task-text": "x", "agent-profiles": "alpha" };
+    const defaults = parseFacilitateOptions(base, makeRuntime());
+    assert.strictEqual(defaults.advisorModel, undefined);
+    assert.strictEqual(defaults.advisorMaxUses, 3);
+
+    const opts = parseFacilitateOptions(
+      { ...base, "advisor-model": "adv-m", "advisor-max-uses": "5" },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.advisorModel, "adv-m");
+    assert.strictEqual(opts.advisorMaxUses, 5);
+
+    assert.throws(
+      () =>
+        parseFacilitateOptions({ ...base, "advisor-max-uses": "5" }, makeRuntime()),
+      /--advisor-max-uses requires --advisor-model/,
+    );
+  });
+
+  test("discuss surfaces the advisor options with max-uses defaulting to 3", () => {
+    const defaults = parseDiscussOptions({ "task-text": "x" }, makeRuntime());
+    assert.strictEqual(defaults.advisorModel, undefined);
+    assert.strictEqual(defaults.advisorMaxUses, 3);
+
+    const opts = parseDiscussOptions(
+      { "task-text": "x", "advisor-model": "adv-m", "advisor-max-uses": "5" },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.advisorModel, "adv-m");
+    assert.strictEqual(opts.advisorMaxUses, 5);
+
+    assert.throws(
+      () =>
+        parseDiscussOptions(
+          { "task-text": "x", "advisor-max-uses": "5" },
+          makeRuntime(),
+        ),
+      /--advisor-max-uses requires --advisor-model/,
+    );
+  });
+});
+
 describe("blank model flags fall through to the role constants", () => {
   // Composite-action inputs are strings, so an unset input arrives as
   // `--lead-model=` (empty string). Blank must behave like absent so the

--- a/libraries/libharness/test/lead-flags.test.js
+++ b/libraries/libharness/test/lead-flags.test.js
@@ -174,7 +174,10 @@ describe("--advisor-model / --advisor-max-uses across lead modes", () => {
 
     assert.throws(
       () =>
-        parseFacilitateOptions({ ...base, "advisor-max-uses": "5" }, makeRuntime()),
+        parseFacilitateOptions(
+          { ...base, "advisor-max-uses": "5" },
+          makeRuntime(),
+        ),
       /--advisor-max-uses requires --advisor-model/,
     );
   });

--- a/libraries/libharness/test/run-advisor.test.js
+++ b/libraries/libharness/test/run-advisor.test.js
@@ -22,7 +22,10 @@ function makeRuntime() {
 }
 
 function parse(values, runtime = makeRuntime()) {
-  return parseRunOptions({ "task-text": "do it", cwd: "/work", ...values }, runtime);
+  return parseRunOptions(
+    { "task-text": "do it", cwd: "/work", ...values },
+    runtime,
+  );
 }
 
 const adviceMessages = [

--- a/libraries/libharness/test/run-advisor.test.js
+++ b/libraries/libharness/test/run-advisor.test.js
@@ -1,0 +1,173 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { PassThrough } from "node:stream";
+
+import {
+  createMockAgentQuery,
+  createMockFs,
+  createTestRuntime,
+} from "@forwardimpact/libmock";
+
+import { parseRunOptions, wireRunSession } from "../src/commands/run.js";
+import { advisorGuidance } from "../src/advisor.js";
+import { createNoopRedactor } from "../src/redaction.js";
+import { SequenceCounter } from "../src/sequence-counter.js";
+
+const PROFILE_MD = "---\nname: coder\n---\nYou are the coder persona.";
+
+function makeRuntime() {
+  return createTestRuntime({
+    fs: createMockFs({ "/work/.claude/agents/coder.md": PROFILE_MD }),
+  });
+}
+
+function parse(values, runtime = makeRuntime()) {
+  return parseRunOptions({ "task-text": "do it", cwd: "/work", ...values }, runtime);
+}
+
+const adviceMessages = [
+  { type: "system", subtype: "init", session_id: "sess-adv" },
+  {
+    type: "result",
+    subtype: "success",
+    result: "Advice.",
+    total_cost_usd: 0.01,
+    usage: { input_tokens: 10, output_tokens: 5 },
+  },
+];
+
+async function wire({ values = {}, query } = {}) {
+  const runtime = makeRuntime();
+  const opts = parse(values, runtime);
+  const output = new PassThrough();
+  const wired = await wireRunSession({
+    opts,
+    redactor: createNoopRedactor(),
+    output,
+    counter: new SequenceCounter(),
+    query: query ?? createMockAgentQuery(adviceMessages),
+    runtime,
+  });
+  return { ...wired, output, runtime };
+}
+
+const outputLines = (output) =>
+  (output.read()?.toString() ?? "")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map(JSON.parse);
+
+describe("parseRunOptions - advisor flags", () => {
+  test("defaults: no advisor model, max-uses 3", () => {
+    const opts = parse();
+    assert.strictEqual(opts.advisorModel, undefined);
+    assert.strictEqual(opts.advisorMaxUses, 3);
+  });
+
+  test("flag values parse through", () => {
+    const opts = parse({ "advisor-model": "adv-m", "advisor-max-uses": "5" });
+    assert.strictEqual(opts.advisorModel, "adv-m");
+    assert.strictEqual(opts.advisorMaxUses, 5);
+  });
+
+  test("--advisor-max-uses without --advisor-model is a usage error", () => {
+    assert.throws(
+      () => parse({ "advisor-max-uses": "5" }),
+      /--advisor-max-uses requires --advisor-model/,
+    );
+  });
+});
+
+describe("wireRunSession - advisor wiring", () => {
+  test("no advisor flag: no advisor server, no system prompt (today's behavior)", async () => {
+    const { runner, advisor } = await wire();
+    assert.strictEqual(advisor, null);
+    assert.strictEqual(runner.mcpServers, null);
+    assert.strictEqual(runner.systemPrompt, null);
+  });
+
+  test("advisor server present iff advisorModel is set", async () => {
+    const { runner, advisor } = await wire({
+      values: { "advisor-model": "adv-m" },
+    });
+    assert.ok(advisor);
+    assert.strictEqual(runner.mcpServers.advisor.type, "sdk");
+    assert.deepStrictEqual(
+      Object.keys(runner.mcpServers.advisor.instance._registeredTools),
+      ["Advisor"],
+    );
+  });
+
+  test("with a profile the guidance rides the profile amendment", async () => {
+    const { runner } = await wire({
+      values: { "advisor-model": "adv-m", "agent-profile": "coder" },
+    });
+    const append = runner.systemPrompt.append;
+    assert.match(append, /You are the coder persona\./);
+    assert.ok(append.includes(advisorGuidance(3)));
+    assert.ok(append.indexOf("<session_protocol>") !== -1);
+  });
+
+  test("with no profile the guidance is the sole session-protocol fragment", async () => {
+    const { runner } = await wire({ values: { "advisor-model": "adv-m" } });
+    assert.deepStrictEqual(runner.systemPrompt, {
+      type: "preset",
+      preset: "claude_code",
+      append: `<session_protocol>\n${advisorGuidance(3)}\n</session_protocol>`,
+    });
+  });
+
+  test("a consult forwards the seeded composed prompt and lands advisor + consult lines with monotonic seq", async () => {
+    const captured = [];
+    const query = createMockAgentQuery(adviceMessages, (params) =>
+      captured.push(params),
+    );
+    const { runner, output } = await wire({
+      values: { "advisor-model": "adv-m" },
+      query,
+    });
+
+    const advisorTool =
+      runner.mcpServers.advisor.instance._registeredTools.Advisor;
+    const result = await advisorTool.handler({ question: "Which way?" }, {});
+
+    assert.match(result.content[0].text, /Advice\./);
+    // The recorder was seeded with the composed (preset) system prompt.
+    assert.match(captured[0].prompt, /<caller_system_prompt>/);
+    assert.match(captured[0].prompt, /\(claude_code preset\)/);
+    assert.ok(captured[0].prompt.includes(advisorGuidance(3)));
+    assert.strictEqual(captured[0].options.model, "adv-m");
+
+    const lines = outputLines(output);
+    const sources = lines.map((l) => l.source);
+    assert.deepStrictEqual(sources, ["advisor", "advisor", "orchestrator"]);
+    const event = lines[2].event;
+    assert.strictEqual(event.type, "advisor_consult");
+    assert.strictEqual(event.caller, "agent");
+    assert.strictEqual(event.model, "adv-m");
+    assert.strictEqual(event.remaining, 2);
+    const seqs = lines.map((l) => l.seq);
+    for (let i = 1; i < seqs.length; i++) assert.ok(seqs[i] > seqs[i - 1]);
+  });
+
+  test("onPrompt feeds the recorder: a later consult forwards the delivered task", async () => {
+    const captured = [];
+    const query = createMockAgentQuery(adviceMessages, (params) =>
+      captured.push(params),
+    );
+    const { runner } = await wire({
+      values: { "advisor-model": "adv-m" },
+      query,
+    });
+
+    await runner.run("The delivered task");
+    const advisorTool =
+      runner.mcpServers.advisor.instance._registeredTools.Advisor;
+    await advisorTool.handler({ question: "Q" }, {});
+
+    const consultParams = captured[captured.length - 1];
+    assert.match(consultParams.prompt, /<caller_prompts>\nThe delivered task/);
+    assert.match(consultParams.prompt, /<caller_transcript>/);
+  });
+});

--- a/libraries/libharness/test/run-advisor.test.js
+++ b/libraries/libharness/test/run-advisor.test.js
@@ -80,6 +80,15 @@ describe("parseRunOptions - advisor flags", () => {
       /--advisor-max-uses requires --advisor-model/,
     );
   });
+
+  test("a malformed --advisor-max-uses is a usage error, not a silent NaN", () => {
+    for (const bad of ["abc", "0", "-2"]) {
+      assert.throws(
+        () => parse({ "advisor-model": "adv-m", "advisor-max-uses": bad }),
+        /--advisor-max-uses must be a positive integer/,
+      );
+    }
+  });
 });
 
 describe("wireRunSession - advisor wiring", () => {

--- a/libraries/libharness/test/supervisor-factory.test.js
+++ b/libraries/libharness/test/supervisor-factory.test.js
@@ -160,3 +160,61 @@ describe("Supervisor - createSupervisor factory", () => {
     assert.strictEqual(s.supervisorRunner.maxTurns, 200);
   });
 });
+
+describe("Supervisor - advisor wiring", () => {
+  const registeredTools = (runner) =>
+    Object.keys(runner.mcpServers.orchestration.instance._registeredTools);
+
+  test("with advisorModel the agent server carries the Advisor tool and the lead carries neither", () => {
+    const s = createSupervisor({ ...baseOpts(), advisorModel: "adv-model" });
+    assert.ok(registeredTools(s.agentRunner).includes("Advisor"));
+    assert.ok(!registeredTools(s.supervisorRunner).includes("Advisor"));
+    assert.ok(!s.supervisorRunner.systemPrompt.includes("`Advisor` tool"));
+  });
+
+  test("guidance is composed after an existing amendment in the agent prompt", () => {
+    const s = createSupervisor({
+      ...baseOpts(),
+      advisorModel: "adv-model",
+      agentSystemPromptAmend: "<EXISTING_AMEND>",
+    });
+    const append = s.agentRunner.systemPrompt.append;
+    const amendAt = append.indexOf("<EXISTING_AMEND>");
+    const guidanceAt = append.indexOf("`Advisor` tool is available");
+    assert.ok(amendAt !== -1, "existing amendment present");
+    assert.ok(guidanceAt !== -1, "guidance present");
+    assert.ok(amendAt < guidanceAt, "guidance follows the amendment");
+  });
+
+  test("without advisorModel no advisor text or tool appears", () => {
+    const s = createSupervisor(baseOpts());
+    assert.ok(!s.agentRunner.systemPrompt.append.includes("Advisor"));
+    assert.ok(!registeredTools(s.agentRunner).includes("Advisor"));
+  });
+
+  test("loop stop aborts a pending consult, which resolves fail-open", async () => {
+    // The advisor session's query hangs until its abort controller fires —
+    // the same shape as a wedged live consult.
+    const hangingQuery = (params) =>
+      (async function* () {
+        await new Promise((_, reject) => {
+          params.options.abortController.signal.addEventListener("abort", () =>
+            reject(new Error("aborted by signal")),
+          );
+        });
+      })();
+    const s = createSupervisor({
+      ...baseOpts(),
+      query: hangingQuery,
+      advisorModel: "adv-model",
+    });
+
+    const advisor =
+      s.agentRunner.mcpServers.orchestration.instance._registeredTools.Advisor;
+    const pending = advisor.handler({ question: "Q" }, {});
+    // #stop() aborts this controller; trigger the same path directly.
+    s.abortController.abort();
+    const result = await pending;
+    assert.match(result.content[0].text, /advisor is unavailable/);
+  });
+});

--- a/libraries/libharness/test/transcript-recorder.test.js
+++ b/libraries/libharness/test/transcript-recorder.test.js
@@ -1,0 +1,103 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+
+import { createTranscriptRecorder } from "../src/transcript-recorder.js";
+import { createNoopRedactor } from "../src/redaction.js";
+
+/** Redactor stub replacing a fixed needle in every string it walks. */
+const needleRedactor = (needle, placeholder) => ({
+  redactValue: (value) =>
+    typeof value === "string" ? value.split(needle).join(placeholder) : value,
+});
+
+describe("createTranscriptRecorder", () => {
+  test("throws on missing redactor", () => {
+    assert.throws(() => createTranscriptRecorder({}), /redactor is required/);
+  });
+
+  test("seeds a preset system prompt with a preset note", () => {
+    const recorder = createTranscriptRecorder({
+      systemPrompt: {
+        type: "preset",
+        preset: "claude_code",
+        append: "You are a test agent.",
+      },
+      redactor: createNoopRedactor(),
+    });
+    const rendered = recorder.render();
+    assert.match(rendered, /<caller_system_prompt>/);
+    assert.match(rendered, /\(claude_code preset\)\nYou are a test agent\./);
+  });
+
+  test("seeds a plain-string system prompt verbatim", () => {
+    const recorder = createTranscriptRecorder({
+      systemPrompt: "Plain persona.",
+      redactor: createNoopRedactor(),
+    });
+    assert.match(
+      recorder.render(),
+      /<caller_system_prompt>\nPlain persona\.\n<\/caller_system_prompt>/,
+    );
+  });
+
+  test("accepts an absent system prompt and omits its section", () => {
+    const recorder = createTranscriptRecorder({
+      redactor: createNoopRedactor(),
+    });
+    recorder.recordPrompt("A task");
+    assert.ok(!recorder.render().includes("<caller_system_prompt>"));
+  });
+
+  test("redacts the seeded system prompt and delivered prompts", () => {
+    const recorder = createTranscriptRecorder({
+      systemPrompt: "Persona with hunter2 inside.",
+      redactor: needleRedactor("hunter2", "[REDACTED]"),
+    });
+    recorder.recordPrompt("Prompt with hunter2 too.");
+    const rendered = recorder.render();
+    assert.ok(!rendered.includes("hunter2"));
+    assert.match(rendered, /Persona with \[REDACTED\] inside\./);
+    assert.match(rendered, /Prompt with \[REDACTED\] too\./);
+  });
+
+  test("message lines pass through unredacted by the recorder", () => {
+    const recorder = createTranscriptRecorder({
+      redactor: needleRedactor("hunter2", "[REDACTED]"),
+    });
+    recorder.recordMessage('{"type":"assistant","text":"hunter2"}');
+    assert.match(recorder.render(), /"hunter2"/);
+  });
+
+  test("render() contains all three sections in order", () => {
+    const recorder = createTranscriptRecorder({
+      systemPrompt: "Persona.",
+      redactor: createNoopRedactor(),
+    });
+    recorder.recordPrompt("First prompt");
+    recorder.recordPrompt("Second prompt");
+    recorder.recordMessage('{"type":"assistant"}');
+    recorder.recordMessage('{"type":"result"}');
+
+    const rendered = recorder.render();
+    const sys = rendered.indexOf("<caller_system_prompt>");
+    const prompts = rendered.indexOf("<caller_prompts>");
+    const transcript = rendered.indexOf("<caller_transcript>");
+    assert.ok(sys !== -1 && prompts !== -1 && transcript !== -1);
+    assert.ok(sys < prompts && prompts < transcript);
+    assert.match(rendered, /First prompt\n\nSecond prompt/);
+    assert.match(rendered, /\{"type":"assistant"\}\n\{"type":"result"\}/);
+  });
+
+  test("a second render() after more messages reflects the fuller record", () => {
+    const recorder = createTranscriptRecorder({
+      redactor: createNoopRedactor(),
+    });
+    recorder.recordMessage('{"seq":1}');
+    const first = recorder.render();
+    recorder.recordMessage('{"seq":2}');
+    const second = recorder.render();
+    assert.ok(!first.includes('{"seq":2}'));
+    assert.ok(second.includes('{"seq":1}'));
+    assert.ok(second.includes('{"seq":2}'));
+  });
+});

--- a/websites/fit/docs/libraries/coordinate-team/index.md
+++ b/websites/fit/docs/libraries/coordinate-team/index.md
@@ -144,6 +144,42 @@ thread for a question that outlives the current session. In `discuss` mode,
 `Acknowledge` posts a brief message straight to the thread (a status update or a
 reply to a human follow-up) without discharging an owed Answer.
 
+## Consult an advisor
+
+An advisor is a bounded, read-only, one-shot consult on a stronger model. When
+an agent participant hits a hard decision — an architectural fork, an unclear
+root cause, a trade-off it cannot rank — it calls the `Advisor` tool with one
+focused question. The harness forwards the agent's full session context (its
+system prompt, delivered prompts, and transcript so far) plus the question to
+a fresh session on the advisor model. That session can read files but cannot
+write, execute, or spawn agents; its final text returns as the tool result and
+the caller stays in control of its own loop.
+
+Two flags enable it, on `run`, `supervise`, `facilitate`, and `discuss`:
+
+```sh
+npx fit-harness facilitate \
+  --task-file=sessions/release-review/task.md \
+  --lead-profile=release-facilitator \
+  --agent-profiles=security-engineer,release-engineer \
+  --advisor-model="claude-opus-4-8[1m]" \
+  --advisor-max-uses=3 \
+  --output=trace.ndjson
+```
+
+Omitting `--advisor-model` disables the tool entirely — no advisor prompt
+text, no tool, no cost. `--advisor-max-uses` (default 3) is a session-wide
+budget shared by all participants and enforced in code; once spent, further
+consults return "proceed with your best judgment" without starting an advisor
+session. Consults are fail-open: a consult that times out, errors, or is
+aborted resolves the same way, and the caller's session continues normally.
+Lead roles never get the tool — only agent participants do.
+
+Every consult is evident in the trace: an `advisor_consult` orchestrator event
+records the caller, question, model, duration, and remaining budget, and the
+advisor session's own lines — including its result event with token usage and
+cost — appear under a distinct `advisor` source.
+
 ## Run a facilitated session
 
 Write a facilitator profile and one profile per participant. Each participant


### PR DESCRIPTION
## Summary

Implements spec 2230 (plan-a): an executor-triggered advisor consult for `fit-harness` sessions. Any agent participant can, when the operator enables it with `--advisor-model`, ask one focused question of a stronger model and get bounded advice grounded in its full session context — with the consult budget enforced in code and every consult visible in the trace.

- `AgentRunner` gains an `onPrompt` tap (`src/agent-runner.js`) feeding a new per-participant `TranscriptRecorder` (`src/transcript-recorder.js`) that records the composed system prompt, delivered prompts, and session lines.
- `createAdvisor` (`src/advisor.js`) runs one fresh, solo, read-only session per consult (`Read`/`Glob`/`Grep` allowed; write, execute, subagent, orchestration, notebook, todo, and web tools structurally removed via `disallowedTools`); the final text is the advice; 5-minute timeout; timeout/error/abort all resolve fail-open to an in-band `{unavailable}` result.
- `advisorTool` (`src/orchestration-toolkit.js`) checks the shared `createAdvisorBudget` cap in code before any advisor spend and emits an `advisor_consult` orchestrator event; the advisor session's lines land in the trace under a distinct `advisor` source, carrying its own usage and cost.
- All four modes wire it: supervise/facilitate/discuss per-agent in their factories (leads excluded; consult aborts registered on the loop's stop path), run via an extracted query-injectable `wireRunSession`. Consult guidance rides the existing amendment seam; with the advisor off, prompts and tool surfaces are byte-identical to before.
- `--advisor-model` / `--advisor-max-uses` (default 3; usage error without the model flag or when not a positive integer) on `run`, `supervise`, `facilitate`, `discuss`; documented in `--help` and in a new "Consult an advisor" section of the coordinate-team guide.

Clean 5-reviewer `kata-review` panel: 0 blockers; the consensus findings (NaN budget bypass on a malformed `--advisor-max-uses`, disallowed-tools list narrower than the spec's read-only contract, stale CLI golden) are fixed in the final commit with dismissal rationale for singletons recorded there.

Spec relation: implements `specs/2230-libharness-advisor/` (spec + design-a + plan-a, all merged on main; STATUS at `plan approved`, set to `implemented` on ship).

## Test plan

- [x] `bun run check`
- [x] `bun run test` (5576 pass, 0 fail)
- [x] `bun test` in `libraries/libharness` (922 pass; all ten spec success criteria have direct assertions against the injected fake-query seam — no live LLM spend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)