### PR TITLE
docs(spec-2240): rework scored benchmark tasks to row-authoritative grading

### DIFF
--- a/specs/2240-scored-benchmark-tasks/design-a.md
+++ b/specs/2240-scored-benchmark-tasks/design-a.md
@@ -1,93 +1,104 @@
 # Design 2240-a — Scored Benchmark Tasks
 
-Implements spec 2240. A task becomes **scored** when its `invariants.sh` emits
-weighted check rows on the results fd; a pure derivation turns those rows into
-a score in [0, 1], the runner composes it with the existing gates, the record
-carries it, and `report` aggregates it. Judged tasks — every task that emits no
-weighted row — flow through unchanged code paths and produce byte-identical
-records. Nothing new declares a task's shape (no file, manifest field, or
-flag); the rows are the declaration.
+Implements spec 2240. The NDJSON rows on the results fd are the single
+authoritative grading channel: every row is a check, its role (gate, scored,
+diagnostic) rides on the row itself, and a pure derivation turns the rows plus
+the script's exit health into a verdict and a score in [0, 1]. The exit code
+carries no verdict meaning — nonzero means "the grader crashed", which fails
+the run so a dead hook can never mint marks. Clean break: every hook in
+`benchmarks/` and the test fixtures migrates in this change; no dual-channel
+compatibility mode exists.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-  INV["invariants.sh<br/>fd-3 rows ± weight"] --> RI[runInvariants<br/>rows → details]
-  RI --> DS["deriveScore(details)<br/>score.js (pure)"]
-  DS --> RUN["runner #executeCell<br/>gates ∧ fullMarks → verdict, record.score"]
-  RI --> RUN
+  INV["invariants.sh<br/>fd-3 rows + exit health"] --> RI[runInvariants<br/>rows → details]
+  RI --> GR["gradeInvariants(details, exitCode)<br/>grade.js (pure)"]
+  GR --> RUN["runner #executeCell<br/>invariants verdict ∧ judge → cell verdict, record.score"]
   JD["judge (binary gate)"] --> RUN
   RUN --> LEDGER[(results.jsonl)]
   LEDGER --> REP["report<br/>meanScore + score@k"]
-  DS --> CMD["invariants subcommand<br/>same derivation + gate composition"]
+  GR --> CMD["invariants subcommand<br/>same grading, process exit mirrors verdict"]
 ```
 
-Score derivation is one pure function with two callers (runner and the
-`invariants` subcommand), so the arithmetic exists once and records are
-self-describing — `report` reads `score` off the record, never re-deriving it
-from details.
+Grading is one pure function with one caller (`runInvariants`), so the
+arithmetic exists once and records are self-describing — `report` reads
+`score` off the record, never re-deriving it from details.
 
-## The scored-row convention (normative)
+## The row contract (normative)
 
-The rules in this section are the single home for the row and scoring
+The rules in this section are the single home for the row and grading
 semantics; the component rows below reference them rather than restating.
 
-A details row is a **scored check** iff it carries a numeric `weight > 0`:
+Every parsed row is a check by default. Roles, checked in order:
 
-```json
-{"test": "filter-case-insensitive", "pass": false, "weight": 1}
-```
+1. **Diagnostic** — `weight` is exactly `0`. Free-form; never graded.
+2. **Gate** — `gate` is exactly `true` and no positive `weight` is present.
+   Requires a boolean `pass`. Any failing gate → `gatesPass` false.
+3. **Scored** — everything else. `weight` must be absent (defaults to 1) or a
+   finite number > 0; `pass` must be a boolean.
+   `score = Σ weight(passing) / Σ weight(all scored)`.
+4. **Malformed** — a row that fits no role: missing or non-boolean `pass` on a
+   graded row, non-boolean `gate`, invalid `weight` (negative, non-finite,
+   non-numeric), `gate: true` alongside a positive `weight`, or an fd-3 line
+   that fails to parse as JSON. A malformed row counts as a **failing scored
+   check** — at its own weight when it carries a valid positive one, else at
+   unit weight 1 — and increments the derivation's `malformed` count.
+   Silently dropping a defect could mint full marks from a broken hook;
+   failing the whole run would zero work that mechanically completed.
 
-- `score = Σ weight(passing scored checks) / Σ weight(all scored checks)`.
-- **Full marks** is the count predicate *every scored check passes*, exposed as
-  a `fullMarks` boolean on the derivation result. The verdict never compares
-  float sums, so fractional weights carry no equality hazard.
-- **A `weight` key declares scored intent; malformed intent fails.** Any row
-  carrying a `weight` key is a scored check. If the weight is invalid (not a
-  finite number > 0) or `pass` is missing or non-boolean, the row counts as a
-  *failing* scored check — an invalid weight contributes at the unit weight 1,
-  a valid one at its own value, in the denominator only — and the derivation's
-  `malformed` count records it. Silently dropping either defect could mint
-  full marks from a broken hook. Rows the fd-3 parser already marks
-  `parseError` carry no keys to inspect and stay diagnostic.
-- Zero scored checks → the task is judged; derivation returns `null` and no
-  `score` field appears anywhere.
-- Rows without `weight` remain what they are today: diagnostic detail. A
-  scored task may mix both — gate diagnostics unweighted, graded checks
-  weighted.
-- **Scored checks never couple to the gate.** The hook's gate checks keep the
-  documented `assert() { … || FAIL=1; }` pattern; scored checks use a variant
-  that discards the per-check exit status (`|| true`), because the exit code
-  reports gate conditions only (spec requirement 3). The authoring reference
-  documents both helpers side by side.
+Derived predicates:
+
+- `healthy` — the script exited 0. Unhealthy → verdict `fail`, score 0,
+  whatever the rows say (spec requirement 3).
+- `fullMarks` — integer count predicate: `malformed === 0` and every scored
+  check passes. The verdict never compares float sums, so fractional weights
+  carry no equality hazard.
+- Zero scored checks → the task is binary; `score` is `null` and no `score`
+  field appears anywhere.
+- **Invariants verdict** = `healthy ∧ gatesPass ∧ fullMarks` (vacuously true
+  parts when no gate or scored rows exist — a row-less exit-0 hook still
+  passes, preserving today's no-op-hook behavior).
+- **Effective record score** (scored tasks only) =
+  `healthy ∧ gatesPass ∧ judgePass ? score : 0`. Full marks does not zero it —
+  a fractional score with verdict `fail` is the point.
+- Hooks never manage exit codes for checks; they end `exit 0`. Early
+  `exit 0` after emitting a failing gate row is the documented
+  dependency-chain pattern (nothing downstream can be asserted).
 
 ## Components
 
 | Component | Where | Responsibility |
 | --- | --- | --- |
-| `deriveScore(details)` | new `benchmark/score.js` | Pure: apply § convention, return `{score, fullMarks, malformed}` or `null`. Sole home of the arithmetic and the full-marks predicate. |
-| Verdict + score composition | `benchmark/runner.js` `#executeCell` | Effective score: `null` when derivation is `null`; `0` when the invariants exit code or the judge gate fails; the derived score otherwise. Verdict: `pass` iff every gate passes ∧ (derivation is `null` ∨ `fullMarks`). Preflight-failure records never reach this path and stay exactly as today (no invariants, no score); their zero is realized in aggregation per spec requirement 4. |
-| Record schema | `benchmark/result.js` | Optional `score` (number, 0–1) and optional `malformedChecks` (integer, present only when > 0) on the happy record and on the invariants record, so the report reads both off the record without re-deriving from details. Preflight records are unchanged. |
-| `invariants` subcommand | `commands/benchmark-invariants.js` | Same derivation and the same gate composition as `run` (invariants exit code ≠ 0 → record score 0), so hook authoring iterates against the real contract. The record's existing `exitCode` field keeps mirroring the script's exit; the CLI *process* exits non-zero when the gate fails or `fullMarks` is false — the invariants-gate ∧ full-marks portion of `run`'s cell verdict (no judge runs here). |
-| Report aggregation | `benchmark/report.js` | A task group is scored when ≥ 1 record carries `score`. Per scored task: `meanScore` and `scoreAtK[k]` (§ Estimator). A record without `score` in a scored group contributes its verdict as the degenerate score — pass = 1, fail = 0 — so a preflight failure drags the mean down and a pre-conversion passing cell does not (its old verdict already asserted full marks). |
-| Report rendering | `benchmark/report.js` | Text: the pass@k table gains `score` and `score@k` columns only when the report contains a scored task (judged rows render `—`); the per-task runs table gains a `Score` column under the same condition; records with `malformedChecks` render a warning in the task detail. JSON: fields appear on scored tasks only. |
-| `fit-trace assert --weight` | `commands/assert.js` + the CLI definition in `bin/fit-trace.js` | Optional flag; validates a positive number; adds `weight` to the emitted row. Keeps the documented authoring contract able to author scored checks without hand-written JSON. |
-| Leading example | `benchmarks/kata-skills/tasks/implement-feature/hooks/` | Gate: app present + the **baseline** suite green, run against pristine baseline tests restored from `$HOOKS_DIR` first (the agent-editable copy in `app/test/` cannot vouch for itself; the same restore-from-hooks move the hidden test already uses). The `hooks/` copy duplicates the family `workdir/` baseline test — an accepted drift pair, since `$FAMILY_DIR` is absent under the `invariants` subcommand; the family README names the pair. Score: the hidden feature suite split into one test file per scored check; each runs as its own `node --test` invocation and its exit status becomes one `weight: 1` row — the process-exit analog of the assert helper, with no reporter parsing. Judge (scope discipline) unchanged. Family README rows updated. |
-| Docs | `fit-benchmark` SKILL.md, `references/authoring.md`, `references/cli.md`, Run a Benchmark guide, `benchmarks/README.md` | Scored vs judged shapes, the row convention, the exit-code contract and gate/score helper split, gate-protection semantics, report columns, and when to author which shape. |
+| `gradeInvariants(details, exitCode)` | new `benchmark/grade.js` | Pure: apply § row contract, return `{verdict, gatesPass, score, fullMarks, malformed}` (`score` null for binary tasks). Sole home of the arithmetic. |
+| Invariants result | `benchmark/invariants.js` | Verdict comes from `gradeInvariants` (today: `exitCode === 0`). The result carries `verdict`, `details`, `exitCode` (diagnostic mirror), and the grade fields `gatesPass`, `score?`, `malformed?`. Unparseable fd-3 lines stop being `parseError` diagnostics and enter grading as malformed rows. |
+| Cell composition | `benchmark/runner.js` `#executeCell` | Cell verdict: `invariants.verdict ∧ judge` (unchanged shape). Record score per § contract's effective-score rule; `malformedChecks` when > 0. Preflight-failure records never reach the hook and stay score-free; their zero is realized in aggregation (spec requirement 9). |
+| Record schema | `benchmark/result.js` | Optional `score` (number, 0–1) and `malformedChecks` (integer ≥ 1) on the happy record and the invariants record; preflight branch pins both `undefined`. |
+| `invariants` subcommand | `commands/benchmark-invariants.js` | Same grading via `runInvariants`; the CLI process exits 0 iff the invariants verdict is `pass`, so hook authoring iterates against the real contract without agent runs. The record's `exitCode` field keeps mirroring the script. |
+| Report aggregation | `benchmark/report.js` | A task group is scored when ≥ 1 record carries `score`. Per scored task: `meanScore` and `scoreAtK[k]` (§ Estimator). A record without `score` in a scored group contributes its verdict as the degenerate score — pass = 1, fail = 0 — so a preflight failure drags the mean down instead of vanishing from the denominator. |
+| Report rendering | `benchmark/report.js` | Text: the pass@k table gains `score` and `score@k` columns only when the report contains a scored task (binary rows render `—`); the per-task runs table gains a `Score` column under the same condition; records with `malformedChecks` render a warning in the task detail. JSON: fields appear on scored tasks only. |
+| `fit-trace assert --gate/--weight` | `commands/assert.js` + the CLI definition in `bin/fit-trace.js` | `--weight` validates a finite number > 0 and adds `weight`; `--gate` adds `gate: true`; combining them is an error. **Emit-then-fail:** an invalid grading flag emits a *failing* row (`{"test": …, "pass": false, "message": …}`) before the nonzero exit, so a typo shrinks the score, never the denominator. |
+| Hook migration | `benchmarks/*/tasks/*/hooks/invariants.sh`, libharness `test/fixtures/` | § Migration. One helper — `check() { fit-trace assert "$@" >&"$RESULTS_FD" \|\| true; }` — no `FAIL` bookkeeping, `exit 0` at the end. |
+| Leading example | `benchmarks/kata-skills/tasks/implement-feature/hooks/` | Gate row: the **pristine baseline** suite restored from `$HOOKS_DIR` and run alone (the agent-editable copy cannot vouch for itself). Scored rows: the hidden feature suite split into one test file per check; each `node --test` invocation's exit status becomes one weight-1 row. Judge (scope discipline) unchanged. |
+| Docs | `fit-benchmark` SKILL.md, `references/authoring.md`, `references/cli.md`, Run a Benchmark guide, `benchmarks/README.md` | Rows-authoritative contract, roles table, exit-code demotion, gate-vs-scored authoring guidance, report columns. |
 
 ## Key Decisions
 
 | Decision | Choice | Rejected alternative |
 | --- | --- | --- |
-| How a task declares itself scored | Row-level `weight` on fd-3 check rows | A `{"score": 0.8}` summary row — every hook reimplements the arithmetic, rounding drifts across families, and per-check evidence is lost. A manifest/flag — configuration that can contradict what the rows actually contain. |
-| Verdict for scored cells | `pass` requires gates ∧ full marks | Gates-only verdict — pass@k saturates on partially-solved tasks and `run`'s exit code goes green on partial capability, breaking CI semantics. |
-| Gate failure vs score | A failed invariants/judge gate forces record score 0; row-less failures resolve at aggregation | Reporting the raw score alongside a failed gate — a cell that hacked the scaffold or flunked the scope judge could mint high scores into the mean, which is the gaming vector the gates exist to close. |
-| Malformed scored rows | Count as failing scored checks + surfaced warning (§ convention) | Silently ignoring them — see the convention's rationale. Failing the whole hook — turns a diagnostic-quality issue into a gate failure, zeroing runs that mechanically completed work. |
-| Where the score is computed | At record time, one pure function, two callers | At report time from `details` — every downstream consumer re-implements weighting, and ledgers stop being self-describing. |
-| Score-less records in a scored group | Degenerate verdict score: pass = 1, fail = 0 | Skipping them — inflates the mean exactly when the agent fails hardest (preflight failures vanish from the denominator). Counting all as 0 — deflates pre-conversion passing cells that the Compatibility section promises merge cleanly. |
+| Grading channel | Single: the rows, with roles as row fields | Dual channel (weights beside an authoritative exit code — this design's first draft): grading semantics split across a data and a process channel, coupled by a documentation-only contract where one wrong helper zeroes every partial run. |
+| Exit code | Demoted to script health: nonzero → run fails, score 0 | Ignored entirely — a hook that crashes after one passing row would score 1.0; the exit code is the one completion signal a crash cannot fake. A terminal sentinel row — more protocol for the same guarantee. |
+| Gate semantics | A row role (`gate: true`), multiplicative: fail → score 0 | Encoding gates as huge weights — additive weights cannot express "this failing must zero everything", and the attempt reintroduces the distinction it removes, worse. |
+| Default weight | Absent `weight` = scored at 1; diagnostics opt out with `weight: 0` | Opt-in weights (rows without `weight` stay decorative) — leaves most emitted evidence ungraded and requires the dual-channel contract to gate anything. |
+| Malformed rows | Failing scored check + surfaced count (§ contract) | Silently ignoring them — mints full marks from broken hooks. Failing the whole run — turns a diagnostic-quality issue into a total zero for mechanically completed work. |
+| Unparseable fd-3 lines | Malformed (graded), no longer `parseError` diagnostics | Keeping them diagnostic — under a rows-authoritative contract, a garbled line may be a lost check; skipping it silently shrinks the denominator. |
+| Where the score is computed | At record time, one pure function, called inside `runInvariants` | At report time from `details` — every downstream consumer re-implements weighting, and ledgers stop being self-describing. |
+| Verdict for scored cells | `pass` requires health ∧ gates ∧ full marks ∧ judge | Gates-only verdict — pass@k saturates on partially-solved tasks and `run`'s exit code goes green on partial capability, breaking CI semantics. |
+| Score-less records in a scored group | Degenerate verdict score: pass = 1, fail = 0 | Skipping them — inflates the mean exactly when the agent fails hardest (preflight failures vanish from the denominator). |
 | Best-of-k statistic | Exact expected-max via order statistics (§ Estimator) | Mean only — hides best-case capability and is asymmetric with pass@k. Monte Carlo — nondeterministic reports for the same ledger. |
-| Leading example | Convert `implement-feature`; emit rows directly from per-file `node --test` exit codes | A new synthetic task — duplicates fixture maintenance and cannot demonstrate the gate + score + judge composition authors must copy. Parsing one suite's TAP output — couples the hook to reporter format and test-name escaping. |
-| Weight authoring surface | Extend `fit-trace assert`; document the direct-emission pattern for process-exit checks | Raw `echo` JSON as the only path — leaves the documented assertion contract unable to author the new shape for file/content checks, forcing authors off the recommended path. |
+| Compatibility | None: clean break, all hooks migrate in-change | A shim honoring exit-code verdicts for row-less hooks — permanent dual semantics, and the only consumers are our own nine hooks plus four fixtures. |
+| Leading example | Convert `implement-feature`; emit rows directly from per-file `node --test` exit codes | A new synthetic task — duplicates fixture maintenance and cannot demonstrate the gate + score + judge composition authors must copy. Parsing one suite's TAP output — couples the hook to reporter format. |
 
 ## Estimator
 
@@ -107,26 +118,43 @@ the existing pass@k field carries, so the two estimators expose one idiom.
 ## Interfaces
 
 ```js
-// benchmark/score.js
-deriveScore(details) // → {score: number, fullMarks: boolean, malformed: number} | null
+// benchmark/grade.js
+gradeInvariants(details, exitCode)
+// → {verdict: "pass"|"fail", gatesPass: boolean,
+//    score: number|null, fullMarks: boolean, malformed: number}
+
+// InvariantsResult — verdict now row-derived; grade fields added
+{ verdict, details, exitCode, gatesPass, score?: number, malformed?: number, stderr? }
 
 // ResultRecord (happy branch) — additive
-{ …existing, score?: number, malformedChecks?: number }  // absent on judged tasks
-
-// InvariantsRecord — additive
-{ taskId, invariants, exitCode, score?: number, malformedChecks?: number }
+{ …existing, score?: number, malformedChecks?: number }  // absent on binary tasks
 
 // report JSON — additive, scored tasks only
 task: { …existing, meanScore?: number, scoreAtK?: Record<k, number|{error: string}> }
 ```
 
-## Compatibility
+## Migration
 
-Judged tasks and existing ledgers are untouched: no weighted rows → `null`
-derivation → no `score` field → no report columns. The schema changes are
-additive optional fields, so old records validate, and mixed old/new shard
-merges aggregate under the degenerate-score rule above. The judge template
-contract, hook environment, sharding, and the composite action are unchanged —
-the new report columns flow through the existing step-summary path.
+All nine family hooks and four fixture hooks move in this change. The common
+mechanical rewrite: drop `FAIL` bookkeeping, end with `exit 0`, mark
+presence/sanity checks `--gate`, leave content checks as default-weight scored
+rows, keep early `exit 0` after a failing dependency gate.
+
+| Hook | Gate rows | Scored rows |
+| --- | --- | --- |
+| coaligned/author-job | jtbd-present | 6 tag/section checks |
+| coaligned/bootstrap-repo | 3 presence checks | 6 content checks |
+| fit-wiki/cli-fix (also rewrites `{"id","verdict"}` rows to `test`/`pass`) | summary-intact, memory-intact (anti-tamper) | audit-passes |
+| kata/coordinate-finding | issue-present, change-present | 3 linkage checks |
+| kata/design-feature | file-present, under-200-lines (review Blocker) | has-decisions, names-tradeoff |
+| kata/implement-feature | app-present, baseline-tests (pristine restore) | 5 per-file hidden feature checks |
+| kata/plan-feature | file-present | 4 structure checks |
+| kata/product-issue-triage | issue-present | 3 triage-evidence checks |
+| kata/spec-feature | file-present, no-how-leak (constraint) | 3 section checks + cites-jtbd |
+| fixtures pass/fail/repo-state/preflight-broken | role per existing single check | — |
+
+Pre-migration ledgers still render — records carry their verdicts — but no
+score comparison may span the semantics break; the first post-break run
+starts a fresh baseline.
 
 — Staff Engineer 🛠️

--- a/specs/2240-scored-benchmark-tasks/plan-a.md
+++ b/specs/2240-scored-benchmark-tasks/plan-a.md
@@ -2,148 +2,155 @@
 
 Implements [design-a.md](design-a.md) for [spec 2240](spec.md).
 
-**Approach.** Build bottom-up along the design's data flow: the pure derivation
-first, then the schemas that carry its output, then the two callers (runner,
-`invariants` subcommand), then report aggregation and rendering, then the
-authoring surface (`fit-trace assert --weight`), the `implement-feature`
-conversion, and finally documentation. Every step lands with its tests; judged
-tasks flow through untouched code paths at each step, so the existing suite
-doubles as the compatibility check (spec criterion 2). The design's paths
-predate the current layout: benchmark modules live under
+**Approach.** Build bottom-up along the design's data flow: the pure grading
+derivation first, then the invariants integration and schemas that carry its
+output, then the runner and the `invariants` subcommand, then report
+aggregation and rendering, then the authoring surface (`fit-trace assert
+--gate/--weight`), then the migration — fixtures and their suites before the
+nine family hooks — and finally documentation. This is a clean break: existing
+suites that assert exit-code-derived verdicts are updated to the row contract,
+not preserved. Benchmark modules live under
 `libraries/libharness/src/benchmark/` and CLI handlers under
-`libraries/libharness/src/commands/`; the fit-trace CLI definition is inline in
-`libraries/libharness/bin/fit-trace.js`.
+`libraries/libharness/src/commands/`; the fit-trace CLI definition is inline
+in `libraries/libharness/bin/fit-trace.js`.
 
-Libraries used: libharness (benchmark runner/report/result, fit-trace assert),
-zod (record schemas), libmock + libutil (test runtimes).
+Libraries used: libharness (benchmark runner/report/result/invariants,
+fit-trace assert), zod (record schemas), libmock + libutil (test runtimes).
 
-## Step 1: Score derivation module
+## Step 1: Grading module
 
-One pure function owning the arithmetic of design § The scored-row convention.
+One pure function owning the arithmetic of design § The row contract.
 
-- Created: `libraries/libharness/src/benchmark/score.js`,
-  `libraries/libharness/test/benchmark-score.test.js`
+- Created: `libraries/libharness/src/benchmark/grade.js`,
+  `libraries/libharness/test/benchmark-grade.test.js`
 
-`deriveScore(details)` → `{score, fullMarks, malformed} | null`:
+`gradeInvariants(details, exitCode)` →
+`{verdict, gatesPass, score, fullMarks, malformed}`:
 
-- Skip rows that are not plain objects (the fd-3 parser pushes any valid JSON
-  line verbatim, so a bare `null`, number, or string reaches `details`) and
-  rows carrying `parseError` — both diagnostic only, never scored.
-- A row is a scored check iff it has a `weight` key (`Object.hasOwn`).
-- A scored check is **valid** iff `weight` is a finite number > 0 and `pass`
-  is a boolean; otherwise it is malformed and counts as failing.
-- Denominator: valid checks at their own weight; malformed checks with an
-  invalid weight at unit weight 1; malformed checks with a valid weight at
-  their own value. Numerator: valid checks with `pass === true`.
-- `malformed` = malformed-check count. `fullMarks` = integer count predicate:
+- Classify each details row per the contract's role order: diagnostic
+  (`weight === 0`), gate (`gate === true`, boolean `pass`, no positive
+  weight), scored (boolean `pass`, `weight` absent → 1 or finite > 0),
+  else malformed. Rows the fd-3 parser marked `parseError` are malformed.
+  Non-object rows (a bare `null`, number, or string is valid JSON and reaches
+  `details` verbatim) are malformed.
+- Malformed → failing scored check: own weight when it carries a valid finite
+  weight > 0, else unit weight 1; increments `malformed`.
+- `score = Σ weight(passing scored) / Σ weight(all scored)`; `null` when zero
+  scored checks (binary task).
+- `gatesPass` = every gate row passes (vacuously true).
+- `fullMarks` = integer count predicate:
   `malformed === 0 && passingCount === scoredCount` — never a float
-  comparison against `score === 1`.
-- Zero scored checks → return `null`.
+  comparison against `score === 1`. Vacuously true with zero scored checks.
+- `verdict` = `exitCode === 0 && gatesPass && fullMarks ? "pass" : "fail"`.
 
-Test cases: weighted fraction over mixed weights; unweighted rows ignored;
-all-diagnostic details → `null`; invalid weight (string, 0, negative,
-Infinity, NaN) → failing at unit denominator weight + `malformed` counted;
-valid weight with missing/non-boolean `pass` → failing at own weight;
-`parseError` rows and non-object rows (`null`, `42`, `"text"`) skipped
-without throwing; `fullMarks` true only when every scored check is
-valid and passing; fractional weights (e.g. 0.1 × 3) still yield
+Test cases: weighted fraction over mixed weights; absent weight defaults to
+1; `weight: 0` rows ignored; gate rows excluded from the score; failing gate
+→ `gatesPass` false with score still derived; exit 1 with all-passing rows →
+verdict fail (crash cannot mint marks); zero scored checks → `score: null`
+and row-less exit-0 → verdict pass (no-op-hook behavior); malformed shapes
+(missing/non-boolean `pass`, non-boolean `gate`, `gate` + positive `weight`,
+negative/Infinity/NaN/string weight, `parseError` row, non-object row) each
+counted failing at the documented weight; `fullMarks` true only when every
+scored check is valid and passing; fractional weights (0.1 × 3) still yield
 `fullMarks: true` when all pass.
 
-Verification: `bun test test/benchmark-score.test.js` in `libraries/libharness`.
+Verification: `bun test test/benchmark-grade.test.js` in
+`libraries/libharness`.
 
-## Step 2: Record schemas
+## Step 2: Invariants integration + record schemas
 
-Additive optional `score` / `malformedChecks` on both record shapes.
+Row-derived verdict inside `runInvariants`; additive schema fields.
 
-- Modified: `libraries/libharness/src/benchmark/result.js`,
-  `libraries/libharness/test/benchmark-result.test.js`
+- Modified: `libraries/libharness/src/benchmark/invariants.js`,
+  `libraries/libharness/src/benchmark/result.js`, their tests
+
+`invariants.js`: after parsing the fd-3 buffer, call `gradeInvariants`;
+the result becomes `{verdict, details, exitCode, gatesPass, score?,
+malformed?, stderr?}` — `verdict` no longer `exitCode === 0`, `exitCode`
+kept as the diagnostic mirror, `score`/`malformed` present only when
+non-null/positive. The absent-hook early return keeps
+`{verdict: "pass", details: [], exitCode: 0, gatesPass: true}`.
+
+`result.js`:
 
 | Schema | Change |
 | --- | --- |
-| `HAPPY_RECORD` | `score: z.number().min(0).max(1).optional()`, `malformedChecks: z.number().int().min(1).optional()` |
+| `HAPPY_RECORD` | `score: z.number().min(0).max(1).optional()`, `malformedChecks: z.number().int().min(1).optional()`; the embedded invariants object accepts the new grade fields |
 | `PREFLIGHT_RECORD` | both as `z.undefined().optional()` (branch stays score-free) |
 | `INVARIANTS_RECORD_SCHEMA` | same two optional fields as `HAPPY_RECORD` |
 
-Tests: happy record with `score: 0.6` accepted; `score: 1.5` and `score: -0.1`
-rejected; `malformedChecks: 0` rejected; preflight record with a `score`
-rejected; invariants record with `score` + `malformedChecks` accepted; the
-existing fixtures pass unmodified.
+Tests: existing invariants unit tests updated to the row contract (exit 1 +
+passing rows → fail; failing gate row + exit 0 → fail; failing scored row +
+exit 0 → fail with fractional score on the result); schema accept/reject
+cases (`score: 1.5`, `malformedChecks: 0`, preflight with `score` rejected).
 
-Verification: `bun test test/benchmark-result.test.js`.
+Verification: `bun test test/invariants.test.js test/benchmark-result.test.js`
+(actual invariants test filename per repo layout).
 
-## Step 3: Runner verdict + score composition
+## Step 3: Runner composition
 
-Compose gates, full marks, and effective score in `#executeCell`.
+Cell verdict and effective score in `#executeCell`.
 
 - Modified: `libraries/libharness/src/benchmark/runner.js`
 - Created: `libraries/libharness/test/benchmark-runner-score.test.js`
 
-In `#executeCell`, after the judge block:
+The existing composition `invariants.verdict ∧ judge` already yields the
+spec's verdict now that `invariants.verdict` is row-derived. Add the record
+fields:
 
 ```js
-const derivation = deriveScore(invariants.details);
-const gatesPass =
-  invariants.verdict === "pass" &&
-  (judgeVerdict === null || judgeVerdict.verdict === "pass");
-const verdict =
-  gatesPass && (derivation === null || derivation.fullMarks) ? "pass" : "fail";
-// on the record:
-...(derivation && { score: gatesPass ? derivation.score : 0 }),
-...(derivation && derivation.malformed > 0 && { malformedChecks: derivation.malformed }),
+const judgePass = judgeVerdict === null || judgeVerdict.verdict === "pass";
+const scoreValid =
+  invariants.exitCode === 0 && invariants.gatesPass && judgePass;
+...(invariants.score != null && { score: scoreValid ? invariants.score : 0 }),
+...(invariants.malformed > 0 && { malformedChecks: invariants.malformed }),
 ```
 
-The preflight branch and `#buildPreflightFailureRecord` are untouched (design:
-row-less zeros resolve at aggregation).
+The preflight branch and `#buildPreflightFailureRecord` are untouched
+(row-less zeros resolve at aggregation).
 
-Tests mirror the `benchmark-runner-concurrency.test.js` setup — fixture family
-`test/fixtures/benchmark-family`, `task: "pass"`, `runs: 1`, injected
-`runAgent`/`runJudge`/`runInvariants` seams; each case injects an
-`InvariantsResult` and asserts the yielded record:
+Tests mirror the `benchmark-runner-concurrency.test.js` setup (fixture
+family, injected `runAgent`/`runJudge`/`runInvariants` seams); each case
+injects an `InvariantsResult` and asserts the yielded record:
 
 | Injected invariants / judge | Expected record |
 | --- | --- |
-| exit 0, weighted 2 pass + 1 fail (w=1), judge pass | `verdict: "fail"`, `score ≈ 2/3` |
-| exit 0, all weighted pass, judge pass | `verdict: "pass"`, `score: 1` |
-| exit 1, all weighted rows passing | `verdict: "fail"`, `score: 0` |
-| exit 0, all weighted pass, judge **fail** | `verdict: "fail"`, `score: 0` |
-| exit 0, unweighted rows only | no `score` key, `verdict: "pass"` |
-| exit 0, one malformed weighted row | `verdict: "fail"`, `malformedChecks: 1` |
+| healthy, gates pass, scored 2/3, judge pass | `verdict: "fail"`, `score ≈ 2/3` |
+| healthy, gates pass, full marks, judge pass | `verdict: "pass"`, `score: 1` |
+| exit 1, all rows passing | `verdict: "fail"`, `score: 0` |
+| healthy, failing gate row, scored rows passing | `verdict: "fail"`, `score: 0` |
+| healthy, full marks, judge **fail** | `verdict: "fail"`, `score: 0` |
+| healthy, gate rows only (binary) | no `score` key, verdict from gates |
+| one malformed row | `verdict: "fail"`, `malformedChecks: 1` |
 
 Every record must pass `validateResultRecord`.
 
-Verification: `bun test test/benchmark-runner-score.test.js` plus the existing
-runner/e2e suites unmodified.
+Verification: `bun test test/benchmark-runner-score.test.js`.
 
 ## Step 4: `invariants` subcommand
 
-Same derivation, invariants-gate ∧ full-marks process exit (no judge here).
+Process exit mirrors the row-derived verdict.
 
 - Modified: `libraries/libharness/src/commands/benchmark-invariants.js`,
-  `libraries/libharness/test/benchmark-invariants.integration.test.js`
-  (gains a command-level `describe` block; at 144 lines it has ample room)
+  `libraries/libharness/src/commands/benchmark-definition.js` (the command
+  description stops saying the exit code is authoritative),
+  `libraries/libharness/test/benchmark-invariants.integration.test.js`,
+  `test/golden/fit-benchmark/` help goldens (deliberate refresh — the old
+  description states the old contract)
 
-After `runInvariants`: derive, and compute the gate **once** —
-`const gatePass = invariants.verdict === "pass"` — used for both faces (the
-same `verdict` idiom Step 3 uses; never re-derive from `exitCode`). The record
-gains `score` (`gatePass ? derivation.score : 0`) and `malformedChecks` when
-> 0, both only when derivation is non-`null`. The record's `exitCode` field
-keeps mirroring the script. The command's return becomes `ok` iff
-`gatePass && (derivation === null || derivation.fullMarks)`.
+The command's return is `ok` iff `invariants.verdict === "pass"`. The record
+gains `score` / `malformedChecks` straight off the invariants result (no
+judge runs here; the runner's judge-zeroing does not apply). The record's
+`exitCode` field keeps mirroring the script.
 
-Do **not** touch the command's description or the examples in
-`src/commands/benchmark-definition.js` — the `test/golden/fit-benchmark/`
-help goldens capture them.
+Tests: on-disk family under `mkdtemp` (`agent.task.md` +
+`hooks/invariants.sh`, `chmod 0o755`), `createDefaultRuntime()`, `--output`
+to a temp file: partial scored emission + exit 0 → record `score` fractional,
+`ok: false`; full marks → `ok: true`, `score: 1`; passing rows + exit 1 →
+`score: 0`, `ok: false`; gate rows only → no `score` key.
 
-Tests: build a minimal on-disk family (`mkdtemp` root with
-`tasks/t1/agent.task.md` + `tasks/t1/hooks/invariants.sh`, the script
-`chmod 0o755` — the task loader treats a non-executable hook as absent) and
-invoke `runBenchmarkInvariantsCommand` with `createDefaultRuntime()` and
-`--output` pointing at a temp file (avoids stdout capture): partial weighted
-emission → record `score` fractional, return `ok: false`; full marks + exit 0
-→ `ok: true`, `score: 1`; exit 1 with passing weighted rows → `score: 0`; no
-weighted rows → record has no `score` key and today's exit semantics.
-
-Verification: `bun test test/benchmark-invariants.integration.test.js`.
+Verification: `bun test test/benchmark-invariants.integration.test.js` and
+the refreshed goldens.
 
 ## Step 5: Report aggregation
 
@@ -151,165 +158,153 @@ Verification: `bun test test/benchmark-invariants.integration.test.js`.
 
 - Modified: `libraries/libharness/src/benchmark/report.js`
 - Created: `libraries/libharness/test/benchmark-report-score.test.js`,
-  `libraries/libharness/test/report-helpers.js` (`benchmark-report.test.js`
-  is 420 lines, already over the 400-line target in
-  `.claude/rules/test-file-shape.md` — new coverage goes in the sibling, and
-  the `baseRecord`/`jsonlRuntime` setup already copy-pasted between
-  `benchmark-report.test.js` and `benchmark-report-merge.test.js` is lifted
-  into the helper, which the new sibling imports; migrating the two existing
-  files onto it is optional and out of scope)
+  `libraries/libharness/test/report-helpers.js` (lift the
+  `baseRecord`/`jsonlRuntime` setup copy-pasted between
+  `benchmark-report.test.js` and `benchmark-report-merge.test.js`; migrating
+  the two existing files onto it is optional and out of scope)
 
 In `aggregate`, per task group:
 
 - Group is scored iff `group.some((r) => r.score !== undefined)`.
 - Effective per-record score: `r.score ?? (r.verdict === "pass" ? 1 : 0)`
-  (degenerate rule).
-- `task.meanScore` = mean of effective scores; `task.scoreAtK[k]` for each
-  `kValues` entry via the design § Estimator: sort effective scores ascending,
+  (degenerate rule — covers preflight failures that never reached the hook).
+- `task.meanScore` = mean of effective scores; `task.scoreAtK[k]` per design
+  § Estimator: sort effective scores ascending,
   `score@k = Σ_{i=k..n} s₍ᵢ₎ · C(i−1, k−1) / C(n, k)` using the existing
   BigInt `binomial` helper (`Number()` the two coefficients, same idiom as
   `passAtKValue`); `k > n` → `{error: "k > n"}`.
-- Judged groups gain neither field (JSON additive, scored tasks only).
+- Binary groups gain neither field (JSON additive, scored tasks only).
 
-Tests: binary 0/1 scores reproduce `passAtK` within `1e-12` for a pass/fail
-mix (the per-term summation can drift a ulp from `passAtKValue`'s single
-division — assert closeness, not strict equality); fractional case scores
-`[0.5, 1]` → `score@1 = 0.75`, `score@2 = 1`; mixed
-group (scored records + a score-less preflight fail + a score-less pass) →
-mean applies 0 and 1 degenerates; group with no `score` on any record → no
-`meanScore`/`scoreAtK` keys; `k > n` error shape.
+Tests: binary 0/1 scores reproduce `passAtK` within `1e-12` (per-term
+summation can drift a ulp from the single-division form — assert closeness);
+fractional scores `[0.5, 1]` → `score@1 = 0.75`, `score@2 = 1`; mixed group
+(scored records + a score-less preflight fail + a score-less pass) applies
+0 and 1 degenerates; all-binary group → no `meanScore`/`scoreAtK` keys;
+`k > n` error shape.
 
-Verification: `bun test test/benchmark-report-score.test.js` plus
-`benchmark-report.test.js` / `benchmark-report-merge.test.js` unmodified.
+Verification: `bun test test/benchmark-report-score.test.js`.
 
 ## Step 6: Report rendering
 
 Score columns and malformed warnings, only when the report contains a scored
 task.
 
-- Modified: `libraries/libharness/src/benchmark/report.js` (same PR-step file,
-  rendering half), tests in `benchmark-report-score.test.js`
+- Modified: `libraries/libharness/src/benchmark/report.js` (rendering half),
+  tests in `benchmark-report-score.test.js`
 - `buildRunDetail` copies `score` and `malformedChecks` onto the run detail.
 - Compute the report-level condition once — `report.tasks.some((t) =>
-  t.meanScore !== undefined)` — and thread it as a parameter through
-  `renderFullReport` → `renderTaskDetail` → `renderRunsTable` (a signature
-  change to those private renderers).
+  t.meanScore !== undefined)` — and thread it through `renderFullReport` →
+  `renderTaskDetail` → `renderRunsTable`.
 - `renderPassAtKTable`: under that condition, append a `score` column (mean,
-  `toFixed(4)`) and one `score@{k}` column per k; judged rows render `—`.
-  No scored task → byte-identical table.
+  `toFixed(4)`) and one `score@{k}` column per k; binary rows render `—`.
 - `renderRunsTable`: append a `Score` column under the same condition (`—`
   for score-less runs).
-- Task detail: for each run with `malformedChecks`, add a bullet to the
-  Errors section: `- **Run N:** ⚠️ M malformed scored check row(s) — counted
-  as failing`.
+- Task detail: for each run with `malformedChecks`, an Errors bullet:
+  `- **Run N:** ⚠️ M malformed check row(s) — counted as failing`.
 
-Tests: text report over a mixed ledger shows the new columns with `—` on the
-judged row; a judged-only ledger renders **no** `score`/`score@`/`Score`
-column and no score keys in JSON (the unmodified `benchmark-report.test.js`
-assertions are the judged-unchanged proof — no snapshot capture needed);
+Tests: mixed ledger shows the new columns with `—` on the binary row; a
+binary-only ledger renders no score columns and no score keys in JSON;
 malformed warning renders; compact report gains the same pass@k-table columns
 (it shares `renderPassAtKTable`).
 
-Verification: `bun test test/benchmark-report-score.test.js`; SC6 covered by
-the mixed-ledger case.
+Verification: `bun test test/benchmark-report-score.test.js`.
 
-## Step 7: `fit-trace assert --weight`
+## Step 7: `fit-trace assert --gate` and `--weight`
 
-Weight emission through the standard assertion helper.
+Role flags on the standard assertion helper, emit-then-fail on bad input.
 
 - Modified: `libraries/libharness/src/commands/assert.js`,
   `libraries/libharness/bin/fit-trace.js`,
   `libraries/libharness/test/assert.test.js`
-- CLI definition (assert command options in `bin/fit-trace.js`): add
-  `weight: { type: "string", description: "Attach a positive numeric weight
-  to the emitted row, marking it a scored check" }`. Do not add examples —
-  the top-level help golden lists commands and examples only, so the option
-  is golden-neutral.
-- `evaluateAssertion`: when `values.weight` is present, `Number()` it; not a
-  finite number > 0 → throw `assert: --weight must be a positive number`;
-  otherwise set `output.weight` to the numeric value. Exit semantics
-  unchanged (the scored-helper `|| true` lives in the hook, not the command).
+- CLI definition: `weight` (string, "attach a numeric weight; 0 marks the row
+  diagnostic") and `gate` (boolean, "mark the row a gate check").
+- `evaluateAssertion`: `--gate` sets `output.gate = true`; `--weight` is
+  `Number()`ed — a finite number ≥ 0 sets `output.weight`, anything else is
+  invalid; `--gate` with a positive `--weight` is invalid. **Emit-then-fail:**
+  on an invalid combination, `runAssertCommand` still writes
+  `{"test": <name>, "pass": false, "message": "assert: <reason>"}` to stdout
+  before returning `{ok: false}`, so the row lands in the denominator as a
+  failing check instead of vanishing (spec requirement 10). Assertion-failure
+  exit semantics are otherwise unchanged (hooks append `|| true`; the exit
+  code no longer matters inside `invariants.sh`).
 
-Tests: weight appears on the emitted row (pass and fail cases); invalid
-weights (`0`, `-1`, `abc`) throw; no `--weight` → row byte-identical to today.
+Tests: `--gate` and `--weight` appear on emitted rows; `--weight 0` emits a
+diagnostic row; invalid weights (`-1`, `abc`) and `--gate --weight 2`
+emit a failing row *and* return `ok: false`; no flags → row byte-identical to
+today.
 
-Verification: `bun test test/assert.test.js` and the golden suite
-(`bin-smoke.integration.test.js`) unmodified.
+Verification: `bun test test/assert.test.js`; fit-trace help goldens refresh
+only if the new options surface in pinned output.
 
-## Step 8: Convert `implement-feature` to the leading scored example
+## Step 8: Migrate test fixtures and affected suites
 
-Gate on the pristine baseline, score per hidden feature test, keep the judge.
+The libharness suites become the first consumers of the new contract.
 
-- Created: `benchmarks/kata-skills/tasks/implement-feature/hooks/todo.test.js`
-  (byte-copy of `benchmarks/kata-skills/workdir/app/test/todo.test.js` — the
-  accepted drift pair), `hooks/feature-checks/feature-helpers.js` (no `.test.js`
-  suffix so it never runs as a test; exports the `appDir`/`bin` derivation, a
-  `store` loader, `runList`, and the sample todos — one home for the setup all
-  five checks share),
-  `hooks/feature-checks/{filter-selects-matching,filter-case-insensitive,filter-no-match,list-filter-output,list-no-filter}.test.js`
-  (one `node:test` case each, split from today's `feature.test.js`, each
-  importing `./feature-helpers.js` and deriving `appDir` as today)
-- Deleted: `hooks/feature.test.js`
-- Modified: `hooks/invariants.sh`, `benchmarks/kata-skills/README.md`
+- Modified: the four hooks under
+  `libraries/libharness/test/fixtures/benchmark-family/tasks/*/hooks/`,
+  plus every suite asserting exit-code-derived verdicts
+  (`benchmark-e2e.integration`, `benchmark-parity`,
+  `benchmark-runner-concurrency`, `benchmark-shard`, invariants tests)
 
-`invariants.sh` (gate exit code never reflects scored checks):
+Fixture rewrites (all end `exit 0`; roles keep the tasks binary so e2e
+verdict expectations and any score-free assertions hold):
 
-```sh
-#!/bin/sh
-set -u
-APP="$AGENT_CWD/app"
-FAIL=0
+| Fixture | Row |
+| --- | --- |
+| `pass` (service probe) | `{"test":"probe","pass":true/false,"gate":true}` |
+| `fail` | `{"test":"forced-fail","pass":false,"gate":true}` |
+| `repo-state` | `{"test":"file"/"sha", …, "gate":true}` |
+| `preflight-broken` | unchanged (unreachable) |
 
-if [ ! -d "$APP" ]; then
-  echo '{"test":"app-present","pass":false}' >&"$RESULTS_FD"
-  exit 1
-fi
+Sweep the suites for assertions on `invariants.exitCode`-as-verdict and
+update to row-role expectations. Add one e2e-level scored case only if the
+existing fixture family can absorb it cheaply; otherwise Step 3's seam tests
+carry the scored coverage.
 
-# Gate: pristine baseline restored from hooks/ (the agent-editable copy in
-# app/test/ cannot vouch for itself), run alone so agent-added test files
-# cannot flip the gate.
-cp "$HOOKS_DIR/todo.test.js" "$APP/test/todo.test.js"
-if (cd "$APP" && node --test test/todo.test.js >/dev/null 2>&1); then
-  echo '{"test":"baseline-tests","pass":true}' >&"$RESULTS_FD"
-else
-  echo '{"test":"baseline-tests","pass":false,"message":"baseline suite failed"}' >&"$RESULTS_FD"
-  FAIL=1
-fi
+Verification: full `bun test` in `libraries/libharness` green.
 
-# Scored checks: one hidden test file per check, its process exit is the row.
-cp "$HOOKS_DIR/feature-checks/feature-helpers.js" "$APP/test/"
-for CHECK in "$HOOKS_DIR"/feature-checks/*.test.js; do
-  NAME=$(basename "$CHECK" .test.js)
-  cp "$CHECK" "$APP/test/"
-  if (cd "$APP" && node --test "test/$(basename "$CHECK")" >/dev/null 2>&1); then
-    echo "{\"test\":\"$NAME\",\"pass\":true,\"weight\":1}" >&"$RESULTS_FD"
-  else
-    echo "{\"test\":\"$NAME\",\"pass\":false,\"weight\":1}" >&"$RESULTS_FD"
-  fi
-done
+## Step 9: Migrate the nine family hooks
 
-[ "$FAIL" = 0 ] && exit 0 || exit 1
-```
+Mechanical rewrite per design § Migration: one
+`check() { fit-trace assert "$@" >&"$RESULTS_FD" || true; }` helper, `--gate`
+on presence/sanity/anti-tamper checks, content checks left as default-weight
+scored rows, no `FAIL`, final `exit 0`, early `exit 0` after a failing
+dependency gate.
 
-`preflight.sh` and `judge.task.md` are unchanged. Family README: update the
-`implement-feature` grading cell (baseline gate, five weighted feature
-checks, scope judge), rewrite § Hidden tests for the split layout, and name
-the `hooks/todo.test.js` ↔ `workdir/app/test/todo.test.js` drift pair.
+- Modified: all nine `benchmarks/*/tasks/*/hooks/invariants.sh`, the three
+  family READMEs (grading rows per task)
+- `fit-wiki/cli-fix` additionally rewrites its nonstandard
+  `{"id","verdict"}` rows to `test`/`pass` shape (they would grade as
+  malformed under the row contract).
+- `implement-feature` gets the full leading-example conversion:
+  - Created: `hooks/todo.test.js` (byte-copy of `workdir/app/test/todo.test.js`
+    — an accepted drift pair, named in the family README; `$FAMILY_DIR` is
+    absent under the `invariants` subcommand),
+    `hooks/feature-checks/feature-helpers.js` (no `.test.js` suffix; shared
+    `appDir`/`bin` derivation, store loader, sample todos),
+    `hooks/feature-checks/{filter-selects-matching,filter-case-insensitive,filter-no-match,list-filter-output,list-no-filter}.test.js`
+    (one `node:test` case each, split from today's `feature.test.js`)
+  - Deleted: `hooks/feature.test.js`
+  - `invariants.sh`: `app-present` gate (early `exit 0` when missing);
+    restore the pristine baseline from `$HOOKS_DIR` and run it alone as the
+    `baseline-tests` gate row (the agent-editable copy cannot vouch for
+    itself; agent-added test files cannot flip the gate); then per check
+    file, `cp` + `node --test test/<file>` and emit
+    `{"test": <name>, "pass": <exit==0>}` — a default-weight scored row from
+    the process exit, no reporter parsing; end `exit 0`.
+  - `preflight.sh` and `judge.task.md` unchanged.
 
-Verification (SC 7/8, run locally, nothing committed): hand-build three
-`--run-dir` fixtures under `tmp/` — (a) `cwd/app` copied from the family
-`workdir/` plus a **partial** hand-written `filterTodos` (case-sensitive
-match, no CLI flag) → `bunx fit-benchmark invariants
---family=benchmarks/kata-skills --task=implement-feature --run-dir=…` exits 1
-with `0 < score < 1`; (b) a complete implementation → exits 0 with
-`score: 1`; (c) an empty `cwd/` → gate fail and **no** `score` key (the hook
-exits after the unweighted `app-present` row, so the derivation is `null`;
-that record's zero is realized at aggregation, per design).
+Verification (spec criteria 9–10, run locally, nothing committed):
+hand-build three `--run-dir` fixtures under `tmp/` — partial implementation
+→ `fit-benchmark invariants` reports `ok: false` with `0 < score < 1`;
+complete → `ok: true`, `score: 1`; empty `cwd/` → failing gate row, no
+`score` key. `grep -rn 'FAIL' benchmarks/*/tasks/*/hooks/invariants.sh`
+returns nothing. Spot-run one task per family end-to-end if budget allows.
 
-## Step 9: Documentation
+## Step 10: Documentation
 
-State the scored/judged distinction and the exit-code authoring contract on
-every surface the spec names.
+State the row contract and the exit-code demotion on every surface that
+states the old contract.
 
 - Modified: `.claude/skills/fit-benchmark/SKILL.md`,
   `.claude/skills/fit-benchmark/references/authoring.md`,
@@ -319,76 +314,70 @@ every surface the spec names.
 
 | Surface | Content |
 | --- | --- |
-| SKILL.md | Two-shape table (judged/scored, opt-in by emitted rows); Lifecycle step 3 gains one sentence: weighted rows make the task scored, exit code stays the gate; Result Records mentions the optional `score`. |
-| references/authoring.md | New § Scored tasks, placed inside the existing § invariants authoring contract so the gate helper is stated once and the scored variant sits beside it (the file already carries the gate snippet at two sites — do not add a third): gate `assert() { fit-trace assert "$@" >&"$RESULTS_FD" \|\| FAIL=1; }` vs scored `scored() { fit-trace assert "$@" >&"$RESULTS_FD" \|\| true; }` with `--weight`; the exit-code contract (a failing weighted check must not fail the gate); the process-exit direct-emission pattern (one JSON row per hidden test run); when to author scored vs judged; and the failure mode that an **invalid** `--weight` makes `assert` exit without emitting a row, which `\|\| true` then swallows — silently shrinking the denominator — so always validate scored hooks with `fit-benchmark invariants` against a fixture before paying for agent runs. |
-| references/cli.md | `invariants`: exit is now gate ∧ full-marks for scored tasks (record `exitCode` still mirrors the script); `report`: `meanScore`/`scoreAtK` fields and the score columns, degenerate rule one-liner. |
-| Run a Benchmark guide | Under `#### hooks/invariants.sh`: a `##### Scored tasks` subsection with the row convention and gate/score split; § Aggregate Into pass@k: bullets for mean score and `score@k` (expected best-of-k, continuous analog of pass@k). |
-| benchmarks/README.md | One paragraph in the task-family layout notes: a task whose `invariants.sh` emits `weight` rows is scored; exit code remains the gate. |
+| SKILL.md | Lifecycle step 3 rewritten: rows are authoritative, roles table (gate/scored/diagnostic), exit code = script health; Result Records mentions the optional `score`; Grading Surfaces examples updated to row emission. |
+| references/authoring.md | The invariants authoring contract rewritten around the single `check()` helper (no `FAIL` bookkeeping — both existing snippet sites): the roles table, default weight 1, `--gate` for presence/sanity/anti-tamper checks, `weight: 0` diagnostics, the crash rule (nonzero exit = grader failure, score 0), the early-`exit 0` dependency pattern, the process-exit direct-emission pattern, when a check is a gate versus scored, and validating hooks with `fit-benchmark invariants` before paying for agent runs. |
+| references/cli.md | `invariants`: process exit mirrors the row-derived verdict; `report`: `meanScore`/`scoreAtK` fields, score columns, degenerate rule one-liner. |
+| Run a Benchmark guide | `#### hooks/invariants.sh` rewritten to the row contract with a worked gate + scored example; § Aggregate Into pass@k gains mean score and `score@k` (expected best-of-k, continuous analog of pass@k). |
+| benchmarks/README.md | Layout notes: `invariants.sh — structural rubric; rows are the verdict (exit code = script health)`; one paragraph on gate vs scored rows. |
 
 Skill `## Documentation` lists and CLI `documentation` arrays are unchanged
 (no new guides), so the parity rule needs no edit.
 
 Verification:
-`rg -n 'weight' .claude/skills/fit-benchmark websites/fit/docs/libraries/prove-changes/run-benchmark benchmarks/README.md`
-shows every surface; `bun run check` passes (markdown format/lint).
+`rg -n 'exit code' .claude/skills/fit-benchmark websites/fit/docs/libraries/prove-changes/run-benchmark benchmarks/README.md`
+shows no surviving claim that the exit code is the verdict; `bun run check`
+passes.
 
-## Step 10: Full verification sweep
+## Step 11: Full verification sweep
 
 - Modified: none
 
-Run `bun run check` at the repo root and `bun test` in `libraries/libharness`.
-Confirm SC2 explicitly: `git diff --stat` shows no edits under
-`test/golden/` and the pre-existing benchmark suites
-(`benchmark-e2e.integration`, `benchmark-report`, `benchmark-report-merge`,
-`benchmark-parity`, `benchmark-shard`, `benchmark-runner-concurrency`) pass
-without modification.
-
-Verification: clean check + test output pasted into the PR.
+`bun run check` at the repo root and `bun test` in `libraries/libharness`.
+Golden diffs under `test/golden/` are expected **only** for the command
+descriptions Steps 4 and 7 deliberately touched; any other golden diff is a
+regression. Paste clean check + test output into the PR.
 
 ## Risks
 
-- **Baseline-gate scope narrows.** Today the gate runs the whole `app/test/`
-  suite, including files the agent added; after Step 8 it runs only the
-  restored pristine baseline. An agent leaving broken tests of its own no
-  longer fails the gate — intended (the gate guards regressions and scaffold
-  sanity; junk files are the scope judge's lane), but it is a behavior change
-  a reviewer comparing old ledgers should know about.
-- **Per-file hidden-test runs change failure granularity.** If the agent broke
-  `src/store.js` exports outright, today one suite fails once; after the
-  split every check file fails individually, yielding score 0 rather than a
-  single aggregate row. Same verdict, different detail rows — README's task
-  table must describe the new shape so ledger diffs aren't misread.
+- **Test blast radius.** Every suite that encodes "exit code is the verdict"
+  breaks by design. Step 8 does the sweep in one place, before the family
+  hooks move, so failures localize to the contract change rather than
+  smearing across migration commits.
+- **A crashed hook and a failed gate now look alike at the verdict level**
+  (both `fail`, score 0). They differ on the record — nonzero `exitCode` +
+  `stderr` versus a failing gate row — and the report's run detail shows
+  both; no aggregate distinguishes them, which is acceptable for now.
+- **Semantics break across ledgers.** Pre- and post-migration ledgers must
+  not be compared; the PR description and `benchmarks/README.md` say so, and
+  the first post-merge scheduled run starts the new baseline.
+- **Baseline-gate scope narrows** (`implement-feature`): the gate runs only
+  the restored pristine baseline, so an agent leaving broken tests of its own
+  no longer fails the gate — intended (junk files are the scope judge's
+  lane), but a behavior change reviewers should know.
+- **The judge now sees seven hook-copied files** in `implement-feature`'s
+  workdir (restored baseline, helpers, five check files). If the
+  scope-discipline judge starts flagging them as agent scope creep, amend
+  `judge.task.md` to exempt hook-restored test files — watch the first real
+  runs.
 - **Filename collisions in `app/test/`.** The hook `cp`s check files into the
-  agent-writable tree; an agent that happened to create a same-named file is
-  silently overwritten. Distinctive `feature-*`/`filter-*` names make this
-  unlikely; a collision only ever overwrites in the ephemeral CWD.
-- **The judge now sees seven hook-copied files.** The judge session runs
-  after invariants, so the workdir it inspects contains the restored
-  `todo.test.js`, `feature-helpers.js`, and five check files (today: one
-  copied file). If the scope-discipline judge starts flagging them as agent
-  scope creep, amend `judge.task.md` to exempt hook-restored test files —
-  watch the first real runs for this.
-- **`report.js` is nearing the file-length lint ceiling.** Steps 5 and 6 both
+  agent-writable tree; distinctive `filter-*`/`list-*` names make collisions
+  unlikely, and a collision only overwrites in the ephemeral CWD.
+- **`report.js` nearing the file-length lint ceiling.** Steps 5 and 6 both
   land in it; if the ceiling trips, extract the `scoreAtK` estimator next to
-  `deriveScore` in `score.js` (its natural second home) rather than waiving
-  the lint.
+  `gradeInvariants` in `grade.js` rather than waiving the lint.
 - **`Number(binomial(...))` overflow for very large n** in `scoreAtK` — the
-  same exposure the existing `passAtKValue` already carries; keeping the
-  idiom is deliberate (one estimator idiom, design § Estimator), not an
-  oversight to fix here.
-- **Golden sensitivity.** The fit-benchmark and fit-trace help goldens pin
-  command descriptions and examples; Steps 4 and 7 add behavior without
-  touching either. Any accidental description edit surfaces as a golden diff
-  in Step 10 — treat that as a regression, not a golden refresh.
+  same exposure `passAtKValue` already carries; keeping the idiom is
+  deliberate (one estimator idiom), not an oversight to fix here.
 
 ## Execution
 
 Single unit, one implementation PR. Steps 1→6 are sequential (each consumes
-the previous step's exports); Step 7 is independent and can interleave; Step 8
-depends on Step 4 (its verification uses the scored `invariants` subcommand);
-Step 9 last, after the contracts it documents are locked. Route the whole plan
-to an engineering agent via `kata-implement` — the documentation step cites
-helper code shipped in the same PR, so splitting it to `technical-writer`
-would only add a handoff.
+the previous step's exports); Step 7 is independent and can interleave;
+Step 8 depends on Steps 2–4; Step 9 depends on Steps 4 and 7 (hooks use the
+new flags and are validated with the scored `invariants` subcommand); Step 10
+last, after the contracts it documents are locked. Route the whole plan to an
+engineering agent via `kata-implement` — the documentation step cites helper
+patterns shipped in the same PR, so splitting it to `technical-writer` would
+only add a handoff.
 
 — Staff Engineer 🛠️

--- a/specs/2240-scored-benchmark-tasks/spec.md
+++ b/specs/2240-scored-benchmark-tasks/spec.md
@@ -1,13 +1,20 @@
-# Spec 2240 — Scored Benchmark Tasks: A Mechanical Capability Gradient Alongside Binary Gates
+# Spec 2240 — Scored Benchmark Tasks: Row-Authoritative Grading with a Mechanical Capability Gradient
 
 Every `fit-benchmark` cell (`(task, runIndex)`) collapses to one bit: the
 invariants exit code AND the judge verdict. The only signal a skill-pack change
 can move is therefore the pass **rate** across repeated runs. pass@k measures
 reliability, not capability: a task with a rich hidden test suite grades an
-agent that solved 90% of it identically to an agent that produced nothing. This
-spec adds a second task grading shape, **scored**, whose cell result carries a
-mechanical score in [0, 1] derived from weighted invariant checks, so a skill
-improvement shows up as a % movement instead of only a flipped bit.
+agent that solved 90% of it identically to an agent that produced nothing.
+
+This spec replaces the grading contract. The structured rows a task's
+invariants script emits become the **single authoritative grading channel**:
+every row is a check, a row's role (gate, scored, diagnostic) is carried in
+its own fields, and a mechanical score in [0, 1] is derived from the scored
+rows. The script's exit code is demoted to script health — nonzero means "the
+grader itself failed", never "the agent failed". This is a **clean break**:
+the benchmark has no consumers outside this repository, so we take the
+evergreen contract now and migrate every existing hook in the same change
+instead of carrying a dual-channel compatibility mode as tech debt.
 
 Serves **Platform Builders** — the persona who hires `fit-benchmark` to *prove
 a skill change improved outcomes* (see
@@ -21,12 +28,12 @@ Partial capability gains, the common case while a skill matures, are invisible.
 
 ## Problem
 
-**One bit per cell.** The runner composes a cell verdict from two binary gates:
-the invariants script's exit code and (when present) the judge's
+**One bit per cell.** The runner composes a cell verdict from two binary
+gates: the invariants script's exit code and (when present) the judge's
 success/failure conclusion. Nothing between 0 and 1 exists in the result
 record, so nothing between 0 and 1 can exist in the report.
 
-**The collection mechanism exists; no gradient uses it.** A task's invariants
+**The collection mechanism exists; nothing reads it.** A task's invariants
 script emits structured per-check rows (`{"test": …, "pass": …}`) on the
 results file descriptor; they land in the record's invariants details and the
 report renders them per run, but no aggregate reads them. The
@@ -38,43 +45,56 @@ never edited a file.
 
 **Saturation in both directions.** Once a family passes reliably, pass@k pins
 at 1.0 and further skill improvements are unmeasurable; a genuinely hard task
-pins at 0.0 with no gradient to climb. Task authors have no way to express "how
-far did the agent get", so families are written as all-or-nothing suites and
-the benchmark under-reports exactly the changes it exists to prove.
+pins at 0.0 with no gradient to climb. Task authors have no way to express
+"how far did the agent get", so families are written as all-or-nothing suites
+and the benchmark under-reports exactly the changes it exists to prove.
 
-**The naive fix is worse.** Asking the judge for a graded rubric score would
-manufacture a gradient from an LLM's opinion: ambiguous, noisy across runs,
-and gameable by persuasive prose in the trace. The gradient must be mechanical.
+**Two channels invite a fragile coupling.** The incremental fix — weights on
+rows while the exit code keeps gating — splits grading semantics across a data
+channel and a process channel, held together by a documentation-only contract
+("a failing scored check must not fail the exit code"). One wrong helper in a
+hook silently zeroes every partial run. With no external users, the coupling
+is pure downside; the rows can simply be the contract.
+
+**The naive gradient is worse.** Asking the judge for a graded rubric score
+would manufacture a gradient from an LLM's opinion: ambiguous, noisy across
+runs, and gameable by persuasive prose in the trace. The gradient must be
+mechanical.
 
 ## What
 
-Two task grading shapes, distinguished per task **by convention — no
-configuration**. Every task keeps today's gates; a task becomes scored by what
-its invariants emit, exactly as a task opts into a judge by shipping
-`judge.task.md` and into fixtures by shipping `workdir/`.
+One grading channel: the NDJSON rows on the results fd. Every row is a check
+by default; a row declares its role with its own fields. The exit code stops
+carrying any verdict meaning.
 
-A **weighted check row** is an invariant check row carrying a positive numeric
-weight alongside its pass/fail boolean. Rows without a weight keep their
-current role: diagnostic detail, never scored.
-
-| Shape | Grading | How a task opts in |
+| Row | Role | Grading effect |
 | --- | --- | --- |
-| **Judged** (today's shape) | Invariants gate + optional judge gate; binary verdict | Default — nothing new |
-| **Scored** | Judged shape **plus** a mechanical score in [0, 1] from weighted invariant checks | The invariants script emits at least one weighted check row |
+| `{"test": …, "pass": …, "gate": true}` | **Gate** | Any failing gate → verdict `fail`, score 0. |
+| `{"test": …, "pass": …}` or with `"weight": w > 0` | **Scored** | Contributes `w` (default 1) to the weighted score. |
+| `{"weight": 0, …}` | **Diagnostic** | Never graded; free-form detail. |
+| Malformed or unparseable | **Malformed** | Counts as a failing scored check; surfaced in the report. |
+
+A task with at least one scored row is a **scored task** and its records carry
+a score in [0, 1]; a task emitting only gate rows stays **binary**. Both
+shapes may carry a judge.
 
 Requirements:
 
 | # | Requirement |
 | --- | --- |
-| 1 | **Mechanical score.** A scored cell's score is the weighted fraction of passing weighted checks emitted by the task's invariants. No LLM output contributes to the score. |
-| 2 | **Judge is a gate, never a grade.** Judge verdicts remain binary pass/fail. A scored task may still carry a judge (e.g. scope discipline on a coding task); the judge protects the score's validity, it does not adjust it. |
-| 3 | **Exit code is the gate, not the grade.** In a scored task the invariants exit code reports gate conditions only — scaffold sanity, regressions, tampering. A failing weighted check must not fail the exit code; otherwise every partial completion zeroes out and no fractional score can exist. This authoring contract is load-bearing and the documentation (requirement 9) states it. |
-| 4 | **Gates protect the score.** A cell that fails any gate earns no partial credit. A gate-failing record that carries at least one weighted check row records score 0; a gate failure that produced no weighted rows (a preflight failure, or a script that died before emitting any) is indistinguishable from a judged record at record time, so its zero is realized in aggregation (requirement 7). Partial credit cannot be earned by breaking the scaffold, gaming the hidden tests, or violating the task's constraints. |
-| 5 | **Verdict semantics preserved.** A scored cell's verdict is `pass` only when every gate passes **and** every weighted check passes (full marks). pass@k keeps meaning "fully solved"; the `run` exit-code contract is unchanged. |
-| 6 | **Convention over configuration.** No new file, manifest field, or CLI flag declares a task's shape; the emitted rows decide. Judged tasks, existing families, and existing ledgers behave identically to today. |
-| 7 | **Report shows the gradient.** `report` adds, for scored tasks, a per-task mean score and a best-of-k score — the expected best score over k of the task's n runs, the continuous analog of pass@k — in both JSON and text formats, without disturbing the pass@k presentation for judged tasks. A task's group counts as scored when at least one of its records carries a score; records in that group without one (row-less gate failures, pre-conversion ledgers) contribute their verdict as the degenerate score: pass = 1, fail = 0. A group in which every run failed before emitting weighted rows carries no score evidence and renders as judged — its all-fail pass@k already tells the story. |
-| 8 | **Leading example.** `implement-feature` (kata-skills family) converts to a scored task: the app's baseline tests gate; each hidden feature test contributes one weighted check; the scope-discipline judge stays. One task demonstrates gate + score + judge composing. |
-| 9 | **Authoring surface.** The documented hook contract can emit weighted checks through the standard assertion helper without coupling them to the gate exit code, and the skill/reference docs state when to author a scored task versus a judged one. |
+| 1 | **Rows are authoritative.** Every row the invariants script emits on the results fd is a check unless it opts out with `weight: 0`. No second channel carries grading semantics. |
+| 2 | **Roles live in the row.** `gate: true` marks a gate check; a positive `weight` (default 1 when the key is absent) marks a scored check; `weight: 0` marks a diagnostic. `gate` and a positive `weight` are mutually exclusive on one row. |
+| 3 | **Exit code is script health only.** A nonzero exit means the grader itself failed: the run records verdict `fail` and score 0 — a crashed hook can never mint marks from the rows it happened to emit before dying. Check outcomes must never drive the exit code; a well-formed hook ends with `exit 0` unconditionally (early `exit 0` after a failing gate is fine — the gate row already carries the failure). |
+| 4 | **Mechanical score.** A scored cell's score is the weighted fraction of passing scored checks: `Σ weight(passing) / Σ weight(all scored)`. No LLM output contributes to the score. |
+| 5 | **Judge is a gate, never a grade.** Judge verdicts remain binary pass/fail. A scored task may still carry a judge (e.g. scope discipline on a coding task); the judge protects the score's validity, it does not adjust it. |
+| 6 | **Gates protect the score.** A failing exit-health check, a failing gate row, or a failing judge forces the record's score to 0. Partial credit cannot be earned by breaking the scaffold, gaming the hidden tests, or violating the task's constraints. |
+| 7 | **Verdict semantics.** A cell's verdict is `pass` iff the script exited 0 AND every gate row passes AND every scored check passes (full marks) AND the judge (when present) passes. pass@k keeps meaning "fully solved"; the `run` exit-code contract is unchanged. |
+| 8 | **Malformed fails loud.** A row with a missing or non-boolean `pass`, an invalid `weight` or `gate` value, a `gate`+positive-`weight` conflict, or an unparseable line counts as a *failing* scored check (at its own weight when valid, else unit weight 1), is tallied on the record, and is surfaced in the report. Silently dropping a defect could mint full marks from a broken hook. |
+| 9 | **Report shows the gradient.** `report` adds, for scored tasks, a per-task mean score and a best-of-k score — the expected best score over k of the task's n runs, the continuous analog of pass@k — in both JSON and text formats. Binary tasks render exactly as today. A record without a score in a scored group (a preflight failure never reached the hook) contributes its verdict as the degenerate score: pass = 1, fail = 0. |
+| 10 | **Authoring surface.** `fit-trace assert` gains `--gate` and `--weight`; hooks need one helper with no exit-code bookkeeping. An invalid `--weight` (or `--gate`/`--weight` conflict) emits a *failing* row before exiting nonzero, so an authoring typo shrinks the score, never the denominator. |
+| 11 | **Clean break with full migration.** Every `invariants.sh` in `benchmarks/` and in the libharness test fixtures migrates to the row contract in this change. No compatibility mode, flag, or dual-channel shim ships. Pre-migration ledgers still render (records carry their verdicts) but are not comparable across the semantics break, and no comparison may span it. |
+| 12 | **Leading example.** `implement-feature` (kata-skills family) becomes the worked scored task: the app's baseline tests as a gate row, each hidden feature test as one weight-1 scored row, the scope-discipline judge unchanged. One task demonstrates gate + score + judge composing. |
+| 13 | **Documentation.** Every surface that states the old contract ("exit code is authoritative/is the verdict") states the new one: rows authoritative, roles table, exit code = script health, and when to author gates versus scored checks. |
 
 ## Scope
 
@@ -82,11 +102,13 @@ In scope, by surface:
 
 | Surface | Change |
 | --- | --- |
-| libharness benchmark grading | Score derivation from weighted invariant check rows; verdict composition; result-record and invariants-record schemas gain an optional score |
-| libharness benchmark report | Per-task mean score and best-of-k aggregation + rendering (JSON and text) |
-| `fit-benchmark invariants` subcommand | Emits the score with the exit-code gate zeroing it as in `run` (no judge runs here), so authors can validate scored hooks against fixtures without paying for agent runs |
-| `fit-trace` assertion command | Weight emission on assertion result rows |
-| `benchmarks/kata-skills/tasks/implement-feature` | Converted to the leading scored example (hooks + family README rows) |
+| libharness benchmark grading | Pure grading derivation from rows + exit health; invariants verdict composed from it; result-record and invariants-record schemas gain optional score fields |
+| libharness benchmark runner | Cell verdict composition with the judge gate; effective-score zeroing |
+| libharness benchmark report | Per-task mean score and best-of-k aggregation + rendering (JSON and text); malformed-row warnings |
+| `fit-benchmark invariants` subcommand | Grades with the same derivation; process exit mirrors the graded verdict so authors can validate hooks against fixtures without paying for agent runs |
+| `fit-trace assert` | `--gate` and `--weight` flags; emit-then-fail on invalid grading flags |
+| `benchmarks/` (all three families) | All nine `invariants.sh` hooks migrate: presence/sanity checks become gate rows, content checks become scored rows, `FAIL`-driven exit codes are removed; `implement-feature` converts to the leading scored example; `fit-wiki/cli-fix` rewrites its nonstandard row shape to `test`/`pass` |
+| libharness test fixtures + suites | The four fixture hooks and every test asserting exit-code-derived verdicts move to the row contract; help-text goldens refresh where command descriptions change |
 | Documentation | `fit-benchmark` skill + authoring/CLI references, the Run a Benchmark guide, `benchmarks/README.md` |
 
 Excluded:
@@ -95,34 +117,40 @@ Excluded:
   spec; mean score per task already gives the % that a before/after pair of
   reports compares.
 - **Judge rubric or graded scoring** — explicitly rejected; judges stay binary.
-- **Converting the remaining tasks.** One leading example ships here; other
-  conversions are ordinary task authoring afterwards.
 - **Score time-series / XmR integration** — recording scores across runs over
   time is an analysis concern outside the benchmark CLI.
 - **Composite action and reusable workflow changes** — the report flows through
   the existing summary path; no new inputs are needed.
+- **`preflight.sh`** — the smoke probe keeps its exit-code contract; it emits
+  no rows and grades nothing.
 
 ## Success criteria
 
 | # | Claim | Verification |
 | --- | --- | --- |
-| 1 | An invariants script emitting weighted check rows yields a record whose score equals the weighted passing fraction | Unit tests over the score derivation; `fit-benchmark invariants --run-dir` against a fixture with a known partial completion |
-| 2 | A task emitting no weighted rows produces records without a score and byte-identical verdict behavior | Existing libharness benchmark suite and golden fixtures pass unmodified |
-| 3 | A gate-failing record whose invariants emitted passing weighted rows carries score 0 | Unit test on the verdict/score composition |
-| 4 | A row-less gate failure (preflight) in a scored task's group enters the per-task mean as 0, and a score-less `pass` record enters as 1 | Report unit test over a mixed group |
-| 5 | A scored cell's verdict is `pass` iff every gate passes and every weighted check passes | Unit test on runner verdict composition |
-| 6 | `report` renders mean score and best-of-k per scored task in text and JSON, and renders judged tasks exactly as today | Report unit/golden tests over a mixed ledger |
-| 7 | `implement-feature` yields a fractional score on a partial implementation | `fit-benchmark invariants` with a hand-authored partial fixture: 0 < score < 1 |
-| 8 | A complete correct implementation still records verdict `pass`, full marks | Same command on a complete fixture |
-| 9 | Authors can emit a weighted check through the standard assertion helper without failing the gate | Assertion command test: weight appears on the emitted row; documented hook pattern separates scored checks from gate checks |
-| 10 | Docs updated with the scored/judged distinction and the exit-code contract | Scored-task sections exist in the skill, the authoring reference, and the Run a Benchmark guide |
+| 1 | A hook emitting scored rows yields a record whose score equals the weighted passing fraction, with absent `weight` defaulting to 1 | Unit tests over the grading derivation; `fit-benchmark invariants --run-dir` against a fixture with a known partial completion |
+| 2 | A nonzero exit records verdict `fail` and score 0 regardless of emitted rows — a crashed hook cannot mint marks | Unit test: passing rows + exit 1 → fail, score 0 |
+| 3 | A failing gate row forces verdict `fail` and score 0 despite passing scored rows | Unit test on the grading composition |
+| 4 | A failing judge forces score 0 on the record | Runner unit test |
+| 5 | Verdict is `pass` iff exit 0 ∧ all gate rows pass ∧ full marks ∧ judge passes | Unit test on runner verdict composition |
+| 6 | Malformed and unparseable rows count as failing scored checks and surface in the report; an invalid `--weight` emits a failing row before `assert` exits nonzero | Derivation unit tests; assert command test |
+| 7 | A task emitting only gate rows carries no score and renders as a binary task | Grading + report unit tests |
+| 8 | `report` renders mean score and best-of-k per scored task in text and JSON; a score-less preflight failure in a scored group enters the mean as 0 | Report unit tests over a mixed ledger |
+| 9 | `implement-feature` yields a fractional score on a partial implementation and verdict `pass` with score 1 on a complete one | `fit-benchmark invariants` with hand-authored partial and complete fixtures |
+| 10 | Every `invariants.sh` under `benchmarks/` and the test fixtures follows the row contract: no `FAIL`-driven exit, roles on rows | Inspection + `grep -rn 'FAIL' benchmarks/*/tasks/*/hooks/invariants.sh` returns nothing; family suites pass |
+| 11 | Docs updated: rows-authoritative contract, roles table, exit-code demotion on every surface that stated the old contract | Scored-task sections exist in the skill, the authoring reference, the CLI reference, the Run a Benchmark guide, and `benchmarks/README.md` |
 
 ## Path to approval
 
 Approval is human-only: the spec advances when `wiki/STATUS.md` shows the
-`2240` row approved, written from a trusted human signal. This spec ships with
-its design in one combined PR (lockstep co-execution); the design covers the
-scored-row convention, the verdict and aggregation composition, the best-of-k
-estimator, and the example-task conversion, and `kata-plan` follows approval.
+`2240` row approved, written from a trusted human signal. This revision
+supersedes the earlier dual-channel draft (weights beside an authoritative
+exit code) after review concluded the coupling contract between the two
+channels was the design's weakest point and a clean break is affordable while
+the benchmark has no external consumers. This spec ships with its design in
+one combined PR (lockstep co-execution); the design covers the row contract,
+the grading and aggregation composition, the best-of-k estimator, the
+authoring surface, and the full hook migration, and `kata-plan` follows
+approval.
 
 — Staff Engineer 🛠️


### PR DESCRIPTION
## Summary

Reworks spec 2240 (spec, design, and plan) from the dual-channel draft to a
single-channel, row-authoritative grading contract for `fit-benchmark`.

The earlier draft added weighted rows *beside* an authoritative exit code,
held together by a documentation-only coupling contract (a failing scored
check must not fail the exit code, or every partial run zeroes out). Review
concluded that coupling was the design's weakest point, and a clean break is
affordable while the benchmark has no consumers outside this repository.

The reworked contract:

- The NDJSON rows on the results fd are the **single grading channel**. Every
  row is a check by default; roles ride on the row — `gate: true`,
  `weight > 0` (default 1), `weight: 0` for diagnostics.
- The **exit code is demoted to script health**: nonzero fails the run with
  score 0, so a crashed hook can never mint marks from partial emission — the
  one completion signal a crash cannot fake.
- Malformed and unparseable rows count as failing scored checks.
- `fit-trace assert` gains `--gate`/`--weight` with emit-then-fail, so an
  authoring typo shrinks the score, never the denominator.
- **Clean break**: all nine family hooks and the four libharness test
  fixtures migrate in-change; no compatibility mode ships.

Report aggregation (`meanScore`, `score@k` expected-best-of-k estimator) and
the `implement-feature` leading example carry over from the previous draft.

Docs-only change — no source under `libraries/` or `services/` is touched;
this lands the spec/design/plan for a subsequent implementation PR.

## Test plan

- [ ] `bun run check` (markdown format + lint over the spec directory)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HyGEFbRLfPmDmQscL8sSYn)_