### PR TITLE
docs(skills): carry the clean-break decision through the spec pipeline

### DIFF
--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -102,11 +102,11 @@ interfaces connect them — and why this architecture over alternatives.
   flow, state machines, sequence diagrams.
 - **Scope-faithful.** Stay within the spec's scope. If scope should change,
   return the spec to draft rather than expanding silently.
-- **Clean break.** Per [§ Clean breaks](../../../CONTRIBUTING.md#checklists),
-  the design replaces the old path and names the components and interfaces it
-  removes — a replacement that deletes nothing is incomplete. Compat appears
-  only when the spec names it as a requirement; if a clean break can't meet
-  the spec, return the spec to `draft` rather than designing around it.
+- **Clean break.** The design replaces the old path — no shims, aliases, or
+  fallbacks — and names the components and interfaces it removes; a
+  replacement that deletes nothing is incomplete. Compat appears only when
+  the spec names it as a requirement; if a clean break can't meet the spec,
+  return the spec to `draft` rather than designing around it.
 
 **Form follows content.** Prefer tables for lists with shared structure
 (components, decisions). Prefer bullets for flat facts. Use prose only for the

--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -102,11 +102,11 @@ interfaces connect them — and why this architecture over alternatives.
   flow, state machines, sequence diagrams.
 - **Scope-faithful.** Stay within the spec's scope. If scope should change,
   return the spec to draft rather than expanding silently.
-- **Clean break.** Follow [§ Clean breaks](../../../CONTRIBUTING.md#checklists):
-  the design replaces the old path, never wraps it in shims or fallbacks. Compat
-  belongs in the design only when the spec names it as a requirement; if a clean
-  break can't meet the spec, return the spec to `draft` rather than designing
-  around it.
+- **Clean break.** Per [§ Clean breaks](../../../CONTRIBUTING.md#checklists),
+  the design replaces the old path and names the components and interfaces it
+  removes — a replacement that deletes nothing is incomplete. Compat appears
+  only when the spec names it as a requirement; if a clean break can't meet
+  the spec, return the spec to `draft` rather than designing around it.
 
 **Form follows content.** Prefer tables for lists with shared structure
 (components, decisions). Prefer bullets for flat facts. Use prose only for the

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -96,10 +96,11 @@ The plan translates an approved design into concrete implementation steps.
 - **Execution recommendation.** Route parts to the most suitable agent —
   engineering agents for code, `technical-writer` for docs. For decomposed
   plans, state which parts can run in parallel vs sequentially.
-- **Clean break.** Follow [§ Clean breaks](../../../CONTRIBUTING.md#checklists):
-  the plan replaces the old path, never wraps it in shims or fallbacks. Compat
-  belongs in the plan only when the design names it as a requirement; if a clean
-  break can't meet the design, revise the design rather than planning around it.
+- **Clean break.** Per [§ Clean breaks](../../../CONTRIBUTING.md#checklists),
+  the plan replaces the old path: every removal the design names lands in a
+  step's deleted list, not in follow-up work. Compat appears only when the
+  design names it as a requirement; if a clean break can't meet the design,
+  revise the design rather than planning around it.
 
 **Form follows content.** Prefer tables for shared-structure lists, bullets for
 flat facts, prose only for narrative connecting them. If a paragraph could be a

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -96,11 +96,11 @@ The plan translates an approved design into concrete implementation steps.
 - **Execution recommendation.** Route parts to the most suitable agent —
   engineering agents for code, `technical-writer` for docs. For decomposed
   plans, state which parts can run in parallel vs sequentially.
-- **Clean break.** Per [§ Clean breaks](../../../CONTRIBUTING.md#checklists),
-  the plan replaces the old path: every removal the design names lands in a
-  step's deleted list, not in follow-up work. Compat appears only when the
-  design names it as a requirement; if a clean break can't meet the design,
-  revise the design rather than planning around it.
+- **Clean break.** The plan replaces the old path — no shims, aliases, or
+  fallbacks — and every removal the design names lands in a step's deleted
+  list, not in follow-up work. Compat appears only when the design names it
+  as a requirement; if a clean break can't meet the design, revise the
+  design rather than planning around it.
 
 **Form follows content.** Prefer tables for shared-structure lists, bullets for
 flat facts, prose only for narrative connecting them. If a paragraph could be a

--- a/.claude/skills/kata-review/SKILL.md
+++ b/.claude/skills/kata-review/SKILL.md
@@ -121,6 +121,8 @@ Match
 and CONTRIBUTING.md § Core Rules. Look for:
 
 - Diff implements every spec success criterion
+- Old path deleted in the same change — no shims, aliases, fallbacks, or
+  compat flags unless the spec requires them
 - No scope creep (refactors, features, cleanup beyond the plan)
 - Atomic, conventional-style commits on the branch
 - Plan deviations noted in commit messages where present

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -78,9 +78,10 @@ Identify which persona and job from [JTBD.md](../../../JTBD.md) the spec serves.
 - **Problem first.** Evidence before proposal — errors, metrics, examples.
 - **Specific scope.** Name affected files, APIs, entities; state what is
   excluded.
-- **Compatibility stance.** One line: clean break (the default) or a compat
-  requirement with its why. Silence means clean break downstream; when
-  breaking, list old-path removal as a success criterion.
+- **Compatibility stance.** One line: clean break, or a compat requirement
+  with its why. Clean break is the default unless CONTRIBUTING.md states a
+  different policy; silence means clean break downstream. When breaking,
+  list old-path removal as a success criterion.
 - **Verifiable success.** Each criterion is a claim plus the command or path
   that verifies it. One sentence each. No rationale, no alternatives considered.
 - **No HOW.** Name what each component does, not which mechanism implements it.

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -78,6 +78,9 @@ Identify which persona and job from [JTBD.md](../../../JTBD.md) the spec serves.
 - **Problem first.** Evidence before proposal — errors, metrics, examples.
 - **Specific scope.** Name affected files, APIs, entities; state what is
   excluded.
+- **Compatibility stance.** One line: clean break (the default) or a compat
+  requirement with its why. Silence means clean break downstream; when
+  breaking, list old-path removal as a success criterion.
 - **Verifiable success.** Each criterion is a claim plus the command or path
   that verifies it. One sentence each. No rationale, no alternatives considered.
 - **No HOW.** Name what each component does, not which mechanism implements it.


### PR DESCRIPTION
## Summary

- Real usage showed clean-break instructions get missed because the rule was an absence-based default ("compat only when the spec names it") and reviews anchor on artifacts — a silent spec gives reviewers nothing to check.
- Each phase now carries the decision as something present: the spec states a one-line compatibility stance (clean break by default, old-path removal as a success criterion when breaking), the design names the components and interfaces it removes, the plan lands every named removal in a step's deleted list, and diff review checks the old path is deleted in the same change.
- The skills state the clean-break default self-contained instead of linking this monorepo's CONTRIBUTING.md § Clean breaks — the pack ships identically to every installation, so CONTRIBUTING.md appears only as a per-repo override point, entering once at the spec.

## Test plan

- [x] `coaligned instructions` (length caps)
- [x] `bun run invariants` (skill genericity and template rules)
- [x] `bunx rumdl check` on the edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFjs43ZN6DMu5pshVv6Rv1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFjs43ZN6DMu5pshVv6Rv1)_