### PR TITLE
fix(map): stage the pathway standard and enforce roster level coverage

### DIFF
--- a/.claude/skills/fit-landmark/SKILL.md
+++ b/.claude/skills/fit-landmark/SKILL.md
@@ -101,7 +101,11 @@ See [`references/workflows.md`](references/workflows.md) for worked examples.
 ## Prerequisites
 
 - GetDX account with API access
-- Map activity schema migrated and populated (`npx fit-map activity migrate`)
+- Map activity database prepared — one of: `npx fit-map substrate stage`
+  (one-shot CI/interview pipeline), `npx fit-map activity start` +
+  `npx fit-map activity seed` (dev flow), or `npx fit-map activity migrate`
+  plus your own ingest (migrations only); the `fit-map` skill documents all
+  three paths
 - Standard data with drivers and markers authored in capability YAML
 - Summit (optional) for inline growth recommendations in health view
 

--- a/.claude/skills/fit-map/SKILL.md
+++ b/.claude/skills/fit-map/SKILL.md
@@ -70,6 +70,7 @@ Homebrew, npm, or falls back to `npx supabase`.
 npx fit-map activity start              # Start local Supabase
 npx fit-map activity status             # Report stack health
 npx fit-map activity migrate            # Reset + re-apply migrations (drops data)
+npx fit-map activity seed               # Seed the database from ./data/activity
 npx fit-map people push <file>          # Upsert into organization_people
 npx fit-map getdx sync                  # Sync GetDX (needs GETDX_API_TOKEN)
 npx fit-map activity transform          # Reprocess the raw bucket
@@ -89,6 +90,15 @@ pipeline collapses the activity-layer flow above — when running
 substrate, `init`, `migrate`, `seed`, `people push`, and `provision` are
 all internal phases. Do not invoke them separately.
 
+Three entry points prepare an activity database — pick one:
+
+- `substrate stage` — one-shot pipeline for CI and interview runs;
+  every phase below is internal.
+- `activity start` + `activity seed` — dev flow: bring the stack up,
+  then seed it from `./data/activity`.
+- `activity migrate` — migrations only; resets the schema (drops data)
+  without seeding.
+
 ### One-shot stage
 
 ```sh
@@ -98,19 +108,28 @@ npx fit-map substrate stage --cwd <agent_dir>
 Phases (failures surface as `[substrate stage: <phase>] <reason>` so CI
 identifies the failing step):
 
-| Phase           | What it does                                                     |
-| --------------- | ---------------------------------------------------------------- |
-| `init`          | Bootstrap `data/pathway/` + `config/config.json` into target     |
-| `copy-activity` | Copy synthetic activity data into target                         |
-| `stack`         | `supabase start`                                                 |
-| `url-discovery` | Parse `supabase status` → set `SUPABASE_URL`/`SUPABASE_ANON_KEY` |
-| `migrate`       | `supabase db reset`                                              |
-| `seed`          | Load activity data                                               |
-| `provision`     | Reconcile `auth.users` against the roster (shared `fit-terrain` capability) |
-| `smoke`         | Invoke every gated product command end-to-end                    |
+| Phase             | What it does                                                     |
+| ----------------- | ---------------------------------------------------------------- |
+| `init`            | Bootstrap `data/pathway/` + `config/config.json` into target     |
+| `copy-activity`   | Copy synthetic activity data into target                         |
+| `copy-pathway`    | Replace target's `data/pathway/` with the standard from the same data root (starter stays when none exists) |
+| `stack`           | `supabase start`                                                 |
+| `url-discovery`   | Parse `supabase status` → set `SUPABASE_URL`/`SUPABASE_ANON_KEY` |
+| `migrate`         | `supabase db reset`                                              |
+| `seed`            | Load activity data                                               |
+| `provision`       | Reconcile `auth.users` against the roster (shared `fit-terrain` capability) |
+| `roster-standard` | Fail when the seeded roster uses level ids the staged standard does not define |
+| `smoke`           | Invoke every gated product command end-to-end                    |
+
+Activity data and the pathway standard ship from the same data root, so
+the seeded roster and the installed standard always match. Seeding
+itself enforces the same invariant on every path: `activity seed` fails
+fast when the roster names a level the installed standard does not
+define.
 
 `SUBSTRATE_FORCE_EMPTY_CORPUS=true` forces the smoke phase to fail with
 the empty-corpus diagnostic — used by CI to assert the failure path.
+Set `FIT_DEBUG=1` to print the full stack trace when a command fails.
 
 ### Persona selection
 

--- a/products/landmark/bin/fit-landmark.js
+++ b/products/landmark/bin/fit-landmark.js
@@ -319,17 +319,25 @@ async function main() {
       }
     }
   } catch (error) {
-    if (error instanceof IdentityUnresolvedError) {
-      cli.error(error.message);
-      process.exit(4);
-    }
-    if (error instanceof SupabaseUnavailableError) {
-      cli.error(error.message);
-      process.exit(3);
-    }
-    cli.error(error.message);
-    process.exit(1);
+    exitWithError(cli, error);
   }
+}
+
+/** Print the error per its class contract and exit with the matching code. */
+function exitWithError(cli, error) {
+  if (error instanceof IdentityUnresolvedError) {
+    cli.error(error.message);
+    process.exit(4);
+  }
+  if (error instanceof SupabaseUnavailableError) {
+    cli.error(error.message);
+    process.exit(3);
+  }
+  cli.error(error.message);
+  if (process.env.FIT_DEBUG) {
+    process.stderr.write(error.stack + "\n");
+  }
+  process.exit(1);
 }
 
 main();

--- a/products/map/CLAUDE.md
+++ b/products/map/CLAUDE.md
@@ -1,0 +1,34 @@
+# Map
+
+For general product conventions see [products/CLAUDE.md](../CLAUDE.md).
+
+## Substrate
+
+`fit-map substrate stage` runs these phases in order (each failure is
+prefixed `[substrate stage: <phase>]` on the original error, so the
+stack survives):
+
+    init → copy-activity → copy-pathway → stack → url-discovery →
+    migrate → seed → provision → roster-standard → smoke
+
+**Activity and pathway are a matched pair.** The roster under
+`data/activity` carries level ids defined by `data/pathway`, so both
+copy phases ship from the same data root (`findDataDir`). `copy-pathway`
+replaces the staged pathway wholesale — init has already materialised
+the starter standard there, and a merge copy would blend starter files
+into the source standard. When no source pathway exists, the starter
+copy stays as the fallback.
+
+The invariant "every seeded level exists in the installed standard" is
+owned by seeding, not staging: `assertSeededLevelsCovered`
+(`src/lib/roster-levels.js`) runs inside `activity seed` (any seeding
+path fails fast) and again as the `roster-standard` stage phase (proves
+the staged copy end-to-end). Stage is only one of three substrate entry
+points — `substrate stage` (CI/interview), `activity start` + `activity
+seed` (dev flow), `activity migrate` (migrations only).
+
+Injectable phase collaborators on `runStageCommand` all have real
+defaults; when touching them, keep a test that runs the defaults
+(`test/activity/substrate-stage.integration.test.js` "default
+dependencies") — fully-stubbed deps objects cannot catch default-wiring
+regressions.

--- a/products/map/bin/fit-map.js
+++ b/products/map/bin/fit-map.js
@@ -537,6 +537,9 @@ async function main() {
     runtime.proc.exit(exitCode);
   } catch (error) {
     cli.error(error.message);
+    if (runtime.proc.env.FIT_DEBUG) {
+      runtime.proc.stderr.write(error.stack + "\n");
+    }
     runtime.proc.exit(1);
   }
 }

--- a/products/map/src/commands/activity.js
+++ b/products/map/src/commands/activity.js
@@ -8,6 +8,7 @@ import { transformAllGitHub } from "@forwardimpact/map/activity/transform/github
 import { transformEvidence } from "@forwardimpact/map/activity/transform/evidence";
 import { transformEvidenceArtifact } from "@forwardimpact/map/activity/transform/evidence-artifact";
 import { getOrganization } from "@forwardimpact/map/activity/queries/org";
+import { assertSeededLevelsCovered } from "../lib/roster-levels.js";
 import {
   formatHeader,
   formatSubheader,
@@ -303,7 +304,15 @@ export async function seed({ data, supabase, runtime, mapData }) {
     result.evidence.errors.length === 0,
   );
 
-  // 4. Verify
+  // 4. Enforce the seeding invariant: every seeded level exists in the
+  // installed standard (skipped when no standard is installed).
+  await assertSeededLevelsCovered({
+    supabase,
+    pathwayDir: join(data, "pathway"),
+    runtime,
+  });
+
+  // 5. Verify
   return verify(supabase, runtime);
 }
 

--- a/products/map/src/commands/substrate-stage.js
+++ b/products/map/src/commands/substrate-stage.js
@@ -1,10 +1,12 @@
 /**
  * `fit-map substrate stage` — workspace-prep terminal phase for the
  * kata-interview workflow targeting Landmark. Runs init against the
- * target dir, brings up the local Supabase stack, discovers its URL/anon
- * key, migrates the schema, seeds the activity data, provisions
- * auth.users for the roster, and runs a self-smoke against every gated
- * Landmark command.
+ * target dir, copies the activity data and pathway standard from the
+ * same data root, brings up the local Supabase stack, discovers its
+ * URL/anon key, migrates the schema, seeds the activity data,
+ * provisions auth.users for the roster, proves the seeded roster's
+ * levels against the staged standard, and runs a self-smoke against
+ * every gated Landmark command.
  *
  * Designed to be invoked once per interview run from CI; not a developer
  * verb (use `fit-map activity start` + manual seed in dev flows).
@@ -44,6 +46,12 @@ export async function runStageCommand(
     loadInit = () => import("./init.js").then((m) => m.runInit),
     loadCopyActivity = () =>
       import("../lib/copy-activity.js").then((m) => m.copyActivity),
+    loadCopyPathway = () =>
+      import("../lib/copy-activity.js").then((m) => m.copyPathway),
+    loadAssertLevels = () =>
+      import("../lib/roster-levels.js").then(
+        (m) => m.assertSeededLevelsCovered,
+      ),
     createSupabaseCli = defaultCreateCli,
     findDataDir = defaultFindDataDir,
     createMapClient = defaultCreateMapClient,
@@ -80,6 +88,17 @@ export async function runStageCommand(
     const dataDir = await findDataDir(undefined, runtime);
     const source = path.join(path.dirname(dataDir), "activity");
     await copyActivity({ source, target: stageTarget, runtime });
+  });
+
+  // Activity and pathway are a matched pair from the same data root: the
+  // roster seeded below carries level ids the standard must define, so
+  // the staged pathway ships from the same source as the activity data
+  // (init's starter copy stays as the fallback when no source pathway
+  // exists).
+  const copyPathway = await loadCopyPathway();
+  await runPhase("copy-pathway", async () => {
+    const source = await findDataDir(undefined, runtime);
+    await copyPathway({ source, target: stageTarget, runtime });
   });
 
   const stageConfig = (await reloadConfig(stageTarget)) ?? config;
@@ -130,6 +149,18 @@ export async function runStageCommand(
     runProvision({ supabase: substrateClient, runtime }),
   );
 
+  // Prove the seeded roster against the standard this workspace actually
+  // ships — the seed phase checked against the source data root; this
+  // one checks the staged copy end-to-end.
+  const assertSeededLevelsCovered = await loadAssertLevels();
+  await runPhase("roster-standard", () =>
+    assertSeededLevelsCovered({
+      supabase,
+      pathwayDir: path.join(stageTarget, "data", "pathway"),
+      runtime,
+    }),
+  );
+
   if (runtime.proc.env.SUBSTRATE_FORCE_EMPTY_CORPUS === "true") {
     throw new Error("[substrate stage: smoke] empty corpus (test injection)");
   }
@@ -146,6 +177,9 @@ async function runPhase(name, fn) {
   try {
     await fn();
   } catch (err) {
-    throw new Error(`[substrate stage: ${name}] ${err.message}`);
+    // Prefix the phase onto the original error rather than wrapping it,
+    // so the stack still points at the failing frame.
+    err.message = `[substrate stage: ${name}] ${err.message}`;
+    throw err;
   }
 }

--- a/products/map/src/lib/copy-activity.js
+++ b/products/map/src/lib/copy-activity.js
@@ -1,14 +1,20 @@
 /**
- * Copy a source directory into `<target>/data/activity/` recursively.
+ * Copy helpers for staging a workspace's `data/` tree. Activity and
+ * pathway are a matched pair from the same data root: the roster under
+ * `data/activity` carries level ids defined by `data/pathway`, so both
+ * ship from the same source.
  *
- * Pure helper — throws raw Error on failure so the caller's runPhase
- * envelope owns the framing. `recursive: true` creates the `data/`
- * parent if absent, matching init.js's semantics.
+ * Pure helpers — they throw raw Errors on failure so the caller's
+ * runPhase envelope owns the framing.
  */
 
 import path from "node:path";
 
 /**
+ * Copy a source directory into `<target>/data/activity/` recursively.
+ * `recursive: true` creates the `data/` parent if absent, matching
+ * init.js's semantics.
+ *
  * @param {object} params
  * @param {string} params.source - Absolute path to the source activity dir
  *   (e.g. `<monorepo>/data/activity`).
@@ -23,4 +29,34 @@ export async function copyActivity({ source, target, runtime }) {
     force: false,
     errorOnExist: false,
   });
+}
+
+/**
+ * Replace `<target>/data/pathway/` with the source pathway directory.
+ *
+ * Unlike `copyActivity`, the staged pathway is replaced wholesale: init
+ * has already materialised the starter standard at the destination, and
+ * a merge copy (`force: false`) would blend starter files into the
+ * source standard. When the source pathway does not exist, the starter
+ * copy stays as the fallback; when source and destination resolve to
+ * the same directory (staging into the data root itself), the copy is
+ * skipped.
+ *
+ * @param {object} params
+ * @param {string} params.source - Absolute path to the source pathway dir
+ *   (e.g. `<monorepo>/data/pathway`).
+ * @param {string} params.target - Absolute path to the workspace target
+ *   (the `--cwd` value).
+ * @param {import('@forwardimpact/libutil/runtime').Runtime} params.runtime - Injected collaborators (fs).
+ */
+export async function copyPathway({ source, target, runtime }) {
+  const dest = path.join(target, "data", "pathway");
+  if (path.resolve(source) === path.resolve(dest)) return;
+  try {
+    await runtime.fs.access(source);
+  } catch {
+    return;
+  }
+  await runtime.fs.rm(dest, { recursive: true, force: true });
+  await runtime.fs.cp(source, dest, { recursive: true });
 }

--- a/products/map/src/lib/roster-levels.js
+++ b/products/map/src/lib/roster-levels.js
@@ -1,0 +1,54 @@
+/**
+ * Seeding invariant: every level carried by a seeded person must exist
+ * in the installed standard's `levels.yaml`. A roster row whose level
+ * the standard does not define makes every level-gated consumer fail
+ * with "Unknown level" long after seeding, so seeding fails fast
+ * instead. When no standard is installed at the given pathway dir the
+ * invariant is vacuous and the check is skipped.
+ */
+
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { getOrganization } from "../activity/queries/org.js";
+
+/**
+ * Throw when `organization_people` contains level ids absent from the
+ * installed `levels.yaml`.
+ *
+ * @param {object} params
+ * @param {import('@supabase/supabase-js').SupabaseClient} params.supabase - Client bound to the activity schema.
+ * @param {string} params.pathwayDir - Installed standard dir (contains levels.yaml).
+ * @param {import('@forwardimpact/libutil/runtime').Runtime} params.runtime - Injected collaborators (fs).
+ * @returns {Promise<void>}
+ */
+export async function assertSeededLevelsCovered({
+  supabase,
+  pathwayDir,
+  runtime,
+}) {
+  const levelsPath = join(pathwayDir, "levels.yaml");
+  let content;
+  try {
+    content = await runtime.fs.readFile(levelsPath, "utf-8");
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+    return;
+  }
+  const installed = new Set(parseYaml(content).map((level) => level.id));
+  const people = await getOrganization(supabase);
+  const missing = [
+    ...new Set(
+      people
+        .map((person) => person.level)
+        .filter((level) => level && !installed.has(level)),
+    ),
+  ].sort();
+  if (missing.length > 0) {
+    throw new Error(
+      `Seeded roster uses levels missing from the installed standard ` +
+        `(${levelsPath}): ${missing.join(", ")}. Installed levels: ` +
+        `${[...installed].join(", ")}. Add the missing levels to ` +
+        `levels.yaml or correct the roster.`,
+    );
+  }
+}

--- a/products/map/test/activity/substrate-stage.integration.test.js
+++ b/products/map/test/activity/substrate-stage.integration.test.js
@@ -54,6 +54,8 @@ function buildDeps({ failPhase = null, invocations }) {
   return {
     loadInit: async () => recorded("init"),
     loadCopyActivity: async () => recorded("copy-activity"),
+    loadCopyPathway: async () => recorded("copy-pathway"),
+    loadAssertLevels: async () => recorded("roster-standard"),
     createSupabaseCli: () => cliStub,
     createMapClient: () => ({ stub: true }),
     findDataDir: async () => "/tmp/data/pathway",
@@ -135,6 +137,8 @@ describe("substrate-stage / fit-map init bootstrap-shape parity", () => {
       {
         loadInit: async () => runInit,
         loadCopyActivity: async () => async () => {},
+        loadCopyPathway: async () => async () => {},
+        loadAssertLevels: async () => async () => {},
         createSupabaseCli: () => ({
           run: recorded("noop"),
           capture: recorded("noop", async () =>
@@ -156,6 +160,63 @@ describe("substrate-stage / fit-map init bootstrap-shape parity", () => {
     const treeA = await listTree(tmpA);
     const treeB = await listTree(tmpB);
     assert.deepEqual(treeA, treeB);
+  });
+});
+
+describe("substrate-stage default dependencies", () => {
+  test("stages with the default reloadConfig, init, and copy helpers", async () => {
+    // Only process-external collaborators (supabase, clients, the seeded
+    // phases) are stubbed; loadInit, both copy helpers, and reloadConfig
+    // run their real defaults against a real target — the wiring that a
+    // fully-stubbed deps object never exercises.
+    const sourceRoot = await fs.mkdtemp(
+      path.join(tmpdir(), "substrate-default-src-"),
+    );
+    const target = await fs.mkdtemp(
+      path.join(tmpdir(), "substrate-default-target-"),
+    );
+    await fs.mkdir(path.join(sourceRoot, "data", "activity"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(sourceRoot, "data", "pathway"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(sourceRoot, "data", "activity", "roster.yaml"),
+      "people: []\n",
+    );
+    await fs.writeFile(
+      path.join(sourceRoot, "data", "pathway", "levels.yaml"),
+      "- id: J080\n",
+    );
+    const runtime = quietRealRuntime();
+    const deps = {
+      createSupabaseCli: () => ({
+        run: async () => {},
+        capture: async () =>
+          JSON.stringify({ API_URL: "http://u", ANON_KEY: "k" }),
+      }),
+      createMapClient: () => ({ stub: true }),
+      findDataDir: async () => path.join(sourceRoot, "data", "pathway"),
+      loadSeed: async () => async () => {},
+      loadProvision: async () => async () => {},
+      loadSmoke: async () => async () => {},
+      loadAssertLevels: async () => async () => {},
+    };
+    try {
+      const code = await runStageCommand({ config: {}, target, runtime }, deps);
+      assert.equal(code, 0);
+      const staged = await fs.readFile(
+        path.join(target, "data", "pathway", "levels.yaml"),
+        "utf-8",
+      );
+      assert.equal(staged, "- id: J080\n");
+      const entries = await fs.readdir(path.join(target, "data", "pathway"));
+      assert.deepEqual(entries, ["levels.yaml"]);
+    } finally {
+      await fs.rm(sourceRoot, { recursive: true, force: true });
+      await fs.rm(target, { recursive: true, force: true });
+    }
   });
 });
 

--- a/products/map/test/copy-pathway.test.js
+++ b/products/map/test/copy-pathway.test.js
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the copyPathway staging helper: wholesale replacement
+ * (never a merge that blends starter and source files), the starter
+ * fallback when no source pathway exists, and the self-copy guard when
+ * staging into the data root itself.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createTestRuntime, createMockFs } from "@forwardimpact/libmock";
+
+import { copyPathway } from "../src/lib/copy-activity.js";
+
+describe("copyPathway", () => {
+  test("replaces the staged pathway wholesale with the source", async () => {
+    const fs = createMockFs({
+      "/repo/data/pathway/levels.yaml": "- id: J080\n",
+      "/work/data/pathway/levels.yaml": "- id: J040\n",
+      "/work/data/pathway/starter-only.yaml": "starter\n",
+    });
+    const runtime = createTestRuntime({ fs });
+
+    await copyPathway({
+      source: "/repo/data/pathway",
+      target: "/work",
+      runtime,
+    });
+
+    assert.equal(fs.data.get("/work/data/pathway/levels.yaml"), "- id: J080\n");
+    assert.equal(fs.data.has("/work/data/pathway/starter-only.yaml"), false);
+  });
+
+  test("keeps the starter fallback when no source pathway exists", async () => {
+    const fs = createMockFs({
+      "/work/data/pathway/levels.yaml": "- id: J040\n",
+    });
+    const runtime = createTestRuntime({ fs });
+
+    await copyPathway({
+      source: "/repo/data/pathway",
+      target: "/work",
+      runtime,
+    });
+
+    assert.equal(fs.data.get("/work/data/pathway/levels.yaml"), "- id: J040\n");
+  });
+
+  test("skips the copy when source resolves to the destination", async () => {
+    const fs = createMockFs({
+      "/work/data/pathway/levels.yaml": "- id: J040\n",
+    });
+    const runtime = createTestRuntime({ fs });
+
+    await copyPathway({
+      source: "/work/data/pathway",
+      target: "/work",
+      runtime,
+    });
+
+    assert.equal(fs.data.get("/work/data/pathway/levels.yaml"), "- id: J040\n");
+    assert.equal(fs.rm.mock.callCount(), 0);
+  });
+});

--- a/products/map/test/roster-levels.test.js
+++ b/products/map/test/roster-levels.test.js
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for the seeding invariant: every seeded level must exist
+ * in the installed standard's levels.yaml, and the check is vacuous
+ * (skipped) when no standard is installed.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createTestRuntime, createMockFs } from "@forwardimpact/libmock";
+
+import { assertSeededLevelsCovered } from "../src/lib/roster-levels.js";
+
+function orgClient(people) {
+  return {
+    from: () => ({
+      select: () => ({ order: async () => ({ data: people, error: null }) }),
+    }),
+  };
+}
+
+const STARTER_LEVELS = "- id: J040\n- id: J060\n";
+
+describe("assertSeededLevelsCovered", () => {
+  test("throws naming each missing level once, sorted", async () => {
+    const runtime = createTestRuntime({
+      fs: createMockFs({ "/work/data/pathway/levels.yaml": STARTER_LEVELS }),
+    });
+
+    await assert.rejects(
+      () =>
+        assertSeededLevelsCovered({
+          supabase: orgClient([
+            { level: "J040" },
+            { level: "J100" },
+            { level: "J080" },
+            { level: "J080" },
+          ]),
+          pathwayDir: "/work/data/pathway",
+          runtime,
+        }),
+      /missing from the installed standard.*J080, J100/,
+    );
+  });
+
+  test("passes when every seeded level is installed; null levels ignored", async () => {
+    const runtime = createTestRuntime({
+      fs: createMockFs({ "/work/data/pathway/levels.yaml": STARTER_LEVELS }),
+    });
+
+    await assertSeededLevelsCovered({
+      supabase: orgClient([{ level: "J040" }, { level: null }]),
+      pathwayDir: "/work/data/pathway",
+      runtime,
+    });
+  });
+
+  test("skips without querying when no standard is installed", async () => {
+    const runtime = createTestRuntime({ fs: createMockFs({}) });
+    const neverQueried = {
+      from: () => {
+        throw new Error("must not query without an installed standard");
+      },
+    };
+
+    await assertSeededLevelsCovered({
+      supabase: neverQueried,
+      pathwayDir: "/work/data/pathway",
+      runtime,
+    });
+  });
+});

--- a/products/map/test/substrate-stage.test.js
+++ b/products/map/test/substrate-stage.test.js
@@ -19,6 +19,8 @@ function stubDeps(statusJson) {
   return {
     loadInit: () => async () => {},
     loadCopyActivity: () => async () => {},
+    loadCopyPathway: () => async () => {},
+    loadAssertLevels: () => async () => {},
     createSupabaseCli: () => ({
       run: async () => {},
       capture: async () => statusJson,
@@ -68,5 +70,33 @@ describe("fit-map substrate stage --emit-env", () => {
     assert.equal(code, 0);
     assert.equal(runtime.proc.env.SUPABASE_URL, "http://u");
     assert.equal(runtime.proc.env.SUPABASE_ANON_KEY, "k");
+  });
+});
+
+describe("fit-map substrate stage phase errors", () => {
+  test("rethrows the original error with the phase prefixed", async () => {
+    const runtime = createTestRuntime();
+    const deps = stubDeps(
+      JSON.stringify({ API_URL: "http://u", ANON_KEY: "k" }),
+    );
+    const original = new Error("seed exploded");
+    original.marker = "original-error";
+    deps.loadSeed = () => async () => {
+      throw original;
+    };
+
+    let caught;
+    try {
+      await runStageCommand(
+        { config: {}, target: "/agent-cwd", runtime },
+        deps,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    assert.equal(caught, original);
+    assert.equal(caught.marker, "original-error");
+    assert.equal(caught.message, "[substrate stage: seed] seed exploded");
   });
 });


### PR DESCRIPTION
## Summary

- `fit-map substrate stage` gains a `copy-pathway` phase: the staged workspace ships the pathway standard from the same data root as the activity data (wholesale replace, starter as fallback, self-copy guarded), so level-gated Landmark commands no longer fail `Unknown level "J080"` against seeded rosters spanning J040–J100.
- New seeding invariant `assertSeededLevelsCovered` (`products/map/src/lib/roster-levels.js`): `fit-map activity seed` fails fast, naming the missing level ids, when the roster uses levels the installed standard does not define; a new `roster-standard` stage phase proves the staged copy end-to-end before smoke.
- `runPhase` now prefixes the phase onto the **original** error and rethrows it (stack survives); `FIT_DEBUG=1` prints full stacks from the `fit-map` and `fit-landmark` bins (message-only otherwise).
- New default-deps integration test runs `runStageCommand` with the real `reloadConfig`/init/copy helpers against a real target — the test class that would have caught 3d2532be.
- Docs: fit-map skill (three substrate entry points, new phases, invariant, FIT_DEBUG), fit-landmark skill prerequisites, new `products/map/CLAUDE.md` § Substrate.

Verified live: `substrate stage --cwd tmp/verify-stage` passes all ten phases; staged `levels.yaml` spans J040–J100; `fit-landmark readiness` for an issued J080 persona reports `J080 → J090`.

## Test plan

- [x] `bun run check`
- [x] `bun test` (map 271 pass, landmark 183 pass) + touched files under `node --test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)