### PR TITLE
fix(guide): one-shot prompts, TTY-aware output, and status/skill accuracy

### DIFF
--- a/.claude/skills/fit-guide/SKILL.md
+++ b/.claude/skills/fit-guide/SKILL.md
@@ -43,11 +43,16 @@ Chat.
 
 - Bootstrap a new project — `npx fit-guide --init` (safe to re-run; no-op on
   existing projects)
-- Authenticate — `npx fit-guide login`
+- Authenticate — `npx fit-guide --login`
 - Start the service stack — `npx fit-rc start`
-- Check system readiness — `npx fit-guide status`
+- Check system readiness — `npx fit-guide --status`
 - Process knowledge content — `npx fit-process resources`,
   `npx fit-process graphs`, `npx fit-process vectors`
+
+`npx fit-guide "question"` and `echo "question" | npx fit-guide` are
+equivalent one-shot forms. Positional words are always prompt text, never
+commands — `npx fit-guide status` sends the word "status" to the agent;
+operational commands are always flags (`--status`, `--login`).
 
 ---
 
@@ -63,20 +68,10 @@ compaction and session persistence automatically.
 
 ### Tool Execution
 
-Guide exposes 10 tools via an MCP endpoint, each backed by a gRPC service:
-
-| Tool                             | Backend | Purpose                      |
-| -------------------------------- | ------- | ---------------------------- |
-| `get_ontology`                   | graph   | Schema vocabulary            |
-| `get_subjects`                   | graph   | Entity URIs by type          |
-| `query_by_pattern`               | graph   | Triple-pattern graph queries |
-| `search_content`                 | vector  | Semantic similarity search   |
-| `pathway_list_jobs`              | pathway | Job combinations             |
-| `pathway_describe_job`           | pathway | Full job description         |
-| `pathway_list_agent_profiles`    | pathway | Agent profile definitions    |
-| `pathway_describe_agent_profile` | pathway | Agent profile detail         |
-| `pathway_describe_progression`   | pathway | Level progression deltas     |
-| `pathway_list_job_software`      | pathway | Software toolkit per job     |
+Guide exposes its tools via an MCP endpoint, each backed by a gRPC
+service. The authoritative list is the `service.mcp.tools` block of your
+`config/config.json`; the starter ships fifteen tools spanning graph
+queries, semantic search, pathway lookups, and activity data.
 
 ### Knowledge Pipeline
 
@@ -111,7 +106,7 @@ npx fit-codegen --all       # Generate gRPC stubs and field metadata
 npx fit-guide --login       # OAuth PKCE login (or set ANTHROPIC_API_KEY in .env)
 npx fit-process resources   # Process starter knowledge HTML
 npx fit-process graphs      # Build the RDF index
-npx fit-process vectors     # Build the vector index (skip if no embeddings backend)
+npx fit-process vectors     # Build the vector index (requires the embedding service; skip only if vector search is not needed)
 npx fit-rc start            # Launch the service stack
 npx fit-guide "What skills does a senior engineer need?"
 ```
@@ -129,13 +124,15 @@ See [`references/cli.md`](references/cli.md) for full command listings.
 Guide requires the service stack to be running. Services are supervised by
 `fit-rc` and defined in `config/config.json`.
 
-| Order | Service | Protocol        | Purpose                     | Port |
-| ----- | ------- | --------------- | --------------------------- | ---- |
-| 1     | trace   | gRPC            | Distributed tracing         | 3001 |
-| 2     | vector  | gRPC            | Vector similarity search    | 3002 |
-| 3     | graph   | gRPC            | RDF triple store            | 3003 |
-| 4     | pathway | gRPC            | Standard data service       | 3004 |
-| 5     | mcp     | Streamable HTTP | MCP tool and prompt gateway | 3005 |
+| Order | Service   | Protocol        | Purpose                     | Port |
+| ----- | --------- | --------------- | --------------------------- | ---- |
+| 1     | span      | gRPC            | Distributed tracing         | 3001 |
+| 2     | embedding | gRPC            | Text embeddings             | 3015 |
+| 3     | vector    | gRPC            | Vector similarity search    | 3002 |
+| 4     | graph     | gRPC            | RDF triple store            | 3003 |
+| 5     | pathway   | gRPC            | Standard data service       | 3005 |
+| 6     | map       | gRPC            | Activity data service       | 3004 |
+| 7     | mcp       | Streamable HTTP | MCP tool and prompt gateway | 3011 |
 
 ### MCP Endpoint Configuration
 
@@ -144,7 +141,7 @@ For Claude Code, register the MCP endpoint in your MCP server config:
 ```json
 {
   "guide": {
-    "url": "http://localhost:3005",
+    "url": "http://localhost:3011",
     "headers": { "Authorization": "Bearer <MCP_TOKEN>" }
   }
 }
@@ -165,13 +162,11 @@ For Claude Code, register the MCP endpoint in your MCP server config:
 See [`references/data.md`](references/data.md) for processing steps and
 directory layout.
 
----
-
 ## Verification
 
 ```sh
-npx fit-guide status                    # All services should show "ok"
-echo "hello" | npx fit-guide            # Should return an agent response
+npx fit-guide --status                  # All services should show "ok"
+npx fit-guide "hello"                   # Should return an agent response
 ```
 
 ## Documentation

--- a/.claude/skills/fit-guide/references/cli.md
+++ b/.claude/skills/fit-guide/references/cli.md
@@ -3,7 +3,9 @@
 ## Conversational Agent
 
 ```sh
-npx fit-guide                              # Send a question (piped or as args)
+npx fit-guide "Tell me about X"            # One-shot positional prompt
+echo "Tell me about X" | npx fit-guide     # Equivalent piped form
+npx fit-guide                              # Interactive session
 npx fit-guide --help                       # Show help
 npx fit-guide --version                    # Print package version
 npx fit-guide --init                       # Bootstrap .env + config/ + .claude/skills/ (idempotent re-runs)
@@ -12,8 +14,11 @@ npx fit-guide --logout                     # Clear stored credentials
 npx fit-guide --resume                     # Resume previous conversation
 npx fit-guide --status                     # Check system readiness
 npx fit-guide --status --json              # Machine-readable status
-echo "Tell me about X" | npx fit-guide     # Piped single prompt
 ```
+
+Positional words are always prompt text, never commands — `npx fit-guide
+status` sends the word "status" to the agent. Operational commands are
+always flags (`--status`, `--login`).
 
 The CLI is built on the Claude Agent SDK. It connects to the MCP endpoint for
 tools and prompts, and streams the response.

--- a/.claude/skills/fit-visualize/SKILL.md
+++ b/.claude/skills/fit-visualize/SKILL.md
@@ -16,14 +16,17 @@ flowing.
 
 ## When to Use
 
-- Render every span as a diagram — `echo "[]" | npx fit-visualize`
+- Render every span as a diagram — `npx fit-visualize "[]"`
 - Filter spans by name — `echo "[?name=='ProcessStream']" | npx fit-visualize`
 - Scope to one trace or resource — `--trace <id>` / `--resource <id>`
 
 ## Usage
 
 ```sh
-# All spans, as a Mermaid sequence diagram
+# All spans, as a Mermaid sequence diagram (one-shot positional query)
+npx fit-visualize "[]"
+
+# Equivalent piped form
 echo "[]" | npx fit-visualize
 
 # Filter by span name
@@ -36,7 +39,8 @@ echo "[]" | npx fit-visualize --trace 0f53069dbc62d
 echo "[?kind==\`2\`]" | npx fit-visualize --resource common.Conversation.abc123
 ```
 
-The JMESPath expression is read from stdin and applied to the spans before
+The JMESPath expression arrives as a one-shot positional argument or on
+stdin — the two forms are equivalent — and is applied to the spans before
 rendering. `--trace` and `--resource` narrow the set first. Output is a fenced
 `mermaid` block, ready to paste into Markdown.
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -2,9 +2,9 @@
 
 Local runtime configuration. This directory is gitignored — each contributor
 maintains their own `config.json`, read by `libconfig` at startup. A fresh
-clone has none: create one from the structure below before running services. A
-minimal `init.services` block (the services you need, in dependency order) is
-enough for `fit-rc`; `service`/`product` blocks override constructor defaults.
+clone has none: create one from the structure below. A minimal `init.services`
+block (dependency order) is enough for `fit-rc`; `service`/`product` blocks
+override constructor defaults.
 
 ## Audience
 
@@ -55,8 +55,8 @@ Defines which processes `fit-rc` manages.
 }
 ```
 
-Each entry has a `name` and a `command` (the shell command `fit-rc` spawns).
-Non-Node commands needing `.env` variables must source them explicitly.
+Each entry has a `name` and a `command` (the shell command `fit-rc`
+spawns); non-Node commands needing `.env` must source it explicitly.
 
 **Declaration order matters.** `start <name>` starts the target and
 everything before it (bringing up dependencies). `stop <name>` and
@@ -92,12 +92,9 @@ is public-facing (its `oidctunnel` mirrors `oauthtunnel`); `tenancy` and
 Oneshot services use `"type": "oneshot"` with `up`/`down` instead of `command`:
 
 ```json
-{
-  "name": "supabase",
-  "type": "oneshot",
+{ "name": "supabase", "type": "oneshot",
   "up": "sh -c '. ./.env && cd products/map && supabase start --workdir .'",
-  "down": "sh -c 'cd products/map && supabase stop --workdir .'"
-}
+  "down": "sh -c 'cd products/map && supabase stop --workdir .'" }
 ```
 
 ### `service.<name>` — service configuration
@@ -105,9 +102,9 @@ Oneshot services use `"type": "oneshot"` with `up`/`down` instead of `command`:
 Values merge with the service's constructor defaults, then overridden by
 `SERVICE_{NAME}_{KEY}` environment variables from `.env` or the shell.
 
-For configuring the platform apps whose credentials feed these blocks and
-`.env` — self-hosted (single-tenant) vs hosted (multi-tenant) — see the
-per-app guides:
+For the platform apps whose credentials feed these blocks and `.env` —
+self-hosted (single-tenant) vs hosted (multi-tenant) — see the per-app
+guides:
 
 - [GitHub server App](../services/ghserver/github-app.md) — installation-token
   App (`ghbridge` / `ghserver`).
@@ -117,8 +114,11 @@ per-app guides:
 
 ### `product.<name>` — product configuration
 
-Same merge/override pattern as services, with `PRODUCT_{NAME}_{KEY}`
-environment variables.
+Same merge/override pattern as services, with `PRODUCT_{NAME}_{KEY}` environment
+variables. Guide's `service.mcp` block and `product.guide.systemPrompt` copy
+from `products/guide/starter/config.json` — the single source of truth
+([products/guide/CLAUDE.md](../products/guide/CLAUDE.md)); with no `tools`, the
+MCP server warns and exposes nothing.
 
 ## `.env`
 

--- a/libraries/libformat/src/index.js
+++ b/libraries/libformat/src/index.js
@@ -147,23 +147,27 @@ export class TerminalFormatter {
   #marked;
   #markedTerminal;
   #terminalMarked;
+  #colors;
 
   /**
    * Creates a terminal formatter with required dependencies
    * @param {object} marked - Marked markdown parser
    * @param {object} markedTerminal - marked-terminal plugin
+   * @param {object} [options]
+   * @param {boolean} [options.colors=true] - Emit ANSI escape codes; pass
+   *   false when the output is not a TTY so pipes receive plain text
    */
-  constructor(marked, markedTerminal) {
+  constructor(marked, markedTerminal, { colors = true } = {}) {
     if (!marked) throw new Error("marked dependency is required");
     if (!markedTerminal)
       throw new Error("markedTerminal dependency is required");
 
     this.#marked = marked;
     this.#markedTerminal = markedTerminal;
+    this.#colors = colors;
 
     // Initialize the terminal marked instance with plugin
     // Pass ignoreIllegals to suppress highlight.js warnings about unknown languages
-    // Disable colors if stdout is not a TTY to prevent broken ANSI codes
     this.#terminalMarked = new this.#marked.Marked({
       silent: true,
     });
@@ -206,7 +210,10 @@ export class TerminalFormatter {
     const processed = this.#formatDetails(markdown);
     const formatted = this.#terminalMarked.parse(processed);
     // Reduce the length of horizontal lines by replacing long sequences of dashes
-    return formatted.replace(/-{73,}/g, "-".repeat(72));
+    const normalized = formatted.replace(/-{73,}/g, "-".repeat(72));
+    if (this.#colors) return normalized;
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI SGR removal is intentional.
+    return normalized.replace(/\[[0-9;]*m/g, "");
   }
 }
 
@@ -315,8 +322,12 @@ export function createHtmlFormatter() {
  * Creates a terminal formatter with automatically injected dependencies
  * @returns {TerminalFormatter} Configured terminal formatter instance
  */
-export function createTerminalFormatter() {
-  return new TerminalFormatter({ Marked: Marked }, markedTerminal);
+export function createTerminalFormatter({
+  isTTY = globalThis.process.stdout.isTTY,
+} = {}) {
+  return new TerminalFormatter({ Marked: Marked }, markedTerminal, {
+    colors: Boolean(isTTY),
+  });
 }
 
 /**

--- a/libraries/libformat/test/libformat.test.js
+++ b/libraries/libformat/test/libformat.test.js
@@ -6,6 +6,7 @@ import {
   AgentTraceFormatter,
   HtmlFormatter,
   TerminalFormatter,
+  createTerminalFormatter,
 } from "../src/index.js";
 
 describe("libformat", () => {
@@ -176,6 +177,25 @@ describe("libformat", () => {
     test("handles empty input", () => {
       const terminal = terminalFormatter.format("");
       assert.strictEqual(typeof terminal, "string");
+    });
+
+    test("strips ANSI codes when colors are disabled", () => {
+      const plain = new TerminalFormatter(mockMarked, mockMarkedTerminal, {
+        colors: false,
+      });
+      const terminal = plain.format("This is **bold** text.");
+
+      assert(!terminal.includes("\x1b["));
+      assert(terminal.includes("bold"));
+    });
+
+    test("createTerminalFormatter emits no ANSI when stdout is not a TTY", () => {
+      const formatted = createTerminalFormatter({ isTTY: false }).format(
+        "# Heading\n\nThis is **bold** text.",
+      );
+
+      assert(!formatted.includes("\x1b["));
+      assert(formatted.includes("bold"));
     });
   });
 

--- a/libraries/librepl/README.md
+++ b/libraries/librepl/README.md
@@ -18,3 +18,26 @@ const repl = new Repl({
 });
 await repl.start();
 ```
+
+## Input contract
+
+One line of input produces one `onLine` call, whichever way it arrives.
+Three equivalent input sources:
+
+- **Positional argv (one-shot)** — `mycli "hello world"` joins the
+  positional args into a single line, echoes `prompt + line`, runs
+  `onLine` once, and exits 0.
+- **Piped stdin** — `echo "hello world" | mycli` delivers one `onLine`
+  call per line, then exits 0.
+- **Interactive readline** — a TTY session delivers one `onLine` call
+  per entered line.
+
+**Flags win.** `--flag` args run their command handlers before any
+positional is processed; a handler returning `false` exits without
+touching the positionals (`mycli --status "hello"` never reaches
+`onLine`).
+
+**Positionals are prompt text, never commands.** `mycli status` sends
+the word "status" to `onLine`; operations are always flags
+(`--status`). Consumers document their own usage; the mechanism lives
+here.

--- a/libraries/librepl/src/index.js
+++ b/libraries/librepl/src/index.js
@@ -151,15 +151,22 @@ export class Repl {
   }
 
   /**
-   * Parses command line arguments to override state values and returns whether to exit early
-   * @returns {Promise<boolean>} True if the process should exit after parsing
+   * Parses command line arguments: `--flag` args run their command
+   * handlers (overriding state values), every other arg is collected as
+   * a positional. Positionals are always prompt text, never commands.
+   * @returns {Promise<{shouldExit: boolean, positionals: string[]}>}
+   *   `shouldExit` is true when a flag handler requested an early exit.
    */
   async #parseArgs() {
     const args = this.#process.argv.slice(2);
+    const positionals = [];
 
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
-      if (!arg.startsWith("--")) continue;
+      if (!arg.startsWith("--")) {
+        positionals.push(arg);
+        continue;
+      }
 
       const { flagName, inlineValue } = this.#parseFlag(arg);
       const commandName = flagName.replace(/-/g, "_");
@@ -172,9 +179,9 @@ export class Repl {
       i += resolved.skip;
 
       const result = await command.handler(resolved.handlerArgs, this.state);
-      if (result === false) return true;
+      if (result === false) return { shouldExit: true, positionals };
     }
-    return false;
+    return { shouldExit: false, positionals };
   }
 
   /**
@@ -376,14 +383,25 @@ export class Repl {
     // Load state from storage first
     await this.#loadState();
 
-    // Parse command line arguments (exits early if any command returns false)
-    // These override loaded state values
-    const shouldExit = await this.#parseArgs();
+    // Parse command line arguments (exits early if any command returns
+    // false — flags win over positionals). These override loaded state
+    // values.
+    const { shouldExit, positionals } = await this.#parseArgs();
     if (shouldExit) return;
 
     // Run setup if provided
     if (this.#app.setup) {
       await this.#app.setup(this.state);
+    }
+
+    // One-shot mode - positional args are a single prompt line,
+    // equivalent to piping the same line via stdin
+    if (positionals.length > 0) {
+      const line = positionals.join(" ");
+      this.#process.stdout.write(`${this.#app.prompt}${line}\n`);
+      await this.#handleLine(line);
+      this.#process.exit(0);
+      return;
     }
 
     // Non-interactive mode - process stdin

--- a/libraries/librepl/test/librepl-oneshot.test.js
+++ b/libraries/librepl/test/librepl-oneshot.test.js
@@ -1,0 +1,138 @@
+/**
+ * One-shot input contract: one line of input produces exactly one
+ * onLine call whether it arrives as positional argv or piped stdin,
+ * flags win over positionals, and positionals are always prompt text —
+ * never commands.
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert";
+
+import { createReplEnvironment } from "@forwardimpact/libmock";
+
+import { Repl } from "../src/index.js";
+
+describe("librepl one-shot input", () => {
+  let mockReadline, mockProcess, mockFormatter, mockOs;
+  let onLineCalls, outputData;
+
+  beforeEach(() => {
+    ({
+      readline: mockReadline,
+      process: mockProcess,
+      os: mockOs,
+      formatter: mockFormatter,
+    } = createReplEnvironment());
+    onLineCalls = [];
+    outputData = "";
+    mockProcess.stdout.write = (text) => {
+      outputData += text;
+    };
+  });
+
+  function buildRepl(app = {}) {
+    return new Repl(
+      {
+        prompt: "> ",
+        onLine: async (input) => {
+          onLineCalls.push(input);
+        },
+        ...app,
+      },
+      mockFormatter,
+      mockReadline,
+      mockProcess,
+      mockOs,
+    );
+  }
+
+  function pipeStdin(line) {
+    mockProcess.stdin = {
+      isTTY: false,
+      setEncoding: () => {},
+      async *[Symbol.asyncIterator]() {
+        yield line;
+      },
+    };
+  }
+
+  test("positional argv produces one onLine call, echoes the prompt, exits 0", async () => {
+    mockProcess.argv = ["node", "script.js", "hello", "world"];
+
+    await buildRepl().start();
+
+    assert.deepStrictEqual(onLineCalls, ["hello world"]);
+    assert(outputData.includes("> hello world"));
+    assert.strictEqual(mockProcess._exitCalled, true);
+    assert.strictEqual(mockProcess._exitCode, 0);
+  });
+
+  test("positional argv and piped stdin deliver the identical single line", async () => {
+    mockProcess.argv = ["node", "script.js", "hello", "world"];
+    await buildRepl().start();
+    const argvCalls = [...onLineCalls];
+
+    onLineCalls = [];
+    mockProcess.argv = ["node", "script.js"];
+    pipeStdin("hello world\n");
+    await buildRepl().start();
+
+    assert.deepStrictEqual(argvCalls, ["hello world"]);
+    assert.deepStrictEqual(onLineCalls, argvCalls);
+  });
+
+  test("a flag handler returning false exits before any positional prompt", async () => {
+    mockProcess.argv = ["node", "script.js", "--status", "hello"];
+
+    await buildRepl({
+      commands: {
+        status: {
+          usage: "Report status",
+          type: "boolean",
+          handler: async () => false,
+        },
+      },
+    }).start();
+
+    assert.deepStrictEqual(onLineCalls, []);
+  });
+
+  test("args consumed as flag values are not prompt text", async () => {
+    mockProcess.argv = ["node", "script.js", "--set-var", "value", "hello"];
+
+    await buildRepl({
+      state: { var: null },
+      commands: {
+        set_var: {
+          usage: "Set var",
+          handler: async ([value], state) => {
+            state.var = value;
+          },
+        },
+      },
+    }).start();
+
+    assert.deepStrictEqual(onLineCalls, ["hello"]);
+  });
+
+  test("positional words are prompt text even when they match a command name", async () => {
+    let statusRuns = 0;
+    mockProcess.argv = ["node", "script.js", "status"];
+
+    await buildRepl({
+      commands: {
+        status: {
+          usage: "Report status",
+          type: "boolean",
+          handler: async () => {
+            statusRuns++;
+            return false;
+          },
+        },
+      },
+    }).start();
+
+    assert.strictEqual(statusRuns, 0);
+    assert.deepStrictEqual(onLineCalls, ["status"]);
+  });
+});

--- a/libraries/libtelemetry/bin/fit-visualize.js
+++ b/libraries/libtelemetry/bin/fit-visualize.js
@@ -26,6 +26,7 @@ const definition = {
     json: { type: "boolean", description: "Output help as JSON" },
   },
   examples: [
+    'fit-visualize "[]"',
     "echo \"[?name=='ProcessStream']\" | fit-visualize",
     'echo "[]" | fit-visualize --trace 0f53069dbc62d',
   ],

--- a/products/guide/src/lib/status.js
+++ b/products/guide/src/lib/status.js
@@ -105,9 +105,30 @@ async function queryDataInventory(graphConfig, runtime) {
   return { resources, triples };
 }
 
-const SERVICE_NAMES = ["span", "vector", "graph", "pathway", "mcp"];
+/**
+ * The services `--status` reports on — the same set the starter config
+ * declares for supervision (`starter/config.json` `init.services`), the
+ * product contract for a working stack. A test pins the two lists
+ * together; change them in the same commit.
+ */
+export const SERVICE_NAMES = [
+  "span",
+  "embedding",
+  "vector",
+  "graph",
+  "pathway",
+  "map",
+  "mcp",
+];
 
-const GRPC_SERVICES = ["span", "vector", "graph", "pathway"];
+const GRPC_SERVICES = [
+  "span",
+  "embedding",
+  "vector",
+  "graph",
+  "pathway",
+  "map",
+];
 
 const HTTP_SERVICES = {
   mcp: "/health",

--- a/products/guide/starter/config.json
+++ b/products/guide/starter/config.json
@@ -8,6 +8,10 @@
         "command": "node -e \"import('@forwardimpact/svcspan/server.js')\""
       },
       {
+        "name": "embedding",
+        "command": "node -e \"import('@forwardimpact/svcembedding/server.js')\""
+      },
+      {
         "name": "vector",
         "command": "node -e \"import('@forwardimpact/svcvector/server.js')\""
       },

--- a/products/guide/test/status.test.js
+++ b/products/guide/test/status.test.js
@@ -1,11 +1,12 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
+import { readFile } from "node:fs/promises";
 import {
   createMockClock,
   createMockFs,
   createMockGrpcHealthDefinition,
 } from "@forwardimpact/libmock";
-import { runStatus } from "../src/lib/status.js";
+import { runStatus, SERVICE_NAMES } from "../src/lib/status.js";
 
 /**
  * Creates a mock createServiceConfig that returns configs with predictable URLs.
@@ -19,6 +20,13 @@ function createMockConfigFactory(overrides = {}) {
       host: "localhost",
       port: 3001,
       url: "grpc://localhost:3001",
+      anthropicToken: async () => "test-anthropic-key",
+    },
+    embedding: {
+      name: "embedding",
+      host: "localhost",
+      port: 3015,
+      url: "grpc://localhost:3015",
       anthropicToken: async () => "test-anthropic-key",
     },
     vector: {
@@ -38,6 +46,13 @@ function createMockConfigFactory(overrides = {}) {
     pathway: {
       name: "pathway",
       host: "localhost",
+      port: 3005,
+      url: "grpc://localhost:3005",
+      anthropicToken: async () => "test-anthropic-key",
+    },
+    map: {
+      name: "map",
+      host: "localhost",
       port: 3004,
       url: "grpc://localhost:3004",
       anthropicToken: async () => "test-anthropic-key",
@@ -45,8 +60,8 @@ function createMockConfigFactory(overrides = {}) {
     mcp: {
       name: "mcp",
       host: "localhost",
-      port: 3005,
-      url: "http://localhost:3005",
+      port: 3011,
+      url: "http://localhost:3011",
       anthropicToken: async () => "test-anthropic-key",
     },
   };
@@ -157,6 +172,18 @@ describe("runStatus", () => {
 
     assert.strictEqual(result.verdict, "not ready");
     assert.strictEqual(result.credentials.ANTHROPIC_API_KEY, "missing");
+  });
+
+  test("status service list matches the starter config's declared services", async () => {
+    const starter = JSON.parse(
+      await readFile(
+        new URL("../starter/config.json", import.meta.url),
+        "utf-8",
+      ),
+    );
+    const declared = starter.init.services.map((s) => s.name);
+
+    assert.deepStrictEqual([...SERVICE_NAMES].sort(), [...declared].sort());
   });
 
   test("result serializes to expected JSON shape", async () => {

--- a/services/mcp/server.js
+++ b/services/mcp/server.js
@@ -28,6 +28,16 @@ if (!handled) {
   const logger = createLogger("mcp", runtime);
   const tracer = await createTracer("mcp");
 
+  if (!config.tools || Object.keys(config.tools).length === 0) {
+    logger.warn(
+      "startup",
+      "No MCP tools configured — the server will expose zero tools and " +
+        "agents cannot query the standard. Define service.mcp.tools in " +
+        "your config.json; see " +
+        "https://www.forwardimpact.team/docs/getting-started/engineers/guide/index.md",
+    );
+  }
+
   const graphClient = await createClient("graph", logger, tracer);
   const vectorClient = await createClient("vector", logger, tracer);
   const pathwayClient = await createClient("pathway", logger, tracer);

--- a/websites/fit/docs/getting-started/engineers/guide/index.md
+++ b/websites/fit/docs/getting-started/engineers/guide/index.md
@@ -71,7 +71,8 @@ mcp) in dependency order. Configuration and secrets are read automatically from
 
 ```sh
 npx fit-guide                                        # Start interactive conversation
-echo "What skills should I focus on for J060?" | npx fit-guide  # Pipe a question
+npx fit-guide "What skills should I focus on for J060?"         # One-shot question
+echo "What skills should I focus on for J060?" | npx fit-guide  # Equivalent piped form
 ```
 
 Example pipe-mode output:

--- a/websites/fit/docs/internals/operations/index.md
+++ b/websites/fit/docs/internals/operations/index.md
@@ -41,7 +41,7 @@ just env-setup     # Generate every secret in .env (idempotent across runs)
 ```
 
 `ANTHROPIC_API_KEY` is set in the environment (provided by the hosting platform,
-`.env`, or `fit-guide login`). Any code using `libconfig` to access Anthropic
+`.env`, or `fit-guide --login`). Any code using `libconfig` to access Anthropic
 credentials works out of the box.
 
 ---
@@ -72,8 +72,9 @@ bunx fit-rc status             # Show service status
 bunx fit-rc start embedding    # Start a single service
 ```
 
-Services run on localhost in local mode (core ports 3001–3005; optional
-services on additional ports). Port mapping is in `.env.local.example`.
+Services run on localhost in local mode (gRPC services on ports
+3001–3005, mcp on 3011, embedding on 3015; optional services on
+additional ports). Port mapping is in `.env.local.example`.
 
 TEI (Text Embeddings Inference) provides local embeddings:
 


### PR DESCRIPTION
## Summary

- **librepl one-shot positional prompts (F3):** `fit-guide "question"` and `echo "question" | fit-guide` are now equivalent, documented invocation forms — librepl collects positional argv into a single prompt line, echoes `prompt + line`, runs `onLine` once, and exits 0. Flags still win (a handler returning `false` exits before positionals); positionals are always prompt text, never commands. Zero consumer changes; `fit-visualize` gains the same one-shot form (`fit-visualize "[]"`).
- **ANSI in pipes (F10):** `TerminalFormatter`'s long-promised TTY check is implemented — `createTerminalFormatter()` strips ANSI SGR codes when stdout is not a TTY. Verified: `fit-guide --status | cat` emits zero escape bytes.
- **fit-guide skill staleness (F4):** port table corrected (span 3001, embedding 3015, vector 3002, graph 3003, pathway 3005, map 3004, mcp 3011), bare `login`/`status` → `--login`/`--status`, vectors note now says the embedding service is required, tool list caught up with the starter config.
- **MCP zero-tools warning (F5):** `svcmcp` logs a loud startup warning (public docs URL, no monorepo paths) when `service.mcp.tools` is empty.
- **`--status` coverage:** `embedding` and `map` added to the status service list and to `starter/config.json` `init.services` (embedding placed before vector, which calls it at query time); a test pins the status list to the starter config so the contract cannot drift.
- Docs: librepl README owns the input contract; fit-guide/fit-visualize skills, config/CLAUDE.md pointer, and websites sweep (`fit-guide --login`, port ranges, one-shot examples) land in the same PR.

## Test plan

- [x] `bun run check`
- [x] `bun test` in librepl (16), libformat (30), guide (15), svcmcp (23), libtelemetry (46)
- [x] `fit-guide --status | cat` — 7 services listed, no ANSI escapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)