### PR TITLE
fix(libcodegen): prune stale generated service dirs and verify freshness in bootstrap

### DIFF
--- a/.claude/skills/fit-codegen/SKILL.md
+++ b/.claude/skills/fit-codegen/SKILL.md
@@ -48,6 +48,10 @@ generates types and clients only. `generate` needs the proto-compiler
 toolchain, which ships with a default install; `download` is lean and carries
 none of it.
 
+Generation prunes stale `generated/services/*` dirs whose proto no longer
+exists (the generated tree is machine-owned, so pruning is safe) — after a
+proto rename, re-running codegen alone fixes the tree.
+
 ## Documentation
 
 - [Keep Types Synced with Proto Definitions](https://www.forwardimpact.team/docs/libraries/typed-contracts/index.md)

--- a/libraries/libcodegen/src/services.js
+++ b/libraries/libcodegen/src/services.js
@@ -42,6 +42,7 @@ export class CodegenServices {
   async runExports(generatedPath) {
     if (!generatedPath) throw new Error("generatedPath is required");
     const serviceDir = this.#base.path.join(generatedPath, "services");
+    this.#pruneStaleDirs(serviceDir);
     const outputFile = this.#base.path.join(serviceDir, "exports.js");
 
     this.#base.fs.mkdirSync(this.#base.path.dirname(outputFile), {
@@ -90,5 +91,29 @@ export class CodegenServices {
     });
 
     this.#base.fs.writeFileSync(outputFile, content);
+  }
+
+  /**
+   * Remove generated service dirs whose proto no longer exists. The
+   * generated tree is fully machine-owned, so pruning is safe; without
+   * it a proto rename leaves the old dir behind and re-enters it into
+   * exports.js on every regeneration.
+   * @param {string} serviceDir - Path to generated/services
+   */
+  #pruneStaleDirs(serviceDir) {
+    if (!this.#base.fs.existsSync(serviceDir)) return;
+    const expected = new Set(
+      this.#base
+        .collectProtoFiles({ includeTools: true })
+        .filter((file) => !file.endsWith(this.#base.path.sep + "common.proto"))
+        .map((file) => this.#base.path.basename(file, ".proto")),
+    );
+    for (const dir of this.#base.fs.readdirSync(serviceDir)) {
+      const dirPath = this.#base.path.join(serviceDir, dir);
+      if (!this.#base.fs.statSync(dirPath).isDirectory()) continue;
+      if (!expected.has(dir)) {
+        this.#base.fs.rmSync(dirPath, { recursive: true, force: true });
+      }
+    }
   }
 }

--- a/libraries/libcodegen/test/services-prune.test.js
+++ b/libraries/libcodegen/test/services-prune.test.js
@@ -5,7 +5,7 @@
  * poison exports.js.
  */
 
-import { test, describe } from "node:test";
+import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert";
 import fs from "node:fs";
 import os from "node:os";
@@ -15,9 +15,17 @@ import protoLoader from "@grpc/proto-loader";
 import mustache from "mustache";
 
 import { CodegenBase, CodegenServices } from "@forwardimpact/libcodegen";
+import { resetEmbeddedAssets } from "@forwardimpact/libcli";
 import { createTestRuntime } from "@forwardimpact/libmock";
 
 describe("CodegenServices.runExports pruning", () => {
+  // Earlier test files in the same bun process may leave the module-global
+  // embedded-assets registry active (see base.test.js) — loadTemplate must
+  // resolve the on-disk templates here.
+  beforeEach(() => {
+    resetEmbeddedAssets();
+  });
+
   test("removes stale service dirs and keeps proto-backed ones", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-prune-"));
     const protoDir = path.join(tmp, "proto");

--- a/libraries/libcodegen/test/services-prune.test.js
+++ b/libraries/libcodegen/test/services-prune.test.js
@@ -1,0 +1,71 @@
+/**
+ * runExports prunes generated/services dirs whose proto no longer
+ * exists — the generated tree is machine-owned, so a proto rename is
+ * fixed by re-running codegen alone instead of leaving the old dir to
+ * poison exports.js.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import protoLoader from "@grpc/proto-loader";
+import mustache from "mustache";
+
+import { CodegenBase, CodegenServices } from "@forwardimpact/libcodegen";
+import { createTestRuntime } from "@forwardimpact/libmock";
+
+describe("CodegenServices.runExports pruning", () => {
+  test("removes stale service dirs and keeps proto-backed ones", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "codegen-prune-"));
+    const protoDir = path.join(tmp, "proto");
+    fs.mkdirSync(protoDir, { recursive: true });
+    fs.writeFileSync(path.join(protoDir, "demo.proto"), 'syntax = "proto3";\n');
+
+    const generated = path.join(tmp, "generated");
+    const demoDir = path.join(generated, "services", "demo");
+    const staleDir = path.join(generated, "services", "stale");
+    fs.mkdirSync(demoDir, { recursive: true });
+    fs.mkdirSync(staleDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(demoDir, "service.js"),
+      "export class DemoBase {}\n",
+    );
+    fs.writeFileSync(
+      path.join(staleDir, "service.js"),
+      "export class StaleBase {}\n",
+    );
+    fs.writeFileSync(
+      path.join(staleDir, "client.js"),
+      "export class StaleClient {}\n",
+    );
+
+    const base = new CodegenBase(
+      [protoDir],
+      tmp,
+      path,
+      mustache,
+      protoLoader,
+      fs,
+      createTestRuntime(),
+    );
+    const services = new CodegenServices(base);
+
+    try {
+      await services.runExports(generated);
+
+      assert.ok(!fs.existsSync(staleDir), "stale dir should be removed");
+      assert.ok(fs.existsSync(demoDir), "proto-backed dir should survive");
+      const exportsSource = fs.readFileSync(
+        path.join(generated, "services", "exports.js"),
+        "utf-8",
+      );
+      assert.ok(exportsSource.includes("DemoBase"));
+      assert.ok(!exportsSource.includes("Stale"));
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -37,6 +37,29 @@ else
   for link in libraries/*/src/generated; do
     [ -e "$link" ] || needs_install=1
   done
+  # generated/services must mirror the proto set exactly, keyed by proto
+  # BASENAME (resource/tool ship via libproto's node_modules protos, not a
+  # service dir). A rename otherwise leaves the old dir behind — codegen's
+  # prune removes it — while the renamed service never gets generated, so
+  # "workspace ready" precedes a crash-loop. Skip common.proto (no service).
+  proto_names=$(
+    for p in services/*/proto/*.proto \
+      node_modules/@forwardimpact/libproto/proto/*.proto \
+      tools/*.proto; do
+      [ -e "$p" ] || continue
+      b=$(basename "$p" .proto)
+      [ "$b" = "common" ] || echo "$b"
+    done | sort -u
+  )
+  for name in $proto_names; do
+    [ -d "generated/services/$name" ] || needs_install=1
+  done
+  if [ -d generated/services ]; then
+    for d in generated/services/*/; do
+      [ -e "$d" ] || continue
+      echo "$proto_names" | grep -qx "$(basename "$d")" || needs_install=1
+    done
+  fi
   if [ "$needs_install" = "0" ]; then
     echo "Workspace ready — node_modules and generated resolve; skipping install and codegen"
   elif [ -d node_modules ]; then


### PR DESCRIPTION
## Summary

- **libcodegen prune:** `runExports` now removes any `generated/services/<dir>` whose proto no longer exists (computed from proto basenames via `collectProtoFiles({includeTools:true})`, minus `common`) before rendering `exports.js`. The generated tree is fully machine-owned, so pruning is safe — a proto rename is fixed by re-running codegen alone.
- **bootstrap.sh warm-path freshness:** the warm path now requires `generated/services/*` to mirror the proto basename set exactly (service protos + `node_modules/@forwardimpact/libproto/proto` + `tools/`, skipping `common.proto`); any missing or extra dir triggers `just codegen`. This closes the F2 gap where the `trace→span` rename left `generated/services/trace` resolving, bootstrap said "workspace ready", and five services crash-looped.

Verified live: `mv generated/services/span generated/services/trace` → `bash scripts/bootstrap.sh` detects the mismatch, runs codegen, `trace/` is pruned, `span/` regenerated, `exports.js` clean; a second run reports "Workspace ready".

## Test plan

- [x] `bun run check`
- [x] `bun test` in libcodegen (17 pass, incl. new prune test seeding a fake `stale/` dir)
- [x] Live rename simulation above

🤖 Generated with [Claude Code](https://claude.com/claude-code)