### PR TITLE
fix(librpc): bound unary calls with an absolute deadline across retries

### DIFF
--- a/.claude/skills/fit-process/SKILL.md
+++ b/.claude/skills/fit-process/SKILL.md
@@ -30,6 +30,8 @@ fit-process vectors
 
 `resources` accepts `--base` (`-b`) to set the base URI for generated
 identifiers (default `https://example.invalid/`). `resources` and `graphs` run
-offline; `vectors` calls the embedding service. Run `resources` before `graphs`
-and `vectors`, which both read the resource index it writes. Once the indexes
-are built, query them with `fit-rag`.
+offline; `vectors` requires the embedding service to be up — when it is
+unreachable, the command fails fast (within the RPC deadline, 60s by
+default) naming the embedding host and port instead of hanging. Run
+`resources` before `graphs` and `vectors`, which both read the resource
+index it writes. Once the indexes are built, query them with `fit-rag`.

--- a/libraries/librag/src/commands/vectors.js
+++ b/libraries/librag/src/commands/vectors.js
@@ -31,7 +31,16 @@ export async function run({ runtime }) {
       const req = new embedding.EmbeddingsRequest({
         input: Array.isArray(input) ? input : [input],
       });
-      const res = await embeddingClient.CreateEmbeddings(req);
+      let res;
+      try {
+        res = await embeddingClient.CreateEmbeddings(req);
+      } catch (err) {
+        err.message =
+          `embedding service unreachable at ` +
+          `${embeddingConfig.host}:${embeddingConfig.port} — start it with ` +
+          `fit-rc (${err.message})`;
+        throw err;
+      }
       return {
         data: res.data.map((v) => ({ embedding: Array.from(v.values) })),
       };

--- a/libraries/librpc/README.md
+++ b/libraries/librpc/README.md
@@ -13,6 +13,19 @@ transport.
 import { Server, Client, createClient, createTracer } from '@forwardimpact/librpc';
 ```
 
+## Unary deadlines
+
+Every unary call carries one absolute gRPC deadline spanning all retry
+attempts (default 60s, sized for the slowest unary in practice —
+embedding model inference). A hung connection fails with
+`DEADLINE_EXCEEDED`, and retryable errors (UNAVAILABLE and friends) keep
+cycling only until the call's budget is spent — the first attempt past
+the deadline fails immediately, and `DEADLINE_EXCEEDED` is not retried.
+Override per service with the `deadline` config key (milliseconds) in
+the service's config block; once the key exists there, the
+`SERVICE_{NAME}_DEADLINE` env var overrides it. Streaming calls are
+exempt: keepalive bounds them, and long-lived streams are legitimate.
+
 ## Documentation
 
 - [Ship a Service Endpoint](https://www.forwardimpact.team/docs/libraries/typed-contracts/ship-endpoint/index.md)

--- a/libraries/librpc/src/client.js
+++ b/libraries/librpc/src/client.js
@@ -94,6 +94,15 @@ export class Client extends Rpc {
   }
 
   /**
+   * Close the underlying gRPC channel, releasing its sockets and timers
+   * so short-lived processes (CLIs, tests) can exit promptly.
+   * @returns {void}
+   */
+  close() {
+    this.#client.close();
+  }
+
+  /**
    * Call a gRPC method with automatic CLIENT span tracing and observability.
    * Supports unary calls.
    * @param {string} methodName - The name of the gRPC method to call

--- a/libraries/librpc/src/client.js
+++ b/libraries/librpc/src/client.js
@@ -9,12 +9,22 @@ import {
   capitalizeFirstLetter,
 } from "./base.js";
 
+// No unary call waits forever: every call carries one absolute gRPC
+// deadline spanning all retry attempts, so both a hung connection and a
+// retryable-error grind (exponential backoff on UNAVAILABLE) fail with
+// DEADLINE_EXCEEDED instead of blocking the caller indefinitely. Sized
+// for the slowest unary in practice (embedding model inference);
+// override per service via the `deadline` config key.
+const DEFAULT_UNARY_DEADLINE_MS = 60_000;
+
 /**
  * Creates a gRPC client with consistent API using pre-compiled definitions
  */
 export class Client extends Rpc {
   #client;
   #retry;
+  #clock;
+  #deadlineMs;
 
   /**
    * Creates a new Client instance
@@ -39,6 +49,8 @@ export class Client extends Rpc {
   ) {
     super(config, runtime, logger, tracer, observerFn, grpcFn, authFn);
     this.#retry = retry || createRetry({ retries: 10, delay: 1000 });
+    this.#clock = runtime.clock;
+    this.#deadlineMs = Number(config.deadline) || DEFAULT_UNARY_DEADLINE_MS;
     this.#setupClient();
   }
 
@@ -199,7 +211,13 @@ export class Client extends Rpc {
   }
 
   /**
-   * Internal unary call handler with retry logic
+   * Internal unary call handler with retry logic. The absolute deadline
+   * is computed once and shared by every retry attempt, so retryable
+   * errors keep cycling only until the call's budget is spent — the
+   * first attempt past the deadline fails immediately with
+   * DEADLINE_EXCEEDED, which is deliberately not retryable. Streaming
+   * calls are exempt (keepalive bounds them, and long-lived streams are
+   * legitimate).
    * @param {string} methodName - The name of the method
    * @param {object} request - Request object
    * @param {object} metadata - gRPC Metadata instance
@@ -207,15 +225,21 @@ export class Client extends Rpc {
    * @private
    */
   async #performUnaryCall(methodName, request, metadata) {
+    const options = { deadline: this.#clock.now() + this.#deadlineMs };
     return await this.#retry.execute(() => {
       return new Promise((resolve, reject) => {
-        this.#client[methodName](request, metadata, (error, response) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve(response);
-          }
-        });
+        this.#client[methodName](
+          request,
+          metadata,
+          options,
+          (error, response) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(response);
+            }
+          },
+        );
       });
     });
   }

--- a/libraries/librpc/test/client-deadline.integration.test.js
+++ b/libraries/librpc/test/client-deadline.integration.test.js
@@ -1,0 +1,63 @@
+/**
+ * Real-grpc deadline behavior: a unary call against a connection that
+ * accepts TCP but never speaks HTTP/2 (the hung-service case) must
+ * reject with DEADLINE_EXCEEDED in bounded time instead of waiting
+ * forever. Uses a raw net server so the channel stays CONNECTING until
+ * the per-attempt deadline fires.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import net from "node:net";
+
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+import { createRetry } from "@forwardimpact/libutil";
+import { createMockObserverFn } from "@forwardimpact/libmock";
+
+import { Client } from "../src/index.js";
+
+describe("Client unary deadline", () => {
+  test("hung connection rejects with DEADLINE_EXCEEDED in bounded time", async () => {
+    const server = net.createServer(() => {
+      // Accept the connection and never respond.
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = server.address().port;
+
+    const base = createDefaultRuntime();
+    const runtime = {
+      ...base,
+      proc: {
+        ...base.proc,
+        env: {
+          ...base.proc.env,
+          SERVICE_SECRET: "test-secret-test-secret-test-secret",
+        },
+      },
+    };
+    const client = new Client(
+      { name: "graph", host: "127.0.0.1", port, deadline: 300 },
+      runtime,
+      null,
+      null,
+      createMockObserverFn(),
+      undefined,
+      undefined,
+      createRetry({ retries: 0, delay: 1 }),
+    );
+
+    const started = Date.now();
+    try {
+      await assert.rejects(
+        () => client.callUnary("GetOntology", {}),
+        (err) => err.code === 4, // grpc.status.DEADLINE_EXCEEDED
+      );
+      assert.ok(
+        Date.now() - started < 5000,
+        "must fail within the deadline, not hang",
+      );
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/libraries/librpc/test/client-deadline.integration.test.js
+++ b/libraries/librpc/test/client-deadline.integration.test.js
@@ -18,8 +18,12 @@ import { Client } from "../src/index.js";
 
 describe("Client unary deadline", () => {
   test("hung connection rejects with DEADLINE_EXCEEDED in bounded time", async () => {
-    const server = net.createServer(() => {
-      // Accept the connection and never respond.
+    // Accept connections and never respond; track the sockets so
+    // teardown can destroy them — open handles would otherwise keep the
+    // node test runner alive after the assertions pass.
+    const sockets = [];
+    const server = net.createServer((socket) => {
+      sockets.push(socket);
     });
     await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
     const port = server.address().port;
@@ -57,6 +61,8 @@ describe("Client unary deadline", () => {
         "must fail within the deadline, not hang",
       );
     } finally {
+      client.close();
+      for (const socket of sockets) socket.destroy();
       server.close();
     }
   });

--- a/libraries/librpc/test/client.test.js
+++ b/libraries/librpc/test/client.test.js
@@ -31,7 +31,9 @@ describe("Client", () => {
     };
 
     mockClientInstance = {
-      TestMethod: spy((_req, _meta, cb) => cb(null, { result: "success" })),
+      TestMethod: spy((_req, _meta, _opts, cb) =>
+        cb(null, { result: "success" }),
+      ),
       StreamMethod: spy((_req, _meta) => {
         const stream = new PassThrough({ objectMode: true });
         process.nextTick(() => {
@@ -107,6 +109,8 @@ describe("Client", () => {
     const response = await client.callUnary("TestMethod", { some: "data" });
     assert.deepStrictEqual(response, { result: "success" });
     assert.strictEqual(mockClientInstance.TestMethod.mock.callCount(), 1);
+    const options = mockClientInstance.TestMethod.mock.calls[0].arguments[2];
+    assert.strictEqual(typeof options.deadline, "number");
   });
 
   test("callStream should execute streaming call", async () => {

--- a/libraries/libvector/src/processor/vector.js
+++ b/libraries/libvector/src/processor/vector.js
@@ -100,25 +100,21 @@ export class VectorProcessor extends ProcessorBase {
       context,
     });
 
-    try {
-      // Collect all texts and make a single embedding request
-      const texts = batch.map((item) => item.text);
-      const embeddings = await this.#llm.createEmbeddings(texts);
+    // Collect all texts and make a single embedding request. A failure
+    // aborts the run: the client's retry layer already absorbed
+    // transient errors, so what reaches here is systemic (embedding
+    // service down, deadline exceeded) and every later batch would fail
+    // the same slow way.
+    const texts = batch.map((item) => item.text);
+    const embeddings = await this.#llm.createEmbeddings(texts);
 
-      // Store each embedding with its corresponding identifier
-      await Promise.all(
-        batch.map(async (item, index) => {
-          const vector = embeddings.data[index].embedding;
-          await this.#vectorIndex.add(item.identifier, vector);
-        }),
-      );
-    } catch (error) {
-      this.logger.debug("Processor", "Failed to process batch", {
-        items: `${processed + 1}-${processed + batchSize}/${total}`,
-        context,
-        error: error.message,
-      });
-    }
+    // Store each embedding with its corresponding identifier
+    await Promise.all(
+      batch.map(async (item, index) => {
+        const vector = embeddings.data[index].embedding;
+        await this.#vectorIndex.add(item.identifier, vector);
+      }),
+    );
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
## Summary

- **librpc unary deadline (F6):** every unary call now carries one absolute gRPC deadline spanning all retry attempts (default 60s, sized for embedding inference; per-service `deadline` config key in ms). Investigation showed the hang was two-layered: a down embedding service surfaces as retryable `UNAVAILABLE`, and the retry's exponential backoff alone sums to ~17 minutes — a per-attempt deadline would not have bounded it. With one absolute deadline, the first attempt past the budget fails `DEADLINE_EXCEEDED` (deliberately not retryable); fast connection errors still cycle within the budget. Streaming calls are exempt (keepalive bounds them).
- **VectorProcessor propagates batch failures:** it previously swallowed them at debug level, so `fit-process vectors` sat silent for a full deadline per batch and exited 0 having indexed nothing. The client retry layer already absorbs transients; what reaches the processor is systemic, so it aborts.
- **Actionable error (librag):** `fit-process vectors` rethrows embedding-call failures as `embedding service unreachable at <host>:<port> — start it with fit-rc (…)`. No upfront health probe — the deadline is the single mechanism.
- Docs: librpc README owns the deadline contract; fit-process skill states `vectors` requires the embedding service and describes the fail-fast.

Verified live: with no embedding service, `fit-process vectors` now fails in ~80s (60s budget + backoff tail) with the actionable message; previously it ran silent past 150s and would have ground on for ~17+ minutes.

## Test plan

- [x] `bun run check`
- [x] `bun test` in librpc (30, incl. new hung-connection DEADLINE_EXCEEDED integration test), libvector (35), librag (7)
- [x] Live verification above

🤖 Generated with [Claude Code](https://claude.com/claude-code)