### PR TITLE
fix(landmark): default the subject email from the signed-in identity

### DIFF
--- a/.claude/skills/fit-landmark/SKILL.md
+++ b/.claude/skills/fit-landmark/SKILL.md
@@ -24,7 +24,7 @@ pipeline; all Landmark computation is deterministic — no LLM calls.
 - Assessing whether culture investments are working —
   `npx fit-landmark snapshot trend --item <id>`
 - Exploring GetDX snapshot trends and comparisons —
-  `npx fit-landmark snapshot compare`
+  `npx fit-landmark snapshot compare --snapshot <id>`
 
 **Find growth areas backed by evidence:**
 
@@ -89,6 +89,13 @@ Each view applies privacy rules based on the audience:
   `voice --manager`
 - **Director** (planning): `snapshot`, `coverage`, `practiced`,
   `voice --manager`
+
+When signed in, subject-scoped commands (`readiness`, `timeline`,
+`coverage`, `sources`, and `voice` with no flags) default `--email` to
+your own identity. `evidence` stays explicit — omitting `--email` there
+deliberately shows the broadest view your access allows.
+`health --manager` takes a team lead's **own** email, not the email of
+the lead's manager.
 
 ---
 

--- a/.claude/skills/fit-landmark/references/cli.md
+++ b/.claude/skills/fit-landmark/references/cli.md
@@ -13,7 +13,7 @@ npx fit-landmark org team                     # Team views
 npx fit-landmark snapshot list                # List available snapshots
 npx fit-landmark snapshot show <id>           # Snapshot detail
 npx fit-landmark snapshot trend               # Score trends over time
-npx fit-landmark snapshot compare             # Factor comparison across snapshots
+npx fit-landmark snapshot compare --snapshot <id>  # Factor comparison for a snapshot
 ```
 
 ### Evidence and Markers
@@ -40,3 +40,8 @@ npx fit-landmark health --manager <email>     # Health for a specific manager's 
 npx fit-landmark voice --manager <email>      # Engineer voice from GetDX comments
 npx fit-landmark voice --email <email>        # Individual voice
 ```
+
+`--manager` takes the team lead's own email. When signed in, `readiness`,
+`timeline`, `coverage`, `sources`, and `voice` (with no flags) default
+`--email` to your identity; `evidence` stays explicit — omitting
+`--email` deliberately shows the broadest view your access allows.

--- a/.claude/skills/fit-landmark/references/workflows.md
+++ b/.claude/skills/fit-landmark/references/workflows.md
@@ -7,3 +7,10 @@
   `npx fit-landmark voice --manager <email>`
 - "What skills are practiced vs only on paper?" →
   `npx fit-landmark practiced --manager <email>`
+- "Where do I stand?" (signed in) → `npx fit-landmark readiness` — the
+  subject defaults to your own identity
+
+Manager-scoped views take the team lead's **own** email. If a persona or
+roster row carries a `parent_email` field, that is the person's upward
+manager — do not pass it to `--manager` when asking about the person's
+own team.

--- a/.claude/skills/fit-terrain/SKILL.md
+++ b/.claude/skills/fit-terrain/SKILL.md
@@ -166,8 +166,9 @@ capability against the
 — a `substrate` Postgres schema of consumer-defined views (`people`
 required; `evidence` and `discovery` optional with declared
 degradation). The verbs query only contract relations, never your
-vendor tables. Command lines and exit codes:
-[`references/cli.md`](references/cli.md).
+vendor tables. In `pick` output, `parent_email` is the persona's
+*upward* manager; manager-scoped views take the persona's own email.
+Command lines and exit codes: [`references/cli.md`](references/cli.md).
 
 ## Feeding Generated Content to Guide
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -89,7 +89,7 @@ ahead of the multi-tenant `ghbridge`/`msbridge` that consume them. Only `oidc`
 is public-facing (its `oidctunnel` mirrors `oauthtunnel`); `tenancy` and
 `ghserver` are internal gRPC (loopback) and need no tunnel.
 
-Oneshot services use `"type": "oneshot"` with `up`/`down` instead of `command`:
+Oneshots (optional; `just supabase-up` bypasses them) use `up`/`down`:
 
 ```json
 { "name": "supabase", "type": "oneshot",

--- a/justfile
+++ b/justfile
@@ -337,13 +337,13 @@ supabase-install:
     #!/usr/bin/env bash
     which supabase >/dev/null 2>&1 || brew install supabase/tap/supabase
 
-# Start local Supabase instance
+# Start local Supabase instance (JWT_SECRET comes from .env via dotenv-load)
 supabase-up:
-    bunx fit-rc start supabase
+    cd products/map && supabase start --workdir .
 
 # Stop local Supabase instance
 supabase-down:
-    bunx fit-rc stop supabase
+    cd products/map && supabase stop --workdir .
 
 # Run Map database migrations
 supabase-migrate:

--- a/libraries/libterrain/bin/fit-terrain.js
+++ b/libraries/libterrain/bin/fit-terrain.js
@@ -191,7 +191,7 @@ const definition = {
     {
       name: "substrate pick",
       description:
-        "Return one invariant-satisfying persona, diversified against --memory when supplied (appending the pick on success; stateless otherwise).",
+        "Return one invariant-satisfying persona, diversified against --memory when supplied (appending the pick on success; stateless otherwise). The output's parent/parent_email is the persona's upward manager — manager-scoped views (e.g. fit-landmark health --manager) take the persona's own email instead.",
       options: {
         format: {
           type: "string",

--- a/products/landmark/bin/fit-landmark.js
+++ b/products/landmark/bin/fit-landmark.js
@@ -297,6 +297,7 @@ async function main() {
       args,
       options: values,
       config,
+      identity,
       mapData: ctx.mapData,
       supabase: ctx.supabase,
       format: ctx.format,

--- a/products/landmark/src/commands/coverage.js
+++ b/products/landmark/src/commands/coverage.js
@@ -16,12 +16,14 @@ import {
   computeCoverageRatio,
   groupEvidenceByProvenance,
 } from "../lib/evidence-helpers.js";
+import { resolveSubjectEmail } from "../lib/identity.js";
 
 export const needsSupabase = true;
 
 /** Fetch artifact counts and compute the ratio of scored-to-total evidence for a person. */
 export async function runCoverageCommand({
   options,
+  identity,
   supabase,
   format,
   queries,
@@ -33,23 +35,21 @@ export async function runCoverageCommand({
     getEvidence,
   };
 
-  if (!options.email) {
-    throw new Error("coverage: --email <email> is required");
-  }
+  const email = resolveSubjectEmail(options, identity);
 
-  const person = await q.getPerson(supabase, options.email);
+  const person = await q.getPerson(supabase, email);
   if (!person) {
     return {
       view: null,
       meta: {
         format,
-        emptyState: EMPTY_STATES.PERSON_NOT_FOUND(options.email),
+        emptyState: EMPTY_STATES.PERSON_NOT_FOUND(email),
       },
     };
   }
 
   const allArtifacts = await q.getArtifacts(supabase, {
-    email: options.email,
+    email,
   });
 
   if (!allArtifacts || allArtifacts.length === 0) {
@@ -57,13 +57,13 @@ export async function runCoverageCommand({
       view: null,
       meta: {
         format,
-        emptyState: EMPTY_STATES.NO_ARTIFACTS_FOR_PERSON(options.email),
+        emptyState: EMPTY_STATES.NO_ARTIFACTS_FOR_PERSON(email),
       },
     };
   }
 
   const unscored = await q.getUnscoredArtifacts(supabase, {
-    email: options.email,
+    email,
   });
 
   const ratio = computeCoverageRatio(allArtifacts, unscored);
@@ -82,12 +82,12 @@ export async function runCoverageCommand({
     allByType[type] = (allByType[type] ?? 0) + 1;
   }
 
-  const evidenceRows = await q.getEvidence(supabase, { email: options.email });
+  const evidenceRows = await q.getEvidence(supabase, { email });
   const byProvenance = groupEvidenceByProvenance(evidenceRows ?? []);
 
   return {
     view: {
-      email: options.email,
+      email,
       name: person.name,
       coverage: ratio,
       byType: allByType,

--- a/products/landmark/src/commands/readiness.js
+++ b/products/landmark/src/commands/readiness.js
@@ -17,12 +17,14 @@ import {
   buildMarkerChecklist,
   computeCoverageRatio,
 } from "../lib/evidence-helpers.js";
+import { resolveSubjectEmail } from "../lib/identity.js";
 
 export const needsSupabase = true;
 
 /** Build a marker checklist for a person's target level and check each marker against existing evidence. */
 export async function runReadinessCommand({
   options,
+  identity,
   mapData,
   supabase,
   format,
@@ -35,16 +37,14 @@ export async function runReadinessCommand({
     getUnscoredArtifacts,
   };
 
-  if (!options.email) {
-    throw new Error("readiness: --email <email> is required");
-  }
+  const email = resolveSubjectEmail(options, identity);
 
-  const person = await q.getPerson(supabase, options.email);
+  const person = await q.getPerson(supabase, email);
   if (!person) {
-    return emptyResult(format, EMPTY_STATES.PERSON_NOT_FOUND(options.email));
+    return emptyResult(format, EMPTY_STATES.PERSON_NOT_FOUND(email));
   }
 
-  const resolved = resolveTargetLevel(person, options, mapData);
+  const resolved = resolveTargetLevel(person, options, mapData, email);
   if (resolved.error) return emptyResult(format, resolved.error);
 
   const { currentLevel, targetLevel, discipline, track } = resolved;
@@ -63,7 +63,7 @@ export async function runReadinessCommand({
     return emptyResult(format, EMPTY_STATES.NO_MARKERS_AT_TARGET);
   }
 
-  const evidenceRows = await q.getEvidence(supabase, { email: options.email });
+  const evidenceRows = await q.getEvidence(supabase, { email });
   const matchedEvidence = (evidenceRows ?? []).filter((e) => e.matched);
 
   const items = buildChecklistItems(checklist, matchedEvidence);
@@ -72,19 +72,16 @@ export async function runReadinessCommand({
   // Zero-artifact short-circuit: a persona with no artifacts is "no
   // signal", not "below floor" — coverage stays null so the formatter
   // renders the checklist as a roadmap instead of the suppression copy.
-  const allArtifacts =
-    (await q.getArtifacts(supabase, { email: options.email })) ?? [];
+  const allArtifacts = (await q.getArtifacts(supabase, { email })) ?? [];
   let coverage = null;
   if (allArtifacts.length > 0) {
-    const unscored = await q.getUnscoredArtifacts(supabase, {
-      email: options.email,
-    });
+    const unscored = await q.getUnscoredArtifacts(supabase, { email });
     coverage = computeCoverageRatio(allArtifacts, unscored);
   }
 
   return {
     view: {
-      email: options.email,
+      email,
       currentLevel: currentLevel.id,
       targetLevel: targetLevel.id,
       checklist: items,
@@ -101,7 +98,7 @@ function emptyResult(format, emptyState) {
 }
 
 /** Format the "unknown discipline" error so the user sees the actionable gap. */
-function unknownDisciplineError(person, options, mapData) {
+function unknownDisciplineError(person, email, mapData) {
   const available = (mapData.disciplines ?? [])
     .map((d) => d.id)
     .sort()
@@ -109,23 +106,23 @@ function unknownDisciplineError(person, options, mapData) {
   const availableSuffix = available
     ? ` Available disciplines: ${available}.`
     : " No disciplines are defined in the pathway.";
-  return `Unknown discipline "${person.discipline}" for ${options.email}. The discipline is not defined in the pathway.${availableSuffix}`;
+  return `Unknown discipline "${person.discipline}" for ${email}. The discipline is not defined in the pathway.${availableSuffix}`;
 }
 
 /** Resolve current level, target level, discipline, and track from the person and options. */
-function resolveTargetLevel(person, options, mapData) {
+function resolveTargetLevel(person, options, mapData, email) {
   const discipline = (mapData.disciplines ?? []).find(
     (d) => d.id === person.discipline,
   );
   if (!discipline) {
-    return { error: unknownDisciplineError(person, options, mapData) };
+    return { error: unknownDisciplineError(person, email, mapData) };
   }
 
   const currentLevel = (mapData.levels ?? []).find(
     (l) => l.id === person.level,
   );
   if (!currentLevel) {
-    return { error: `Unknown level "${person.level}" for ${options.email}.` };
+    return { error: `Unknown level "${person.level}" for ${email}.` };
   }
 
   let targetLevel;

--- a/products/landmark/src/commands/sources.js
+++ b/products/landmark/src/commands/sources.js
@@ -10,6 +10,7 @@
 
 import { readRetention } from "@forwardimpact/map/activity/retention";
 import { EMPTY_STATES } from "../lib/empty-state.js";
+import { resolveSubjectEmail } from "../lib/identity.js";
 
 export const needsSupabase = true;
 
@@ -137,18 +138,24 @@ async function inventoryClass(supabase, cls, email) {
 }
 
 /**
- * Run the sources command — list activity row classes retained about `email`.
+ * Run the sources command — list activity row classes retained about the
+ * subject (explicit `--email`, else the signed-in identity).
  *
  * @param {object} params
  * @param {object} params.options
- * @param {string} params.options.email
+ * @param {string} [params.options.email]
+ * @param {{email: string}|null} [params.identity]
  * @param {import("@supabase/supabase-js").SupabaseClient} params.supabase
  * @param {string} [params.format]
  * @returns {Promise<{view: {email: string, items: object[]}|null, meta: object}>}
  */
-export async function runSourcesCommand({ options, supabase, format }) {
-  const email = options.email;
-  if (!email) throw new Error("sources: --email <e> is required");
+export async function runSourcesCommand({
+  options,
+  identity,
+  supabase,
+  format,
+}) {
+  const email = resolveSubjectEmail(options, identity);
   const items = [];
   for (const cls of CLASSES) {
     const item = await inventoryClass(supabase, cls, email);

--- a/products/landmark/src/commands/timeline.js
+++ b/products/landmark/src/commands/timeline.js
@@ -15,23 +15,23 @@ import {
   computeCoverageRatio,
   highestLevelPerSkillPerQuarter,
 } from "../lib/evidence-helpers.js";
+import { resolveSubjectEmail } from "../lib/identity.js";
 
 export const needsSupabase = true;
 
 /** Query evidence for a person and aggregate the highest proficiency level per skill per quarter. */
 export async function runTimelineCommand({
   options,
+  identity,
   supabase,
   format,
   queries,
 }) {
   const q = queries ?? { getEvidence, getArtifacts, getUnscoredArtifacts };
 
-  if (!options.email) {
-    throw new Error("timeline: --email <email> is required");
-  }
+  const email = resolveSubjectEmail(options, identity);
 
-  const filterOpts = { email: options.email };
+  const filterOpts = { email };
   if (options.skill) filterOpts.skillId = options.skill;
 
   const evidenceRows = await q.getEvidence(supabase, filterOpts);

--- a/products/landmark/src/commands/voice.js
+++ b/products/landmark/src/commands/voice.js
@@ -13,6 +13,7 @@ import {
 import { isRelationNotFoundError } from "../lib/supabase.js";
 import { EMPTY_STATES } from "../lib/empty-state.js";
 import { groupEvidenceBySkill } from "../lib/evidence-helpers.js";
+import { resolveSubjectEmail } from "../lib/identity.js";
 
 export const needsSupabase = true;
 
@@ -33,6 +34,7 @@ const THEME_KEYWORDS = [
 /** Surface engineer voice from GetDX snapshot comments, dispatching to email-scoped or manager-scoped mode. */
 export async function runVoiceCommand({
   options,
+  identity,
   supabase,
   mapData,
   format,
@@ -63,7 +65,14 @@ export async function runVoiceCommand({
       q,
     });
   }
-  throw new Error("voice: one of --email or --manager is required");
+  // Self mode: no flags — default the subject to the signed-in identity.
+  return runEmailVoice({
+    email: resolveSubjectEmail(options, identity),
+    supabase,
+    mapData,
+    format,
+    q,
+  });
 }
 
 async function runEmailVoice({

--- a/products/landmark/src/lib/identity.js
+++ b/products/landmark/src/lib/identity.js
@@ -188,3 +188,21 @@ export async function resolveIdentity({
 
   return { email: creds.email, jwt: creds.access_token };
 }
+
+/**
+ * Resolve the subject email for a subject-scoped command: an explicit
+ * `--email` wins, else the signed-in identity's email. RLS still clamps
+ * everything server-side — this only picks the default subject.
+ *
+ * @param {object} options - Parsed CLI options (may carry `email`).
+ * @param {{email: string}|null} identity - Resolved caller identity, if any.
+ * @returns {string} The subject email.
+ * @throws {Error} When neither an explicit email nor an identity exists.
+ */
+export function resolveSubjectEmail(options, identity) {
+  if (options.email) return options.email;
+  if (identity?.email) return identity.email;
+  throw new Error(
+    "--email <email> is required (sign in with `fit-landmark login` to make it optional)",
+  );
+}

--- a/products/landmark/test/lib/resolve-subject-email.test.js
+++ b/products/landmark/test/lib/resolve-subject-email.test.js
@@ -1,0 +1,32 @@
+/**
+ * Subject defaulting for subject-scoped commands: explicit --email wins,
+ * the signed-in identity fills when omitted, and the error names the
+ * sign-in path when both are absent.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveSubjectEmail } from "../../src/lib/identity.js";
+
+describe("resolveSubjectEmail", () => {
+  it("prefers an explicit --email over the identity", () => {
+    const email = resolveSubjectEmail(
+      { email: "explicit@example.com" },
+      { email: "identity@example.com" },
+    );
+    assert.equal(email, "explicit@example.com");
+  });
+
+  it("fills from the signed-in identity when --email is omitted", () => {
+    const email = resolveSubjectEmail({}, { email: "identity@example.com" });
+    assert.equal(email, "identity@example.com");
+  });
+
+  it("throws with the sign-in hint when both are absent", () => {
+    assert.throws(
+      () => resolveSubjectEmail({}, null),
+      /--email <email> is required.*fit-landmark login/,
+    );
+  });
+});

--- a/products/landmark/test/voice.test.js
+++ b/products/landmark/test/voice.test.js
@@ -98,8 +98,8 @@ describe("voice --manager", () => {
   });
 });
 
-describe("voice validation", () => {
-  it("throws when neither --email nor --manager is set", async () => {
+describe("voice subject defaulting", () => {
+  it("throws with the sign-in hint when no flags and no identity", async () => {
     await assertRejectsMessage(
       () =>
         runVoiceCommand({
@@ -109,7 +109,33 @@ describe("voice validation", () => {
           format: "text",
           queries: stubQueries(),
         }),
-      /--email.*--manager/,
+      /--email.*fit-landmark login/,
     );
+  });
+
+  it("defaults to the signed-in identity's own voice with no flags", async () => {
+    const result = await runVoiceCommand({
+      options: {},
+      identity: { email: "alice@example.com" },
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view);
+    assert.equal(result.view.mode, "email");
+  });
+
+  it("stays manager-scoped when --manager is set and an identity exists", async () => {
+    const result = await runVoiceCommand({
+      options: { manager: "alice@example.com" },
+      identity: { email: "someone-else@example.com" },
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view);
+    assert.equal(result.view.mode, "manager");
   });
 });

--- a/websites/fit/docs/products/signing-in-to-landmark/index.md
+++ b/websites/fit/docs/products/signing-in-to-landmark/index.md
@@ -10,8 +10,11 @@ return data it needs to know who is asking.
 `fit-landmark login` walks you through Supabase's magic-link flow, captures
 the session at a localhost callback, and stores it under
 `~/.config/landmark/credentials.json` (0600). Subsequent commands resolve
-identity automatically; you only run `login` again when the session expires
-or you change machines.
+identity automatically — subject-scoped commands (`readiness`, `timeline`,
+`coverage`, `sources`, and `voice` with no flags) default `--email` to your
+signed-in identity, while `evidence` stays explicit so omitting `--email`
+shows the broadest view your access allows. You only run `login` again when
+the session expires or you change machines.
 
 This guide is for **engineers** signing in to read Landmark from the CLI.
 Operators issuing tokens for unattended agents follow a different path — see


### PR DESCRIPTION
## Summary

- **Landmark subject default (F10):** new `resolveSubjectEmail(options, identity)` helper in `products/landmark/src/lib/identity.js` — explicit `--email` wins, else the signed-in identity's email, else an error naming the sign-in path. Called at the top of `readiness`, `timeline`, `coverage`, `sources`, and in `voice`'s self-mode branch (no flags → your own voice; `--manager` stays manager-scoped; explicit `--email` precedence unchanged). `evidence` never calls it — its omitted `--email` is deliberately the broad RLS-visible view. The bin now threads `identity` into handler payloads; RLS still clamps server-side.
- **`just supabase-up`/`supabase-down` (F7):** call the Supabase CLI directly (dotenv-load already supplies `JWT_SECRET`), so `just seed-full` works on a fresh contributor config with no fit-rc oneshot block; config/CLAUDE.md marks the oneshot as optional.
- **Doc drift (F10/F8):** `snapshot compare` examples gain `--snapshot <id>`; fit-landmark skill + references document which commands default the subject and that `health --manager` takes a team lead's **own** email; fit-terrain skill + `substrate pick --help` define `parent_email` as the persona's *upward* manager (no rename — kata-interview consumes pick output); the sign-in page's "resolves your identity automatically" claim is now concretely true and says so.

Verified live against a staged substrate: `fit-landmark readiness` with **no `--email`** and an issued persona token resolves the persona (J080 → J090); `just supabase-up` starts the stack with no oneshot config.

## Test plan

- [x] `bun run check`
- [x] `bun test` in landmark (188 pass; new resolveSubjectEmail unit tests + voice subject-defaulting tests)
- [x] Live verification above

🤖 Generated with [Claude Code](https://claude.com/claude-code)