### PR TITLE
plan(2250): the Gemba agent-runtime platform product

### DIFF
--- a/specs/2250-agent-platform-product/plan-a-01.md
+++ b/specs/2250-agent-platform-product/plan-a-01.md
@@ -1,0 +1,257 @@
+# Plan 2250-a Part 1: CLI axis — the Gemba package and the command rename
+
+One part because the `public-cli-set` invariant couples bins, launchers, and
+doc/skill invocations: any split leaves a computed launcher without its bin or
+its invocation and fails CI. Sub-steps below are verification units, not
+commit boundaries.
+
+## Step 1.1 — Scaffold `products/gemba/package.json`
+
+Create the consumer package: `bin` + `dependencies`, no `exports`, no `main`,
+no `src/`.
+
+**Created:** `products/gemba/package.json`, `products/gemba/CHANGELOG.md`.
+
+```json
+{
+  "name": "@forwardimpact/gemba",
+  "version": "0.1.0",
+  "description": "Stand up and operate an agent team — the runtime platform's command family (harness, trace, benchmark, selfedit, wiki, xmr) and CI actions, consuming the runtime libraries.",
+  "keywords": ["agent", "harness", "trace", "wiki", "xmr", "runtime", "platform"],
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "products/gemba"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Teams Using Agents",
+      "goal": "Stand Up and Operate an Agent Team",
+      "trigger": "The team wants to run coding agents continuously, but the runtime — bootstrap, session harness, traces, memory, metrics — has no product to hire and must be reverse-engineered from CI plumbing.",
+      "bigHire": "stand up and operate an agent team on one platform: bootstrap the environment, run sessions, inspect traces, persist memory, and measure outcomes.",
+      "littleHire": "run one agent session, read one trace, or chart one metric with a single command from the platform's family.",
+      "competesWith": "hand-rolled CI pipelines around raw agent CLIs; reverse-engineering another team's setup; running agents ad hoc with no memory or measurement",
+      "forces": {
+        "push": "Every team that wants to run agents rebuilds the same bootstrap-run-remember-measure loop from CI plumbing.",
+        "pull": "One installable platform whose CLIs and CI actions are the same loop, proven daily by a reference tenant.",
+        "habit": "Wiring raw agent CLIs into bespoke pipelines and losing the session evidence.",
+        "anxiety": "Adopting a platform might couple the team to one vendor's agent workflow."
+      },
+      "firedWhen": "the platform's loop constrains a team more than the plumbing it replaced; or the team stops running agents in CI."
+    }
+  ],
+  "type": "module",
+  "bin": {
+    "gemba-harness": "./bin/gemba-harness.js",
+    "gemba-trace": "./bin/gemba-trace.js",
+    "gemba-benchmark": "./bin/gemba-benchmark.js",
+    "gemba-selfedit": "./bin/gemba-selfedit.js",
+    "gemba-wiki": "./bin/gemba-wiki.js",
+    "gemba-xmr": "./bin/gemba-xmr.js"
+  },
+  "files": ["bin/**/*.js"],
+  "scripts": { "test": "bun test test/*.test.js" },
+  "dependencies": {
+    "@forwardimpact/libharness": "^2.0.0",
+    "@forwardimpact/libwiki": "^0.2.0",
+    "@forwardimpact/libxmr": "^2.0.0",
+    "@forwardimpact/libcli": "^0.1.0",
+    "@forwardimpact/libconfig": "^0.1.0",
+    "@forwardimpact/libpreflight": "^0.1.0",
+    "@forwardimpact/libtelemetry": "^0.1.22",
+    "@forwardimpact/libutil": "^0.1.0"
+  },
+  "engines": { "bun": ">=1.2.0", "node": ">=22.0.0" },
+  "publishConfig": { "access": "public" }
+}
+```
+
+Ranges track the workspace versions at implementation time; Part 4's release
+cuts bump them. `devDependencies` gains whatever the moved tests import (Step
+1.6) — expected `@forwardimpact/libmock` only if a moved test uses it. Like
+Gear, no hand-authored `README.md`.
+
+**Verify:** `bun install` resolves; `bun run context:check-jtbd` passes the new
+jobs entry.
+
+## Step 1.2 — Move and rename the six bins
+
+`git mv` each bin into `products/gemba/bin/` under its new name; repoint every
+`../src/…` import to a library subpath export (added in Step 1.3); rename
+in-file command tokens (definition `name`, help/usage strings, `mkdtemp`
+prefixes). `packageJsonUrl: new URL("../package.json", import.meta.url)` now
+resolves the gemba package — correct, leave as is.
+
+| From | To |
+| --- | --- |
+| `libraries/libharness/bin/fit-harness.js` | `products/gemba/bin/gemba-harness.js` |
+| `libraries/libharness/bin/fit-trace.js` | `products/gemba/bin/gemba-trace.js` |
+| `libraries/libharness/bin/fit-benchmark.js` | `products/gemba/bin/gemba-benchmark.js` |
+| `libraries/libharness/bin/fit-selfedit.js` | `products/gemba/bin/gemba-selfedit.js` |
+| `libraries/libwiki/bin/fit-wiki.js` | `products/gemba/bin/gemba-wiki.js` |
+| `libraries/libxmr/bin/fit-xmr.js` | `products/gemba/bin/gemba-xmr.js` |
+
+`fit-selfedit.js` is the one bin that contains implementation, not wiring.
+Extract its safeguard-and-write logic into
+`libraries/libharness/src/commands/selfedit.js` (created, exported per Step
+1.3); the product bin keeps only the help text, stdin/argv handling, and
+dispatch. The extraction takes the `minimatch` import with it (libharness
+already depends on minimatch; the gemba package therefore does not). Its
+README pointer (`libraries/libharness/README.md § fit-selfedit`) renames with
+the prose pass in Step 1.7.
+
+**Verify:** `node products/gemba/bin/gemba-<cli>.js --help` exits 0 for all
+six.
+
+## Step 1.3 — Purify the three runtime libraries
+
+Drop the interface surface; export the command modules the bins import. The
+declarative definition modules (`benchmark-definition.js`,
+`cli-definition.js`) stay library-side with the handlers: the design's
+Components table (bins keep "definition-and-dispatch wiring" via package
+imports) governs over its Interfaces shorthand ("a product bin owns … the CLI
+definition") — argv parsing and dispatch live in the bin, the definition data
+is implementation.
+
+| File | Change |
+| --- | --- |
+| `libraries/libharness/package.json` | Delete `bin` field and the four `./bin/fit-*.js` exports. Add subpath exports for the modules the moved bins import: `./commands/output.js`, `./commands/tee.js`, `./commands/run.js`, `./commands/supervise.js`, `./commands/facilitate.js`, `./commands/discuss.js`, `./commands/callback.js`, `./commands/scan-logs.js`, `./commands/trace.js`, `./commands/assert.js`, `./commands/by-discussion.js`, `./commands/benchmark-definition.js`, `./commands/selfedit.js` (new), each mapping to its `./src/commands/*.js` file. Drop `bin/**/*.js` from `files`. |
+| `libraries/libwiki/package.json` | Delete `bin` field and the `./bin/fit-wiki.js` export. Add `./wiki-sync.js` → `./src/wiki-sync.js`, `./util/wiki-dir.js` → `./src/util/wiki-dir.js`, `./cli-definition.js` → `./src/cli-definition.js`. Drop `bin/**/*.js` from `files`. |
+| `libraries/libxmr/package.json` | Delete `bin` field and the `./bin/fit-xmr.js` export. Add `./commands/{analyze,list,validate,chart,summarize,record}.js` → `./src/commands/*.js`. Drop `bin/**/*.js` from `files`. |
+| `libraries/{libharness,libwiki,libxmr}/bin/` | Directories removed by the Step 1.2 `git mv` — confirm none remains. |
+
+**Verify:** `test ! -d libraries/libharness/bin -a ! -d libraries/libwiki/bin
+-a ! -d libraries/libxmr/bin`; `rg '"bin"'
+libraries/{libharness,libwiki,libxmr}/package.json` returns nothing; `bun run
+test` green for the three libraries (handler tests unmoved).
+
+## Step 1.4 — Launchers
+
+`git mv` the five launcher dirs and rewrite each to the canonical two-line
+shape importing the gemba package.
+
+| From | To | Bin content |
+| --- | --- | --- |
+| `launchers/fit-harness/` | `launchers/gemba-harness/` | `import "@forwardimpact/gemba/bin/gemba-harness.js";` |
+| `launchers/fit-trace/` | `launchers/gemba-trace/` | `import "@forwardimpact/gemba/bin/gemba-trace.js";` |
+| `launchers/fit-benchmark/` | `launchers/gemba-benchmark/` | `import "@forwardimpact/gemba/bin/gemba-benchmark.js";` |
+| `launchers/fit-wiki/` | `launchers/gemba-wiki/` | `import "@forwardimpact/gemba/bin/gemba-wiki.js";` |
+| `launchers/fit-xmr/` | `launchers/gemba-xmr/` | `import "@forwardimpact/gemba/bin/gemba-xmr.js";` |
+
+The "Bin content" column shows each file's import line; the full canonical
+file is byte-exact two lines — `#!/usr/bin/env node` then the import, LF,
+single trailing newline. Each `package.json`: `name` = the new invoked name,
+description "Run gemba-<cli> from the npm registry — launcher for
+@forwardimpact/gemba", `repository.directory`, `bin` key/path, single
+dependency `"@forwardimpact/gemba": "0.0.0"` (placeholder kept). No
+`fit-selfedit` launcher exists and no `gemba-selfedit` launcher is created:
+no doc or published skill invokes selfedit via `npx`/`bunx` (root CLAUDE.md's
+`bunx fit-selfedit` is outside the invariant's scanned surfaces), so the
+invariant does not compute one. `launchers/README.md`: worked examples and the
+"npm name = invoked name" prose move to the gemba names; the `coaligned`
+exception paragraph is unchanged.
+
+**Verify:** covered by the Step 1.5 invariant run.
+
+## Step 1.5 — `public-cli-set` invariant
+
+**Modified:** `.coaligned/invariants/public-cli-set.rules.mjs`.
+
+- `INVOKE_RE` →
+  `/\b(?:npx|bunx)\s+(?:-y\s+|--yes\s+)?((?:fit|gemba)-[a-z][a-z-]*)/g`.
+- `SIBLING_ACTION_CLIS` →
+  `["gemba-benchmark", "gemba-harness", "gemba-trace", "gemba-wiki"]`.
+- `collectInvokedNames` skill-dir filter `/^(fit|kata)-/` →
+  `/^(fit|kata|gemba)(-|$)/` (the `gemba` product skill dir, Part 3, has no
+  dash).
+- `computePublicCliSet` `exportsOk`: a source package with **no `exports`
+  field** resolves every subpath by Node's legacy rules, so
+  `exportsOk: !pkg.exports || \`./bin/${cli}.js\` in pkg.exports` — this is
+  what lets the gemba package satisfy the launcher import while declaring no
+  `exports` (spec SC1). Update the `checkLauncherShape` message and the header
+  comment to state both accepted shapes.
+- JSDoc examples (`fit-trace` / `@forwardimpact/libharness`) → gemba
+  equivalents.
+
+**Verify:** after Step 1.7's doc flip, `bun run invariants` is green and
+`ls launchers/` = `README.md coaligned gemba-benchmark gemba-harness
+gemba-trace gemba-wiki gemba-xmr` plus the untouched non-runtime `fit-*`
+launchers — no `fit-harness`/`fit-trace`/`fit-benchmark`/`fit-wiki`/`fit-xmr`
+dirs remain.
+
+## Step 1.6 — Bin-surface tests and goldens
+
+Predicate: a test that exercises a bin entry point (by spawn or by rendering
+its CLI surface) moves to `products/gemba/test/`; handler and component tests
+stay in their libraries.
+
+| From | To |
+| --- | --- |
+| `libraries/libharness/test/bin-smoke.integration.test.js` | `products/gemba/test/` (its `BINS` list → the gemba names) |
+| `libraries/libharness/test/selfedit.integration.test.js` | `products/gemba/test/` (spawns the bin; the extracted `selfedit.js` logic may additionally gain a lib-side unit test) |
+| `libraries/libwiki/test/fit-wiki-smoke.integration.test.js` | `products/gemba/test/gemba-wiki-smoke.integration.test.js` |
+| `libraries/libwiki/test/golden.test.js`, `libraries/libwiki/test/golden-functional.integration.test.js`, and `libraries/libwiki/test/golden/fit-wiki/` | `products/gemba/test/` + `products/gemba/test/golden/gemba-wiki/` — the two tests share the golden dir (golden-functional roots its fixture inside it), so they move **together**; splitting them would orphan the shared fixtures |
+| `libraries/libharness/test/golden/{fit-harness,fit-trace,fit-benchmark,fit-selfedit}/` | `products/gemba/test/golden/gemba-*/` |
+| `libraries/libxmr/test/golden/fit-xmr/` (with its `cases.json`) | `products/gemba/test/golden/gemba-xmr/` |
+
+The libharness and libxmr golden dirs have no in-library runner test — they
+are consumed by `scripts/capture-cli-golden.mjs` (path/CLI conventions) and
+the root `tests/capture-cli-golden*` tests; repoint the paths and CLI names in
+both. Regenerate every moved golden dir from actual output, e.g.:
+
+```sh
+node scripts/capture-cli-golden.mjs --bin gemba-harness \
+  --exec products/gemba/bin/gemba-harness.js \
+  --golden-dir products/gemba/test/golden/gemba-harness
+```
+
+Root `package.json` `test` already finds `./products` tests; no runner change
+in this part.
+
+**Verify:** `bun run test` green; `rg -n 'bin/(fit|gemba)-' libraries/*/test`
+returns nothing; `ls libraries/{libharness,libwiki,libxmr}/test/golden` errors
+(dirs gone).
+
+## Step 1.7 — Repo-wide command rename (prose, skills, agents, scripts)
+
+Blanket-replace the six families across every remaining surface **except** the
+keep-list (plan-a.md) and the four action-source dirs +
+`fit-install.sh`, which Part 2 owns with the move. Inventory of non-obvious
+sites:
+
+| Surface | Notes |
+| --- | --- |
+| `.claude/skills/fit-{harness,trace,benchmark,wiki,xmr}/` → `.claude/skills/gemba-*/` | `git mv` dirs; frontmatter `name`, body, `references/*`, `## Documentation` links. Library paths (`libraries/libharness/...`) and `LIBHARNESS_*` tokens inside stay. |
+| Other `.claude/skills/**` (kata-\*, fit-\*, monorepo-setup, …) | bare invocations (`fit-wiki boot` → `gemba-wiki boot`), cross-links to the renamed skill dirs |
+| `.claude/agents/*.md` | `fit-wiki`/`fit-trace`/`fit-xmr` invocations in profiles and `x-*` references |
+| `.claude/settings.json` | Stop hook `bunx fit-wiki push` → `bunx gemba-wiki push`; any `Edit()`/`Bash()` permission rules naming the six |
+| `.coaligned/invariants/skill-genericity.rules.mjs` | npx-prefix pattern `\bnpx (fit-|coaligned|kata-)` gains `gemba-`; cross-pack link pattern `\]\(((\.\./)+)fit-` gains `gemba-` (gemba skills ship in the fit-skills pack, Part 3, so relative links from kata skills stay banned) |
+| `CLAUDE.md` | `bunx fit-selfedit` line; `fit-harness`/`fit-trace`/`fit-wiki`/`fit-xmr` product-description mentions (framing prose additions are Part 3) |
+| `KATA.md` | command tokens only (tenant framing is Part 3) |
+| `websites/fit/**/*.md` | the ~14 docs pages invoking the six, incl. `docs/internals/release/index.md`'s `fit-gear` catalog row and the operations reference |
+| `.github/workflows/*.yml` | every `bunx`/workspace-resolved invocation of the six → gemba names. **Keep unchanged until Part 4:** `clis:` values, `uses:` pins, and the bare-PATH invocations of pinned-installed binaries (`fit-trace cost` and `fit-harness callback` in `kata-dispatch.yml`, `fit-wiki curate` in `curate-wiki.yml`) — they execute whatever `clis:` installed. **Keep permanently:** path references into `benchmarks/**` (`family: ./benchmarks/fit-wiki` in `eval-wiki.yml` — the eval family dir keeps its name). |
+| `package.json` (root) | `"wiki": "bunx fit-wiki audit"`, `"wiki:fix": "bunx fit-wiki fix"` → gemba-wiki |
+| `justfile` | `bunx fit-wiki {pull,push,audit}`, `bunx --workspace=@forwardimpact/libxmr fit-xmr` → `bunx --workspace=@forwardimpact/gemba gemba-xmr` |
+| `scripts/bootstrap.sh` | `bunx fit-wiki init` / `pull` |
+| `scripts/*.mjs` | `capture-cli-golden` docs, `staff-engineer-record-prior-trace.mjs`, `exp-1738-gate-runtime.mjs`, `spec-1060-migrate-wiki.mjs` comments/tokens |
+| `CONTRIBUTING.md`, `.gitignore` | `bunx fit-selfedit` mentions; any six-family token in ignore comments/patterns |
+| `.coaligned/invariants/shared-workspace-staging.{rules.mjs,allow.json}` | six-family tokens in rules/allowlist entries |
+| `libraries/*/test/fixtures/**` (e.g. `libharness/test/fixtures/divergence-run481.ndjson`, `test/fixtures/trace-query-1220/`) | deliberate fixture edit of the six-family tokens, per the spec-2110 precedent — the consuming tests compare event structure and cost, not these strings |
+| `build/cli-manifest.json` | the five entries `fit-{harness,trace,wiki,xmr,benchmark}` → gemba names; `bundle` stays `"gear"` — the binary distribution vehicle (gear bundle, `fit-gear` cask) is out of the spec's boundary and unchanged |
+| `libraries/{libharness,libwiki,libxmr}/src/**` | help/usage strings, JSDoc, stderr text naming the six commands (`libharness:`-style prefixes stay) |
+| `libraries/{libharness,libwiki,libxmr}/README.md` + `libraries/CLAUDE.md` | catalog rows, worked examples |
+| `libraries/{libharness,libwiki,libxmr}/CHANGELOG.md` | append an entry: bins moved to `@forwardimpact/gemba` under gemba names, `bin` field removed (breaking); historical entries untouched |
+| `products/guide/**` and any other non-kata product docs | stray command mentions |
+
+**Verify:**
+`rg --hidden -n 'fit-(harness|trace|benchmark|selfedit|wiki|xmr)\b' --glob '!specs/**' --glob '!wiki/**' --glob '!benchmarks/**' --glob '!**/CHANGELOG.md' --glob '!node_modules/**' --glob '!.git/**' --glob '!products/kata/**'`
+— inspect every returned **line**; the only allowed remainders are (a)
+`.github/workflows/*.yml` lines that are `clis:` values, `uses:`-pin comments,
+or the three bare-PATH invocations held for Part 4, (b) the
+`benchmarks/fit-wiki` path reference in `eval-wiki.yml`, and (c) the
+Part-2-owned action sources. Confirm the keep-listed path references are
+byte-unchanged (`git diff -- .github/workflows/eval-wiki.yml` shows no `family:`
+change). Then `bun run context:fix`, `bun run check`, and `bun run test` green.

--- a/specs/2250-agent-platform-product/plan-a-01.md
+++ b/specs/2250-agent-platform-product/plan-a-01.md
@@ -198,9 +198,10 @@ stay in their libraries.
 | `libraries/libxmr/test/golden/fit-xmr/` (with its `cases.json`) | `products/gemba/test/golden/gemba-xmr/` |
 
 The libharness and libxmr golden dirs have no in-library runner test — they
-are consumed by `scripts/capture-cli-golden.mjs` (path/CLI conventions) and
-the root `tests/capture-cli-golden*` tests; repoint the paths and CLI names in
-both. Regenerate every moved golden dir from actual output, e.g.:
+are consumed by `scripts/capture-cli-golden.mjs` via its path/CLI
+conventions; repoint any documented paths and CLI names there (the root
+`tests/capture-cli-golden*` tests are stub-based with tmpdir goldens and need
+no repoint). Regenerate every moved golden dir from actual output, e.g.:
 
 ```sh
 node scripts/capture-cli-golden.mjs --bin gemba-harness \
@@ -249,9 +250,11 @@ sites:
 **Verify:**
 `rg --hidden -n 'fit-(harness|trace|benchmark|selfedit|wiki|xmr)\b' --glob '!specs/**' --glob '!wiki/**' --glob '!benchmarks/**' --glob '!**/CHANGELOG.md' --glob '!node_modules/**' --glob '!.git/**' --glob '!products/kata/**'`
 — inspect every returned **line**; the only allowed remainders are (a)
-`.github/workflows/*.yml` lines that are `clis:` values, `uses:`-pin comments,
-or the three bare-PATH invocations held for Part 4, (b) the
-`benchmarks/fit-wiki` path reference in `eval-wiki.yml`, and (c) the
-Part-2-owned action sources. Confirm the keep-listed path references are
-byte-unchanged (`git diff -- .github/workflows/eval-wiki.yml` shows no `family:`
-change). Then `bun run context:fix`, `bun run check`, and `bun run test` green.
+`.github/workflows/*.yml` lines that are `clis:` values or the three bare-PATH
+invocations held for Part 4 (workflow **comments** rename with the family in
+this part — a comment briefly describing the post-Part-4 state is harmless;
+executable names are what the hold protects), (b) the `benchmarks/fit-wiki` path
+reference in `eval-wiki.yml`, and (c) the Part-2-owned action sources. Confirm
+the keep-listed path references are byte-unchanged
+(`git diff -- .github/workflows/eval-wiki.yml` shows no `family:` change). Then
+`bun run context:fix`, `bun run check`, and `bun run test` green.

--- a/specs/2250-agent-platform-product/plan-a-02.md
+++ b/specs/2250-agent-platform-product/plan-a-02.md
@@ -1,0 +1,106 @@
+# Plan 2250-a Part 2: Actions axis — relocate the run surface
+
+Move the four agent-run composite actions under the product and repoint their
+publish wiring. Depends on Part 1 (the action steps invoke the renamed CLIs).
+The sibling repo names and every downstream `uses:` pin are untouched.
+
+## Step 2.1 — Move the four action sources
+
+`git mv` each source dir, then rename the six command families inside the
+moved files (Part 1's codemod excluded these dirs).
+
+| From | To |
+| --- | --- |
+| `.github/actions/bootstrap/` | `products/gemba/actions/bootstrap/` |
+| `libraries/libharness/actions/harness/` | `products/gemba/actions/harness/` |
+| `libraries/libharness/actions/benchmark/` | `products/gemba/actions/benchmark/` |
+| `libraries/libwiki/actions/wiki/` | `products/gemba/actions/wiki/` |
+
+In-file changes with the move:
+
+- `harness/action.yml`: `fit-harness supervise|facilitate|discuss|run`,
+  `fit-trace split`, description/comment tokens → gemba names; the
+  `clis: fit-harness fit-trace` guidance prose → gemba names.
+- `harness/README.md`: the worked example `node
+  libraries/libharness/bin/fit-harness.js callback …` → `node
+  products/gemba/bin/gemba-harness.js callback …` (a bare token replace would
+  yield a path that exists nowhere).
+- `benchmark/action.yml` and the reusable workflow nested **inside the action
+  source** at `benchmark/.github/workflows/benchmark.yml` (moves with the
+  `git mv`): `fit-benchmark run|report`, description tokens → gemba names.
+- `wiki/action.yml`: `fit-wiki $COMMAND` and every `fit-wiki` prose token →
+  `gemba-wiki`.
+- `bootstrap/action.yml`, `bootstrap/README.md`, `bootstrap/apm-verify.mjs`:
+  command-token prose only (`clis:` examples → gemba names).
+- Internal relative paths, if any action references its old home.
+
+**Verify:** `test ! -d .github/actions/bootstrap -a ! -d
+libraries/libharness/actions -a ! -d libraries/libwiki/actions`;
+`products/gemba/actions/{bootstrap,harness,wiki,benchmark}/action.yml` exist;
+`rg -n '(libharness|libwiki|libxmr)/bin/' products/gemba/actions` returns
+nothing.
+
+## Step 2.2 — `fit-install.sh` (moves with bootstrap; edited in place)
+
+**Modified:** `products/gemba/actions/bootstrap/fit-install.sh`.
+
+- `DEFAULT_TOOLS`: `fit-wiki fit-xmr fit-trace` → `gemba-wiki gemba-xmr
+  gemba-trace` (`fit-doc`, `fit-terrain`, `coaligned`, and the third-party
+  tools stay).
+- `is_gear_binary()`: `case "$1" in fit-*|coaligned)` →
+  `fit-*|gemba-*|coaligned)`.
+- Header/usage prose: "any fit-\* CLI" → "any fit-\*/gemba-\* CLI"; the
+  worked examples (`fit-trace fit-wiki`, "the five fit-\* CLIs the kata-\*
+  skills invoke") → gemba names.
+- **Keep** the filename `fit-install.sh`, `FIT_RELEASE_REPO`,
+  `FIT_GEAR_RELEASE` (its default value bumps in Part 4, once the gemba-named
+  gear release exists), and the `fit-gear` cask coordinates.
+
+**Verify:** `bash -n products/gemba/actions/bootstrap/fit-install.sh`;
+`rg 'fit-(harness|trace|benchmark|selfedit|wiki|xmr)\b'
+products/gemba/actions/` returns nothing.
+
+## Step 2.3 — Repoint `publish-actions.yml`
+
+**Modified:** `.github/workflows/publish-actions.yml`.
+
+- Matrix `prefix:` entries: `libraries/libharness/actions/harness` →
+  `products/gemba/actions/harness`; same pattern for `benchmark`, `wiki`;
+  `.github/actions/bootstrap` → `products/gemba/actions/bootstrap`. All four
+  `repo:` names unchanged; the two `products/kata/actions/*` entries
+  unchanged.
+- `on.push.paths`: the four source globs follow the new prefixes.
+- Header comment's action-home description updated.
+
+**Verify:** `yq '.jobs.publish.strategy.matrix.action[].prefix'
+.github/workflows/publish-actions.yml` lists the four new paths and the two
+kata paths; `repo:` values are byte-identical to before.
+
+## Step 2.4 — Path references to the old action homes
+
+Every config or script that names the moved directories by path repoints to
+`products/gemba/actions/`.
+
+| File | Reference |
+| --- | --- |
+| root `package.json` | `test` script `find` excludes `./libraries/libharness/actions/*` and `./libraries/libwiki/actions/*` → `./products/gemba/actions/*` (the `./products/kata/actions/*` exclude stays) |
+| `.github/workflows/publish-binaries.yml` | the gear-release steps sparse-checkout and `sed` `.github/actions/bootstrap/fit-install.sh` by path — both occurrences → `products/gemba/actions/bootstrap/fit-install.sh` (Part 4's release chain depends on this) |
+| `.claude/settings.json` | the session hook running `bash .github/actions/bootstrap/fit-install.sh --soft` → new path |
+| `justfile` | the recipe invoking `.github/actions/bootstrap/fit-install.sh` → new path |
+| `.rumdl.toml`, `biome.json`, `eslint.config.js` | lint/format excludes for the old action dirs → new paths |
+| `.coaligned/invariants/temporal.rules.mjs`, `.coaligned/invariants/model-defaults.rules.mjs` | scoped path lists naming the old action dirs → new paths |
+| `scripts/test-gate.mjs` | action-dir path excludes → new paths |
+
+**Verify:**
+`rg -n --hidden '\.github/actions/bootstrap|libraries/libharness/actions|libraries/libwiki/actions' --glob '!specs/**' --glob '!wiki/**' --glob '!.git/**'`
+returns nothing; `bun run test` green (and does not descend into
+`products/gemba/actions/`).
+
+## Step 2.5 — Action-home prose
+
+| File | Change |
+| --- | --- |
+| `.github/CLAUDE.md` | Third-party-actions intro and table: sources for `bootstrap`/`harness`/`benchmark`/`wiki` now live under `products/gemba/actions/`; § Environment bootstrap path → `products/gemba/actions/bootstrap/fit-install.sh`; `IS_SANDBOX` prose command tokens → gemba names. Repo names/URLs in the table unchanged. |
+| `CLAUDE.md` § Distribution Model | The composite-actions co-location line drops `libraries/*/actions/`: actions live in `products/*/actions/` and `.github/actions/`. The `sibling-composite-actions` enum block content (repo names) is unchanged; reseed via `bunx coaligned invariants --seed enumeration-drift` only if the check reports drift. |
+
+**Verify:** `bun run check` green (`enumeration-drift`, `context`).

--- a/specs/2250-agent-platform-product/plan-a-02.md
+++ b/specs/2250-agent-platform-product/plan-a-02.md
@@ -57,7 +57,7 @@ nothing.
   gear release exists), and the `fit-gear` cask coordinates.
 
 **Verify:** `bash -n products/gemba/actions/bootstrap/fit-install.sh`;
-`rg 'fit-(harness|trace|benchmark|selfedit|wiki|xmr)\b'
+`rg -n 'fit-(harness|trace|benchmark|selfedit|wiki|xmr)\b'
 products/gemba/actions/` returns nothing.
 
 ## Step 2.3 — Repoint `publish-actions.yml`
@@ -90,8 +90,11 @@ Every config or script that names the moved directories by path repoints to
 | `.rumdl.toml`, `biome.json`, `eslint.config.js` | lint/format excludes for the old action dirs → new paths |
 | `.coaligned/invariants/temporal.rules.mjs`, `.coaligned/invariants/model-defaults.rules.mjs` | scoped path lists naming the old action dirs → new paths |
 | `scripts/test-gate.mjs` | action-dir path excludes → new paths |
+| `.github/actions/split-and-push/action.yml` | docstring example `libraries/libwiki/actions/wiki` → `products/gemba/actions/wiki` |
+| `.gitignore` | anchoring comment naming `libraries/libwiki/actions/` → new path |
 
-**Verify:**
+**Verify:** at the end of the part (after Step 2.5's `.github/CLAUDE.md` prose
+repoint, which this gate would otherwise flag):
 `rg -n --hidden '\.github/actions/bootstrap|libraries/libharness/actions|libraries/libwiki/actions' --glob '!specs/**' --glob '!wiki/**' --glob '!.git/**'`
 returns nothing; `bun run test` green (and does not descend into
 `products/gemba/actions/`).

--- a/specs/2250-agent-platform-product/plan-a-03.md
+++ b/specs/2250-agent-platform-product/plan-a-03.md
@@ -71,7 +71,7 @@ sibling pack, would change the distribution model beyond the spec's scope).
 | File | Change |
 | --- | --- |
 | `libraries/libpack/src/skill-pack.js` | Stage selection accepts repeated prefixes and matches `name === prefix \|\| name.startsWith(prefix + "-")` so `gemba` (the product skill) and `gemba-*` both select. |
-| `libraries/libpack/src/builder.js` / CLI definition | `stage --prefix` repeatable (or space-separated value), threaded through. |
+| `libraries/libpack/bin/fit-pack.js` | `stage --prefix` becomes repeatable (its option parsing lives in the bin), threaded through to the stager. |
 | `libraries/libpack/test/**` | Cover multi-prefix and exact-name selection. |
 | `.github/actions/publish-skill-pack/action.yml` | `pack-prefix` documented as space-separated; the run step expands each prefix into a `--prefix` flag (a single-prefix value expands identically to today, so the change is inert until a leg passes two). |
 | `.github/workflows/publish-skills.yml` | `on.push.paths` gains `.claude/skills/gemba*/**`. The fit leg **keeps `prefix: fit`** — the merge-triggered publish runs the SHA-pinned old `fit-pack` binary, which parses only a single `--prefix` (last wins) and would silently stage a fit-skills pack stripped of every `fit-*` skill; Part 4 Step 4.3 flips it to `fit gemba` once the repinned bootstrap installs the multi-prefix `fit-pack`. |

--- a/specs/2250-agent-platform-product/plan-a-03.md
+++ b/specs/2250-agent-platform-product/plan-a-03.md
@@ -1,0 +1,108 @@
+# Plan 2250-a Part 3: Product framing — Gear refocus, page, skill, catalogs
+
+Give the split its product story and keep every catalog and pack in sync.
+Depends on Parts 1–2 (names and homes are final).
+
+## Step 3.1 — Gear refocus
+
+**Modified:** `products/gear/package.json`.
+
+- `dependencies`: delete `@forwardimpact/libharness`, `@forwardimpact/libwiki`,
+  `@forwardimpact/libxmr`. `@forwardimpact/svcspan` and everything else stays.
+- `jobs[0].littleHire`: "query graphs, run vector search, expose services as
+  MCP tools, or chart agent metrics without building infrastructure." → "query
+  graphs, run vector search, or expose services as MCP tools without building
+  infrastructure." (design names only the littleHire clause; the bigHire's
+  eval-tooling phrasing stays with `libterrain`).
+
+**Verify:** `rg 'libharness|libwiki|libxmr' products/gear/package.json`
+returns nothing; `rg 'chart agent metrics' products/` returns nothing;
+`bun install` resolves.
+
+## Step 3.2 — Overview page and site card
+
+**Created:** `websites/fit/gemba/index.md`,
+`websites/fit/assets/scene-gemba.svg`.
+**Modified:** `websites/fit/index.md`.
+
+- `index.md` follows the Gear page shape (`layout: product`, hero, persona
+  sections): the "stand up and operate an agent team" story; the runtime loop
+  **stand up** (bootstrap action) → **run** (harness action /
+  `gemba-harness`) → **see** (`gemba-trace`) → **remember** (wiki action /
+  `gemba-wiki`) → **measure** (benchmark action / `gemba-xmr`), presented once
+  for the CLI axis and once for the CI-actions axis; Getting Started names the
+  bring-up layer (`forwardimpact/bootstrap`, the released `fit-install.sh`
+  one-liner, `scripts/bootstrap.sh`) and `npx gemba-<cli>`; a section names
+  Kata as the reference tenant. No `import` guidance anywhere — APIs are the
+  libraries' pages (spec SC6).
+- `scene-gemba.svg` follows the existing `scene-*.svg` style.
+- `websites/fit/index.md` gains a Gemba product card beside Gear's.
+
+**Verify:** `bunx fit-doc build websites/fit` (or the site's `just` recipe)
+succeeds; the page renders both axes and the four run-loop CLIs (SC12).
+
+## Step 3.3 — `gemba` product skill
+
+**Created:** `.claude/skills/gemba/SKILL.md`.
+
+When to hire the platform and how the capabilities compose into the loop
+(stand up → run → see → remember → measure), pointing to the per-capability
+`gemba-*` skills for command documentation. Per spec SC12 the skill itself
+names the bring-up layer (the `bootstrap` action and its installer) and
+references the four run-loop CLIs (`gemba-harness`, `gemba-trace`,
+`gemba-wiki`, `gemba-xmr`), presenting the CI actions as the same loop.
+Follows the house template (`## When to Use`, `## Documentation` last);
+written generic per `.claude/skills/CLAUDE.md`. CLI-parity `## Documentation`
+blocks stay on the capability skills (renamed in Part 1).
+
+**Verify:** `bun run invariants` green (`skill-genericity` covers the new
+skill after Part 1's prefix additions; `skill-template` scopes only the
+kata/coaligned/monorepo packs and does not gate it); `bun run context` green.
+
+## Step 3.4 — Pack staging for gemba skills
+
+The `fit-skills` pack must carry the renamed capability skills and the product
+skill; today `fit-pack stage --prefix fit` selects `skills/fit-*` only. The
+repeatable `--prefix` and the exact-name match are a small libpack API
+addition the design does not name — recorded here as a plan-level deviation
+required by the pack-staging contract (the alternative, a new `gemba-skills`
+sibling pack, would change the distribution model beyond the spec's scope).
+
+| File | Change |
+| --- | --- |
+| `libraries/libpack/src/skill-pack.js` | Stage selection accepts repeated prefixes and matches `name === prefix \|\| name.startsWith(prefix + "-")` so `gemba` (the product skill) and `gemba-*` both select. |
+| `libraries/libpack/src/builder.js` / CLI definition | `stage --prefix` repeatable (or space-separated value), threaded through. |
+| `libraries/libpack/test/**` | Cover multi-prefix and exact-name selection. |
+| `.github/actions/publish-skill-pack/action.yml` | `pack-prefix` documented as space-separated; the run step expands each prefix into a `--prefix` flag (a single-prefix value expands identically to today, so the change is inert until a leg passes two). |
+| `.github/workflows/publish-skills.yml` | `on.push.paths` gains `.claude/skills/gemba*/**`. The fit leg **keeps `prefix: fit`** — the merge-triggered publish runs the SHA-pinned old `fit-pack` binary, which parses only a single `--prefix` (last wins) and would silently stage a fit-skills pack stripped of every `fit-*` skill; Part 4 Step 4.3 flips it to `fit gemba` once the repinned bootstrap installs the multi-prefix `fit-pack`. |
+| `.claude/skills/CLAUDE.md` | "Skills prefixed `fit-*` and `kata-*` are published" → include `gemba*`; the bare-invoke exception list (`fit-*` / `kata-*` / `coaligned`) gains `gemba-*`; the CLI-location rule gains "Platform: `products/gemba/bin/gemba-<name>.js`". |
+| `products/CLAUDE.md`, `libraries/CLAUDE.md` | CLI/skill linking policy: the six runtime CLIs' home is now the product; worked examples updated. |
+
+**Verify:** `bun test libraries/libpack`; a local
+`fit-pack stage --from .claude --prefix fit --prefix gemba --into /tmp/pack …`
+dry run stages `gemba/`, `gemba-*/`, and every `fit-*/` skill.
+
+## Step 3.5 — Kata framing and identity prose
+
+| File | Change |
+| --- | --- |
+| `KATA.md` | A short paragraph naming Gemba as the platform Kata runs on — Kata is the reference tenant, the proof the substrate is generic — linking the overview page. No `products/kata/` change (SC13). |
+| `CLAUDE.md` § Secondary Products | Add the Gemba entry (one line + overview link, same shape as Gear's); note Kata "runs on Gemba" in the Kata line if it reads naturally. |
+| `CLAUDE.md` § Distribution Model | npm-packages line: `fit-*` and `kata-*` CLIs → `fit-*`, `gemba-*`, and `kata-*`. |
+
+**Verify:** `git diff --stat products/kata/` is empty across the whole PR.
+
+## Step 3.6 — Generated context and hand-maintained counts
+
+- Run `bun run context:fix`: regenerates the `JTBD.md` and
+  `products/README.md` catalog blocks (Gemba row appears, Gear's description
+  unchanged unless edited) and the jobs lines.
+- Hand edits: `products/README.md` intro product-count sentence (reconcile the
+  existing "seven products" against the catalog before writing the new
+  number); `websites/README.md` jobs line if `context:fix` flags it.
+
+**Verify:** `bun run context:fix` produces no further diff; `bun run check`
+and `bun run test` green — final gate for the PR (SC14). Final rename gate:
+re-run the Part 1 verify `rg` unchanged; the allowed remainder is now only
+its items (a) and (b) — the Part-2-owned action sources are moved and
+renamed, so item (c) must be empty.

--- a/specs/2250-agent-platform-product/plan-a-04.md
+++ b/specs/2250-agent-platform-product/plan-a-04.md
@@ -1,0 +1,95 @@
+# Plan 2250-a Part 4: Post-merge release and repin chain
+
+Makes the renamed surfaces real for CI and external consumers. Runs
+immediately after the Parts 1–3 PR merges to `main`; executor
+`release-engineer`, following `kata-release-cut` for every cut. Until this
+part completes, CI installs old-name binaries against new-name instructions —
+the window is expected to break scheduled agent runs (plan-a.md § Risks), so
+execute same-day.
+
+## Step 4.1 — npm release cuts, in dependency order
+
+| Order | Tag | What ships | Bump rationale |
+| --- | --- | --- | --- |
+| 1 | `libharness@v3.0.0` | library without bins; new command-module exports | breaking: `bin` field and `./bin/*` exports removed |
+| 2 | `libxmr@v3.0.0` | same shape | breaking: `bin` removed |
+| 3 | `libwiki@v0.3.0` | same shape; dep ranges → `libharness ^3.0.0` **and** `libxmr ^3.0.0` | 0.x minor signals the break |
+| 4 | `gemba@v0.1.0` | `@forwardimpact/gemba` + the five `gemba-*` launchers (publish-npm stamps and publishes launchers whose single dependency is the tagged package); dep ranges → the versions above | first release |
+| 5 | `gear@v0.2.0` | npm: slimmed meta-package (three runtime deps gone). Same tag also fires `publish-binaries.yml`: gemba-named binaries from `cli-manifest.json`, cask + Linux formula regenerated (gemba `binary` stanzas), `fit-install.sh` staged on the release stamped with `FIT_GEAR_RELEASE=gear@v0.2.0` | 0.x minor signals the dependency break |
+
+`kata-release-cut` owns final version arithmetic; the table records the
+expected magnitudes and the ordering constraint (gemba's deps must exist on
+the registry before its smoke install; gear's binary build compiles the
+product bins, which resolve only after the merge).
+
+**Verify:** `npm view @forwardimpact/gemba version` = 0.1.0;
+`npm view gemba-wiki version` = 0.1.0 (stamped); the `gear@v0.2.0` release
+lists `gemba-*-bun-linux-x64` assets and a stamped `fit-install.sh`; the
+homebrew-tap commit renders `gemba-*` binary stanzas.
+
+## Step 4.2 — Bootstrap pin bump (one small PR)
+
+**Modified:** `products/gemba/actions/bootstrap/fit-install.sh` —
+`FIT_GEAR_RELEASE` default → `gear@v0.2.0`.
+
+Merge; `publish-actions.yml` splits the new source to the sibling `bootstrap`
+repo; tag the sibling release (next `v1.0.x`) per the standing sibling-tag
+process.
+
+**Verify:** the new bootstrap tag's `fit-install.sh` installs `gemba-wiki` on
+a scratch runner.
+
+## Step 4.3 — Repin and flip `clis:` (one PR)
+
+**Modified:** `.github/workflows/*.yml`.
+
+- Every `uses: forwardimpact/bootstrap@<SHA>` → the Step 4.2 tag's SHA.
+- `uses: forwardimpact/harness@<SHA>` (`kata-dispatch.yml`,
+  `eval-guide.yml`), `forwardimpact/wiki@<SHA>` (same files),
+  `forwardimpact/benchmark@<SHA>` (`eval-wiki.yml`) and the reusable
+  `forwardimpact/benchmark/.github/workflows/benchmark.yml@<SHA>`
+  (`eval-kata.yml`, `eval-coaligned.yml`) → the post-merge sibling SHAs
+  carrying the renamed steps (tag them per the standing process if untagged).
+- Every `clis:` value: `fit-wiki fit-harness fit-trace` and variants → gemba
+  names (inventory: `rg -n 'clis:' .github/workflows`), **together with** the
+  bare-PATH run-step invocations held since Part 1: `fit-trace cost` and
+  `fit-harness callback` in `kata-dispatch.yml`, `fit-wiki curate` in
+  `curate-wiki.yml`.
+- `publish-skills.yml` fit leg `prefix: fit` → `fit gemba` — editing the
+  workflow also re-fires the pack publish, now running the multi-prefix
+  `fit-pack` from the repinned bootstrap, which restores the runtime skills
+  and the `gemba` product skill to the published fit-skills pack.
+
+Every pinned SHA must resolve on its sibling repo (citation integrity).
+
+**Verify:** full CI green on the repin PR — this is the first run that
+installs and invokes the gemba binaries end to end; the plan-a-01 `rg` gate's
+allowed remainder shrinks to only the `benchmarks/fit-wiki` path reference in
+`eval-wiki.yml`; the published fit-skills pack lists the `gemba` and
+`gemba-*` skills.
+
+## Step 4.4 — Deprecate the superseded launchers
+
+`npm deprecate` `fit-harness`, `fit-trace`, `fit-benchmark`, `fit-wiki`,
+`fit-xmr` (each: "renamed to gemba-<cli>; install gemba-<cli> instead"), per
+the standing release process. Do not unpublish.
+
+**Verify:** `npm view fit-wiki` shows the deprecation notice.
+
+## Step 4.5 — Follow-up issues
+
+File two issues, each linking spec 2250 and this plan:
+
+1. **Kata repoint** (Kata lane, `agent:staff-engineer`): repoint
+   `products/kata/actions/{kata-agent,kata-interview}` to the gemba CLI names
+   and the new bootstrap tag when Kata next advances its pins — excluded from
+   spec 2250 by SC13; today's SHA-pinned chain (old bootstrap → old gear
+   release → old binary names) stays self-consistent until then.
+2. **Distribution and docs placement**: (a) the gemba CLIs ship inside the
+   `gear` binary bundle and `fit-gear` cask — one product's command family
+   distributed under another's name; (b) the six CLIs' usage guides remain
+   under `websites/fit/docs/libraries/` while documenting product commands.
+   Both are out of spec 2250's boundary; the issue records them so neither is
+   resolved silently.
+
+**Verify:** both issues exist with the links above.

--- a/specs/2250-agent-platform-product/plan-a.md
+++ b/specs/2250-agent-platform-product/plan-a.md
@@ -1,0 +1,150 @@
+# Plan 2250-a: The Gemba agent-runtime platform product
+
+Executes [design 2250-a](./design-a.md) for [spec 2250](./spec.md).
+
+## Name resolution
+
+The spec's deferred product-name decision is resolved: the platform is
+**Gemba** (`products/gemba/`, `@forwardimpact/gemba`, command family
+`gemba-*`), decided by the repository owner in-session on 2026-07-19. The name
+appears in the tree only in historical specs and in `design/kata/index.md` in
+its Lean-philosophy sense — no live collision. All seven npm names
+(`@forwardimpact/gemba` plus the six unscoped command names) were verified
+available on the npm registry on 2026-07-19; five publish as launchers —
+no `gemba-selfedit` launcher is computed, since no doc or published skill
+invokes selfedit via `npx`/`bunx`. Every other deferred decision
+(`fit-terrain` home, `svcpathway` mis-filing) stays open per spec § Deferred
+decisions.
+
+## Approach
+
+Land the monorepo change as three sequential parts on one branch — Part 1 the
+CLI axis (product package, bins, library purification, launchers, invariant,
+and the repo-wide command rename), Part 2 the actions axis (the four
+composite-action moves and their publish wiring), Part 3 the product framing
+(Gear refocus, JTBD, page, skill, pack staging, catalogs) — merged as one PR so
+the clean break is atomic, then run Part 4, the post-merge release-and-repin
+chain that makes the renamed binaries real for CI and external consumers. The
+rename follows the spec-2110 codemod method: category-scoped blanket replace of
+the six command-token families with a keep-list, verified by scoped `rg` gates,
+with golden fixtures regenerated from actual CLI output rather than hand-edited.
+
+Libraries used: libpack (skill-pack stage selection, Part 3); no new library
+dependencies.
+
+## Rename map and token-classification rule
+
+| Old token | New token |
+| --- | --- |
+| `fit-harness` | `gemba-harness` |
+| `fit-trace` | `gemba-trace` |
+| `fit-benchmark` | `gemba-benchmark` |
+| `fit-selfedit` | `gemba-selfedit` |
+| `fit-wiki` | `gemba-wiki` |
+| `fit-xmr` | `gemba-xmr` |
+
+Each family covers the command token everywhere it appears: bin filenames and
+`bin`/`exports` keys, launcher/skill/golden directory names, help and usage
+strings, `mkdtemp` prefixes, comments, doc prose, and workflow `bunx`
+invocations.
+
+**Keep** every match of: library identities (`libharness`, `libwiki`, `libxmr`,
+all `@forwardimpact/*` package names, `LIBHARNESS_*` env vars); every other
+`fit-*` CLI (`fit-doc`, `fit-terrain`, `fit-map`, `fit-pack`, `fit-svc*`, …);
+the sibling action repo names (`bootstrap`, `harness`, `wiki`, `benchmark`) and
+their `uses:` pins; the `fit-skills` pack name; the `fit-gear` cask name; the
+`fit-install.sh` filename and the `FIT_RELEASE_REPO`/`FIT_GEAR_RELEASE`
+variable names; `fit-bootstrap` prose aliases for the bootstrap action;
+`specs/**`, `wiki/**`, `benchmarks/**`, and historical CHANGELOG entries.
+**Path references into kept trees also keep their names**: a token that is a
+path segment of a keep-listed directory is not a command invocation — e.g.
+`family: ./benchmarks/fit-wiki` in `eval-wiki.yml` names the
+`benchmarks/fit-wiki/` eval family dir, which keeps its name; renaming the
+reference would break it permanently. Inventory these before replacing
+(`rg -n 'benchmarks/fit-'`).
+
+Three surfaces keep the old names **deliberately until Part 4**: every `clis:`
+value in `.github/workflows/*.yml` (consumed by SHA-pinned sibling actions that
+install old-name binaries); the bare-PATH invocations of those installed
+binaries in workflow run steps (`fit-trace cost` and `fit-harness callback` in
+`kata-dispatch.yml`, `fit-wiki curate` in `curate-wiki.yml`) — they execute
+whatever `clis:` installed, so they flip together with it; and **everything
+under `products/kata/`** (spec SC13: no Kata diff; follow-up issue filed in
+Part 4).
+
+## Codemod method
+
+Each part performs a blanket replace of its assigned families across its whole
+surface; the per-step file tables are a verified inventory of exemplars and
+non-obvious sites, not an allowlist. The completeness gate is each part's
+family-scoped `rg` verify line — always **line-level** (`rg -n`, never `-l`:
+a file that legitimately keeps a `clis:` line must not mask a missed rename
+elsewhere in it), run with `--hidden` and **explicit** `--glob` exclusions
+(`rg` also honors `.rgignore`; the gates do not rely on it). Guard against
+over-replacement the same way: before replacing, list keep-listed path
+references (§ Rename map) and confirm afterwards they are byte-unchanged.
+Golden CLI fixtures are regenerated via `scripts/capture-cli-golden.mjs`,
+never hand-edited. Recorded test fixtures that embed the old tokens (e.g.
+`libraries/libharness/test/fixtures/divergence-run481.ndjson`) are
+deliberately edited, following the spec-2110 precedent — the consuming tests
+compare event structure and cost, not those strings.
+
+## Parts
+
+| Part | Scope | Executor |
+| --- | --- | --- |
+| [plan-a-01](./plan-a-01.md) | CLI axis: `products/gemba/` package + bins, selfedit extraction, library purification, launchers, `public-cli-set`, cli-manifest, moved bin-surface tests, repo-wide command rename (skills, agents, docs, scripts, workflows' `bunx` sites) | staff-engineer |
+| [plan-a-02](./plan-a-02.md) | Actions axis: move `bootstrap`/`harness`/`benchmark`/`wiki` into `products/gemba/actions/`, repoint `publish-actions.yml`, edit `fit-install.sh`, root test excludes, `.github/CLAUDE.md` | staff-engineer |
+| [plan-a-03](./plan-a-03.md) | Product framing: Gear refocus, overview page + site card, `gemba` product skill, pack staging (libpack + `publish-skills.yml`), KATA.md/CLAUDE.md framing, counts + `context:fix` | staff-engineer |
+| [plan-a-04](./plan-a-04.md) | Post-merge release chain: npm cuts, gear binary release, bootstrap `FIT_GEAR_RELEASE` bump + tag, repin PR (`uses:` pins + `clis:` flips), old-launcher deprecation, Kata follow-up issue | release-engineer |
+
+## Execution
+
+Parts 1–3 are strictly sequential commits on one branch
+(`feat/2250-gemba-platform`), merged as **one PR** — the launcher invariant
+couples bins, launchers, and doc invocations, so the rename must reach `main`
+atomically. Each part ends with `bun run context:fix` (the generated JTBD and
+catalog blocks track the part that changed them, so `bun run check` can pass
+per part), then `bun run check` and `bun run test` green. Part 4 runs
+immediately after the merge, by `release-engineer`, as its own sequence (tags,
+one bootstrap-bump PR, one repin PR). No parts run in parallel.
+
+## Risks
+
+- **The rename window.** Between the PR merge and Part 4's repin, CI installs
+  old-name binaries (pinned `bootstrap` + `FIT_GEAR_RELEASE`) while the merged
+  skills and agent profiles instruct `gemba-*`. Scheduled agent workflows that
+  fire in the window will fail visibly on bare-name invocations. Mitigation:
+  execute Part 4 the same day; if a longer gap is expected, pause the scheduled
+  kata workflows for the window.
+- **Skill-pack publish in the window.** The merge push fires
+  `publish-skills.yml`, whose legs run the SHA-pinned old `fit-pack` gear
+  binary — which parses only a single `--prefix` (last flag wins). The fit
+  leg therefore **keeps `prefix: fit` until Part 4** (Step 4.3 flips it to
+  `fit gemba` once the repinned bootstrap installs the multi-prefix
+  `fit-pack`); flipping it in Part 3 would publish a fit-skills pack silently
+  stripped of every `fit-*` skill. Consequence of the hold: between the merge
+  and Part 4, the published fit-skills pack lacks the renamed runtime skills
+  and the `gemba` product skill.
+- **Downstream pack consumers.** The same merge publishes the kata-skills pack
+  with skills instructing `gemba-*`, while downstream Kata installations run
+  the old pinned bootstrap/gear chain that installs `fit-*` binaries. Fresh
+  `apm` installs in the window get instructions ahead of their binaries; the
+  Step 4.5 follow-up issue owns the Kata-side repoint.
+- **Silent `bunx` fallback.** After the rename, a missed `bunx fit-<cli>` does
+  not error — it resolves the old npm launcher from the registry and runs stale
+  code. The family-scoped `rg --hidden` gates are the only guard; run them
+  exactly as written, over the whole tree minus the keep-list.
+- **Scanner prefixes.** `public-cli-set` (`INVOKE_RE`, skill-dir walk) and
+  `skill-genericity` (npx-prefix and cross-pack-link patterns) both hardcode
+  prefix lists. Missing `gemba` in any of them silently shrinks the computed
+  launcher set or lint coverage; Part 1/Part 3 verify by asserting the expected
+  launcher set and running the full invariant suite.
+- **One tag, two pipelines.** A `gear@v*` tag triggers both the npm publish and
+  the binary/cask release. Part 4's ordering (libraries → gemba → gear) exists
+  so the binary build compiles bins that resolve, and the npm gear package
+  ships the slimmed dependency list, from the same tag.
+- **Local environments.** Developer machines keep old brew binaries until the
+  gear cask updates; `bunx gemba-<cli>` from the checkout works throughout. The
+  checked-out `fit-install.sh` cannot install gemba binaries until Part 4 bumps
+  `FIT_GEAR_RELEASE`; this is the same window as risk 1.


### PR DESCRIPTION
## Summary

Implementation plan for [spec 2250](https://github.com/forwardimpact/monorepo/blob/main/specs/2250-agent-platform-product/spec.md) against [design 2250-a](https://github.com/forwardimpact/monorepo/blob/main/specs/2250-agent-platform-product/design-a.md) (merged in #1971).

**Name resolution:** the spec's deferred product-name decision was resolved by the repository owner in-session on 2026-07-19 — the platform is **Gemba** (`products/gemba/`, `@forwardimpact/gemba`, command family `gemba-*`). All seven npm names verified available the same day.

## Plan shape

- **plan-a.md** — approach, rename map + keep-list, codemod method, execution, risks
- **plan-a-01** — CLI axis: gemba package + six bins, selfedit extraction, library purification, launchers, `public-cli-set` update, repo-wide command rename
- **plan-a-02** — actions axis: bootstrap/harness/benchmark/wiki move to `products/gemba/actions/`, publish wiring, path-reference repoints
- **plan-a-03** — product framing: Gear refocus, overview page, `gemba` skill, pack staging (libpack multi-prefix), catalogs
- **plan-a-04** — post-merge release/repin chain (release-engineer): npm cuts, gear binary release, bootstrap bump, repin PR, launcher deprecation, follow-up issues

Parts 1–3 land as one implementation PR (the launcher invariant couples bins, launchers, and invocations); Part 4 runs immediately post-merge.

## Review

Clean sub-agent panel per kata-review caller protocol: technical panel (3 × staff-engineer) + devex panel (3 × devex-engineer) on the local plan. Cross-panel consensus blocker (publish-skills pack corruption via the pinned single-prefix `fit-pack` binary) and all high/medium findings addressed in the plan before this PR: prefix hold until Part 4, line-level `rg` gates, over-replacement keep-list for `benchmarks/**` path references, `publish-binaries.yml`/settings/justfile path repoints, bare-PATH workflow invocations reclassified into the Part 4 flip, shared libwiki golden dir moved whole, dead `minimatch` dep dropped, libxmr range bump added, per-part `context:fix` sequencing, JTBD forces/firedWhen added. A scoped panel re-read of the amended files will be recorded as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)