### PR TITLE
plan(2260): reframe Co-Aligned as the Jidoka product

### DIFF
--- a/specs/2260-jidoka-product-reframe/plan-a-01.md
+++ b/specs/2260-jidoka-product-reframe/plan-a-01.md
@@ -136,12 +136,13 @@ self-referential tokens inside them — inventory of the non-mechanical edits:
 | `enumeration-drift.topics.yml`, `ambient-deps.{rules.mjs,allow.yml,deny.yml}`, `shared-workspace-staging.rules.mjs`, `subprocess-in-tests.rules.mjs`, `temporal.rules.mjs`, `model-defaults.rules.mjs`, `enumeration-drift.rules.mjs`, `skill-template.rules.mjs` hints | Mechanical: `.coaligned/invariants/…` paths (incl. `temporal.rules.mjs`/`model-defaults.rules.mjs` self-exclude globs and the `model-defaults` `paths` array entry `".coaligned"` → `".jidoka"`), `bunx coaligned invariants --seed …` → `bunx jidoka invariants --seed …`, `libcoaligned` prose → `libinvariant`. |
 
 Update the config-dir consumers that execute or link these paths in the same
-commit: `scripts/audit-service-urls.mjs` (the
-`service-url-drift.url.mjs` import and `REGISTRY` constant),
-`products/CLAUDE.md` L98, `libraries/libmock/README.md` L104,
-`libraries/libutil/src/{calendar,models}.js`, `libraries/libutil/src/findings.js`
-(`libcoaligned` prose), `libraries/libxmr/src/routes.js`,
-`products/outpost/src/scheduler.js` (comments), `CONTRIBUTING.md` L29/223/251.
+commit: `scripts/audit-service-urls.mjs` (the `service-url-drift.url.mjs` import
+and `REGISTRY` constant), `products/CLAUDE.md` L98,
+`libraries/libmock/README.md` L104,
+`libraries/libutil/src/{calendar,models}.js`,
+`libraries/libutil/src/findings.js` (`libcoaligned` prose),
+`libraries/libxmr/src/routes.js`, `products/outpost/src/scheduler.js`
+(comments), `CONTRIBUTING.md` L29/223/251.
 
 **Verify:** `bunx jidoka invariants` green from the repo root (the bin finds
 `.jidoka/invariants` via the finder); `node scripts/audit-service-urls.mjs`

--- a/specs/2260-jidoka-product-reframe/plan-a-01.md
+++ b/specs/2260-jidoka-product-reframe/plan-a-01.md
@@ -1,0 +1,224 @@
+# Plan 2260-a Part 1: CLI + library axis — the Jidoka package and the invariant library
+
+One part because the `public-cli-set` invariant and the workspace couple the
+bin, the launcher set, and the invariant rules: any split leaves a bin
+without its package or a scanner without its prefix and fails CI. Sub-steps
+are verification units, not commit boundaries.
+
+## Step 1.1 — Scaffold `products/jidoka/package.json`
+
+Create the consumer package: `bin` + `dependencies`, no `main`, no `exports`,
+no `src/`, no hand-authored `README.md` (Gear/Gemba precedent).
+
+**Created:** `products/jidoka/package.json`.
+
+```json
+{
+  "name": "@forwardimpact/jidoka",
+  "version": "0.2.0",
+  "description": "Build quality into agent instructions — the jidoka CLI and CI action stop the line the moment an instruction layer drifts, a jobs block goes stale, or a repository invariant breaks.",
+  "keywords": ["jidoka", "instructions", "jtbd", "invariants", "quality", "agent"],
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "products/jidoka"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Teams Using Agents",
+      "goal": "Build Quality Into Agent Instructions",
+      "trigger": "The team's layered instructions exist, but nothing enforces them — layers drift and restate each other, and stale jobs blocks ship unnoticed until an agent misbehaves.",
+      "bigHire": "keep humans and agents on one layered instruction architecture, with checks that stop the line the moment a layer drifts.",
+      "littleHire": "check one layer's caps, validate the jobs blocks, or run the repository's invariant rules with a single command before commit.",
+      "competesWith": "unenforced conventions; review-time nitpicking; hand-rolled lint scripts; letting drift accumulate until a rewrite",
+      "forces": {
+        "push": "Instruction sprawl keeps breaking agent behavior with no layer to blame.",
+        "pull": "One command family and CI action that stop the line at the first drifted layer.",
+        "habit": "Trusting contributors to keep instructions tidy by hand.",
+        "anxiety": "Another gate slowing every commit."
+      },
+      "firedWhen": "the checks block more work than the drift they catch, or the team stops layering its instructions."
+    }
+  ],
+  "type": "module",
+  "bin": { "jidoka": "./bin/jidoka.js" },
+  "files": ["bin/**/*.js"],
+  "dependencies": {
+    "@forwardimpact/libinvariant": "^0.2.0",
+    "@forwardimpact/libcli": "^0.1.17",
+    "@forwardimpact/libpreflight": "^0.1.4",
+    "@forwardimpact/libutil": "^0.1.100"
+  },
+  "engines": { "bun": ">=1.2.0", "node": ">=22.0.0" },
+  "publishConfig": { "access": "public" }
+}
+```
+
+Version `0.2.0` seeds above the renamed pack sibling's retained `v0.1.x` tag
+floor (design § Components). Dependency ranges track the workspace at
+implementation time; the four packages are exactly what the bin imports. No
+`scripts.test` — the moved goldens (Step 1.8) have no runner test.
+
+**Verify:** `bun install` resolves; `bun run context:check-jtbd` passes the
+new jobs entry (run `bun run context:fix` first to regenerate `JTBD.md`).
+
+## Step 1.2 — Move and rename the bin
+
+`git mv libraries/libcoaligned/bin/coaligned.js products/jidoka/bin/jidoka.js`,
+then edit in place:
+
+- Import `../src/index.js` → `@forwardimpact/libinvariant`; the import list
+  drops `INVARIANTS_DIR` (deleted from the library, Step 1.3).
+- Add the product-owned discovery constant:
+  `const INVARIANTS_DIR = ".jidoka/invariants";` — the caller-supplied
+  convention (design § Interfaces).
+- Thread it through the three call sites: `findInvariantsRoot(rt,
+  INVARIANTS_DIR)`, `loadRuleModules({ root, rulesDir: INVARIANTS_DIR,
+  runtime: rt })`, `runRuleModules(modules, { root, runtime: rt, dir })`
+  with `dir = resolve(root, INVARIANTS_DIR)`.
+- Rename command tokens: definition `name: "jidoka"`, description ("…defined
+  in JIDOKA.md…"), examples, pass messages (`jidoka instructions passed`,
+  …), the jtbd stale-hint (`` `jidoka jtbd --fix` ``), and the
+  `.coaligned/invariants` comment above `invariantsHandler`.
+- `packageJsonUrl: new URL("../package.json", import.meta.url)` now resolves
+  the jidoka package — correct (`--version` reports the product), leave as
+  is.
+- Add a `documentation` array to the definition (the docs home is the
+  standard plus the standalone site — spec § Included, Website row), the
+  same two entries the renamed skills' `## Documentation` lists carry
+  (Step 3.3):
+  `{ title: "Jidoka Instruction Architecture Standard", url:
+  "https://github.com/forwardimpact/monorepo/blob/main/JIDOKA.md" }` and
+  `{ title: "Jidoka website", url: "https://www.jidoka.team/" }`.
+
+Subcommand set, options, and dispatch flow unchanged.
+
+**Verify:** `node products/jidoka/bin/jidoka.js --help` exits 0 and lists
+`instructions`, `jtbd`, `invariants` (spec SC2); `node
+products/jidoka/bin/jidoka.js invariants` passes against the Step 1.4 tree.
+
+## Step 1.3 — Rename and purify the library
+
+`git mv libraries/libcoaligned libraries/libinvariant`, then:
+
+| File | Change |
+| --- | --- |
+| `package.json` | `name` → `@forwardimpact/libinvariant`; `description` → "Repository invariant checks — instruction-layer length caps, JTBD block validation, and a declarative rule-module runner over a caller-supplied rules directory."; `keywords` swap `coaligned` → `invariants` family tokens; `repository.directory` → `libraries/libinvariant`; delete the `bin` field and the `./bin/coaligned.js` export (root export `.` → `./src/index.js` stays); drop `bin/**/*.js` from `files`. The `jobs` entry keeps its goal; name tokens only. |
+| `src/index.js` | Drop the `INVARIANTS_DIR` re-export; other exports unchanged. |
+| `src/invariants.js` | Delete `export const INVARIANTS_DIR`; `findInvariantsRoot(runtime)` → `findInvariantsRoot(runtime, rulesDir)` (required — the one signature change); `loadRuleModules` and `checkInvariants` lose the `rulesDir` default (required option); `runRuleModules` loses the `dir` default (required option); `Bun.plugin` name `coaligned-rule-deps` → `invariant-rule-deps`; JSDoc/comments naming `.coaligned/invariants` → "the caller-supplied rules directory". |
+| `src/instructions.js`, `src/enum-drift.js` | Name tokens in comments/strings only (`rg -n -i coaligned` the two files); behavior untouched. |
+| `README.md` | Rename wholesale: import-only library, no CLI; point "run the checks" readers at the Jidoka product (`npx @forwardimpact/jidoka` or the installed binary). |
+| `test/invariants.test.js`, `test/invariant-kit.test.js` | Pass the now-required `rulesDir`/`dir` explicitly with brand-free fixture paths (e.g. `rules/invariants`); assert `findInvariantsRoot` against the passed directory. Handler and component tests otherwise stay put. |
+
+**Verify:** `test ! -d libraries/libcoaligned`; `rg -n '"bin"'
+libraries/libinvariant/package.json` returns nothing;
+`rg -n 'INVARIANTS_DIR' libraries/libinvariant/src` returns nothing;
+`bun test libraries/libinvariant` green (spec SC3).
+
+## Step 1.4 — Move the config directory and self-edit the rule modules
+
+`git mv .coaligned .jidoka` (18 rule modules + 8 data files). Then rename
+self-referential tokens inside them — inventory of the non-mechanical edits:
+
+| File | Change |
+| --- | --- |
+| `public-cli-set.rules.mjs` | `PUBLISHED_NON_FIT_CLIS` → `[]` — the launcher retires with no successor (spec SC11); keep the escape hatch with a comment describing when a non-`fit`/`gemba` public CLI would be named. Header and L51-56 comments drop the `coaligned` example. |
+| `skill-genericity.rules.mjs` | npx pattern → `"\\bnpx (fit-|gemba-|jidoka|kata-)"`; website pattern → `"websites/(fit|kata|jidoka|monorepo)\\b"`; out-of-scope comment `coaligned-*` → `jidoka-*`; hint paths → `.jidoka/invariants/…`. |
+| `skill-template.rules.mjs` | `PACK_SKILL` → `(kata\|jidoka\|monorepo)`; both `coaligned-*` globs → `jidoka-*`; `NPX_PATTERNS` becomes two patterns — `"\\bnpx (fit-\|kata-)"` (unchanged reason) and `"\\b(npx\|bunx) jidoka\\b"` with reason "resolves the squatted third-party jidoka package — invoke the installed binary bare, or npx @forwardimpact/jidoka"; drop the `!**/check-workflows.md` exclusion and its header paragraph (the CI templates switch to the scoped form, Step 3.3, which matches neither pattern). |
+| `enumeration-drift.topics.yml`, `ambient-deps.{rules.mjs,allow.yml,deny.yml}`, `shared-workspace-staging.rules.mjs`, `subprocess-in-tests.rules.mjs`, `temporal.rules.mjs`, `model-defaults.rules.mjs`, `enumeration-drift.rules.mjs`, `skill-template.rules.mjs` hints | Mechanical: `.coaligned/invariants/…` paths (incl. `temporal.rules.mjs`/`model-defaults.rules.mjs` self-exclude globs and the `model-defaults` `paths` array entry `".coaligned"` → `".jidoka"`), `bunx coaligned invariants --seed …` → `bunx jidoka invariants --seed …`, `libcoaligned` prose → `libinvariant`. |
+
+Update the config-dir consumers that execute or link these paths in the same
+commit: `scripts/audit-service-urls.mjs` (the
+`service-url-drift.url.mjs` import and `REGISTRY` constant),
+`products/CLAUDE.md` L98, `libraries/libmock/README.md` L104,
+`libraries/libutil/src/{calendar,models}.js`, `libraries/libutil/src/findings.js`
+(`libcoaligned` prose), `libraries/libxmr/src/routes.js`,
+`products/outpost/src/scheduler.js` (comments), `CONTRIBUTING.md` L29/223/251.
+
+**Verify:** `bunx jidoka invariants` green from the repo root (the bin finds
+`.jidoka/invariants` via the finder); `node scripts/audit-service-urls.mjs`
+imports cleanly; `rg -n --hidden --no-ignore '\.coaligned' --glob '!.git/**'
+--glob '!node_modules/**' --glob '!specs/**' --glob '!wiki/**'` returns
+nothing yet-unowned (Part 3 owns skills/docs/standard; the migration note
+does not exist yet).
+
+## Step 1.5 — Retire the launcher
+
+**Deleted:** `launchers/coaligned/` (both files). **Modified:**
+`launchers/README.md` — the L11-15 exception paragraph now describes
+`PUBLISHED_NON_FIT_CLIS` as an empty escape hatch (what it is for, not who
+uses it); the L33 enforcement path → `.jidoka/invariants/…`. No
+`launchers/jidoka/` is created — `jidoka` never enters the invariant's
+invoked-name set (`INVOKE_RE` matches only `fit-`/`gemba-` names and the
+scoped `npx @forwardimpact/jidoka` form does not match), so the computed set
+is unchanged.
+
+**Verify:** `bun run invariants` green; `ls launchers/` shows no `coaligned`
+and no `jidoka` dir (spec SC11).
+
+## Step 1.6 — Distribution wiring
+
+| File | Change |
+| --- | --- |
+| `build/cli-manifest.json` | Entry `"name": "coaligned"` → `"jidoka"`; `targets` and `bundle: "gear"` unchanged (spec SC12). `build-binary.sh` resolves the name against the new `products/jidoka/package.json` bin at build time. |
+| `products/gemba/actions/bootstrap/fit-install.sh` | `DEFAULT_TOOLS` member `coaligned` → `jidoka` (L61); `is_gear_binary` case pattern → `fit-*\|gemba-*\|jidoka` (L127); comment mentions at L11, L42, L57, L64-66, L92, L124-125, L249, L580. `FIT_GEAR_RELEASE` default is **not** bumped here — Step 4.2 owns it; the script only executes via the pinned sibling until then. |
+| `.github/workflows/publish-npm.yml` | Inline check step: import → `@forwardimpact/libcoaligned` becomes `@forwardimpact/libinvariant`; rules-module path and `dir` → `.jidoka/invariants` (L56/58/62). |
+
+**Verify:** `jq -r '.clis[].name' build/cli-manifest.json` lists `jidoka`
+and no `coaligned`; `bash -n products/gemba/actions/bootstrap/fit-install.sh`.
+
+## Step 1.7 — Root scripts and tool prose
+
+| File | Change |
+| --- | --- |
+| `package.json` (root) | `"invariants"`, `"context:check-instructions"`, `"context:check-jtbd"`, `"context:fix"` — `bunx coaligned …` → `bunx jidoka …` (workspace-resolved; spec SC5). |
+| `justfile` | `check-instructions` recipe → `bunx jidoka instructions` (L212). |
+| `.rumdl.toml` | Comment prose at L8-9, L36: `coaligned` → `jidoka`. |
+| `MONOREPO.md` | L81 required-tools list member `coaligned` → `jidoka`; L177 `.coaligned/invariants/` + `coaligned invariants` → jidoka forms. (Standard-document links at L12/109/121/127 are Part 3.) |
+
+**Verify:** `bun run invariants`, `bun run context` green.
+
+## Step 1.8 — Golden fixtures
+
+`git mv libraries/libcoaligned/test/golden/coaligned
+products/jidoka/test/golden/jidoka` (moves with the Step 1.3 `git mv`;
+relocate from the renamed library), then regenerate all five cases from
+actual output:
+
+```sh
+node scripts/capture-cli-golden.mjs --bin jidoka \
+  --exec products/jidoka/bin/jidoka.js \
+  --golden-dir products/jidoka/test/golden/jidoka
+```
+
+`cases.json` args are name-independent and stay as captured (help, version,
+three subcommand helps — 10 snapshot files). The capture script itself names
+no CLI and needs no edit.
+
+**Verify:** `git diff --stat products/jidoka/test/golden/jidoka` shows every
+`.txt` regenerated; no `coaligned` token remains in the snapshots
+(`rg -n coaligned products/jidoka/test`); re-running the capture command
+produces no further diff.
+
+## Step 1.9 — Part gate
+
+Blanket-check the part's three families across the tree, excluding the
+surfaces later parts own:
+
+```sh
+rg -n -i --hidden --no-ignore 'libcoaligned|\.coaligned' \
+  --glob '!.git/**' --glob '!node_modules/**' --glob '!specs/**' \
+  --glob '!wiki/**' --glob '!**/CHANGELOG.md' --glob '!bun.lock' \
+  --glob '!.claude/skills/**' --glob '!benchmarks/**' --glob '!websites/**' \
+  --glob '!references/**' --glob '!COALIGNED.md'
+```
+
+Inspect every returned line — the expected result is empty
+(`CONTRIBUTING.md` and `MONOREPO.md` path references were updated in Steps
+1.4/1.7; the excluded globs are Part 2/3 surfaces — skills, benchmarks,
+websites, living templates, and the standard). Then `bun install`
+(regenerates `bun.lock`), `bun run context:fix`, `bun run check`, `bun run
+test` green.

--- a/specs/2260-jidoka-product-reframe/plan-a-01.md
+++ b/specs/2260-jidoka-product-reframe/plan-a-01.md
@@ -3,7 +3,9 @@
 One part because the `public-cli-set` invariant and the workspace couple the
 bin, the launcher set, and the invariant rules: any split leaves a bin
 without its package or a scanner without its prefix and fails CI. Sub-steps
-are verification units, not commit boundaries.
+are verification units, not commit boundaries — and Steps 1.1–1.3 form one
+unit: the package resolves and the bin runs only after the library rename
+lands, so run their verify lines once Step 1.3 completes.
 
 ## Step 1.1 — Scaffold `products/jidoka/package.json`
 
@@ -46,6 +48,7 @@ no `src/`, no hand-authored `README.md` (Gear/Gemba precedent).
   "type": "module",
   "bin": { "jidoka": "./bin/jidoka.js" },
   "files": ["bin/**/*.js"],
+  "scripts": { "test": "bun test test/*.test.js" },
   "dependencies": {
     "@forwardimpact/libinvariant": "^0.2.0",
     "@forwardimpact/libcli": "^0.1.17",
@@ -59,8 +62,9 @@ no `src/`, no hand-authored `README.md` (Gear/Gemba precedent).
 
 Version `0.2.0` seeds above the renamed pack sibling's retained `v0.1.x` tag
 floor (design § Components). Dependency ranges track the workspace at
-implementation time; the four packages are exactly what the bin imports. No
-`scripts.test` — the moved goldens (Step 1.8) have no runner test.
+implementation time; the four packages are exactly what the bin imports, and
+the `libinvariant ^0.2.0` range resolves against the version Step 1.3 seeds.
+`scripts.test` runs the golden replay test Step 1.8 wires.
 
 **Verify:** `bun install` resolves; `bun run context:check-jtbd` passes the
 new jobs entry (run `bun run context:fix` first to regenerate `JTBD.md`).
@@ -106,12 +110,13 @@ products/jidoka/bin/jidoka.js invariants` passes against the Step 1.4 tree.
 
 | File | Change |
 | --- | --- |
-| `package.json` | `name` → `@forwardimpact/libinvariant`; `description` → "Repository invariant checks — instruction-layer length caps, JTBD block validation, and a declarative rule-module runner over a caller-supplied rules directory."; `keywords` swap `coaligned` → `invariants` family tokens; `repository.directory` → `libraries/libinvariant`; delete the `bin` field and the `./bin/coaligned.js` export (root export `.` → `./src/index.js` stays); drop `bin/**/*.js` from `files`. The `jobs` entry keeps its goal; name tokens only. |
+| `package.json` | `name` → `@forwardimpact/libinvariant`; `version` → `0.2.0` (0.x minor over 0.1.18 signals the breaking rename and matches the Step 4.1 tag — the product's `^0.2.0` range resolves in-workspace); `description` → "Repository invariant checks — instruction-layer length caps, JTBD block validation, and a declarative rule-module runner over a caller-supplied rules directory."; `keywords` swap `coaligned` → `invariants` family tokens; `repository.directory` → `libraries/libinvariant`; delete the `bin` field and the `./bin/coaligned.js` export (root export `.` → `./src/index.js` stays); drop `bin/**/*.js` from `files`. The `jobs` entry keeps its goal; name tokens only. |
 | `src/index.js` | Drop the `INVARIANTS_DIR` re-export; other exports unchanged. |
 | `src/invariants.js` | Delete `export const INVARIANTS_DIR`; `findInvariantsRoot(runtime)` → `findInvariantsRoot(runtime, rulesDir)` (required — the one signature change); `loadRuleModules` and `checkInvariants` lose the `rulesDir` default (required option); `runRuleModules` loses the `dir` default (required option); `Bun.plugin` name `coaligned-rule-deps` → `invariant-rule-deps`; JSDoc/comments naming `.coaligned/invariants` → "the caller-supplied rules directory". |
 | `src/instructions.js`, `src/enum-drift.js` | Name tokens in comments/strings only (`rg -n -i coaligned` the two files); behavior untouched. |
 | `README.md` | Rename wholesale: import-only library, no CLI; point "run the checks" readers at the Jidoka product (`npx @forwardimpact/jidoka` or the installed binary). |
-| `test/invariants.test.js`, `test/invariant-kit.test.js` | Pass the now-required `rulesDir`/`dir` explicitly with brand-free fixture paths (e.g. `rules/invariants`); assert `findInvariantsRoot` against the passed directory. Handler and component tests otherwise stay put. |
+| `test/invariants.test.js`, `test/invariant-kit.test.js` | Pass the now-required `rulesDir`/`dir` explicitly with brand-free fixture paths (e.g. `rules/invariants`); assert `findInvariantsRoot` against the passed directory. |
+| `test/enumeration-drift.test.js` | Its live-repo read (L98) repoints to `.jidoka/invariants/enumeration-drift.topics.yml` in lockstep with Step 1.4's `git mv` — the one library test wired to the real config directory. Handler and component tests otherwise stay put. |
 
 **Verify:** `test ! -d libraries/libcoaligned`; `rg -n '"bin"'
 libraries/libinvariant/package.json` returns nothing;
@@ -125,7 +130,7 @@ self-referential tokens inside them — inventory of the non-mechanical edits:
 
 | File | Change |
 | --- | --- |
-| `public-cli-set.rules.mjs` | `PUBLISHED_NON_FIT_CLIS` → `[]` — the launcher retires with no successor (spec SC11); keep the escape hatch with a comment describing when a non-`fit`/`gemba` public CLI would be named. Header and L51-56 comments drop the `coaligned` example. |
+| `public-cli-set.rules.mjs` | `PUBLISHED_NON_FIT_CLIS` → `[]` — the launcher retires with no successor (spec SC11); keep the escape hatch with a comment describing when a non-`fit`/`gemba` public CLI would be named. Header and L51-56 comments drop the `coaligned` example. The `SIBLING_ACTION_CLIS` comment records the deliberate exclusion: the published `jidoka` action invokes the `jidoka` CLI, yet the name stays out of both lists — listing it would compute a launcher the squatted bare npm name forbids. |
 | `skill-genericity.rules.mjs` | npx pattern → `"\\bnpx (fit-|gemba-|jidoka|kata-)"`; website pattern → `"websites/(fit|kata|jidoka|monorepo)\\b"`; out-of-scope comment `coaligned-*` → `jidoka-*`; hint paths → `.jidoka/invariants/…`. |
 | `skill-template.rules.mjs` | `PACK_SKILL` → `(kata\|jidoka\|monorepo)`; both `coaligned-*` globs → `jidoka-*`; `NPX_PATTERNS` becomes two patterns — `"\\bnpx (fit-\|kata-)"` (unchanged reason) and `"\\b(npx\|bunx) jidoka\\b"` with reason "resolves the squatted third-party jidoka package — invoke the installed binary bare, or npx @forwardimpact/jidoka"; drop the `!**/check-workflows.md` exclusion and its header paragraph (the CI templates switch to the scoped form, Step 3.3, which matches neither pattern). |
 | `enumeration-drift.topics.yml`, `ambient-deps.{rules.mjs,allow.yml,deny.yml}`, `shared-workspace-staging.rules.mjs`, `subprocess-in-tests.rules.mjs`, `temporal.rules.mjs`, `model-defaults.rules.mjs`, `enumeration-drift.rules.mjs`, `skill-template.rules.mjs` hints | Mechanical: `.coaligned/invariants/…` paths (incl. `temporal.rules.mjs`/`model-defaults.rules.mjs` self-exclude globs and the `model-defaults` `paths` array entry `".coaligned"` → `".jidoka"`), `bunx coaligned invariants --seed …` → `bunx jidoka invariants --seed …`, `libcoaligned` prose → `libinvariant`. |
@@ -164,7 +169,7 @@ and no `jidoka` dir (spec SC11).
 | File | Change |
 | --- | --- |
 | `build/cli-manifest.json` | Entry `"name": "coaligned"` → `"jidoka"`; `targets` and `bundle: "gear"` unchanged (spec SC12). `build-binary.sh` resolves the name against the new `products/jidoka/package.json` bin at build time. |
-| `products/gemba/actions/bootstrap/fit-install.sh` | `DEFAULT_TOOLS` member `coaligned` → `jidoka` (L61); `is_gear_binary` case pattern → `fit-*\|gemba-*\|jidoka` (L127); comment mentions at L11, L42, L57, L64-66, L92, L124-125, L249, L580. `FIT_GEAR_RELEASE` default is **not** bumped here — Step 4.2 owns it; the script only executes via the pinned sibling until then. |
+| `products/gemba/actions/bootstrap/fit-install.sh` | `DEFAULT_TOOLS` member `coaligned` → `jidoka` (L61); `is_gear_binary` case pattern → `fit-*\|gemba-*\|jidoka` (L127); comment mentions at L11, L42, L57, L66, L92, L125, L249, L580. `FIT_GEAR_RELEASE` default is **not** bumped here — Step 4.2 owns it; the script only executes via the pinned sibling until then. |
 | `.github/workflows/publish-npm.yml` | Inline check step: import → `@forwardimpact/libcoaligned` becomes `@forwardimpact/libinvariant`; rules-module path and `dir` → `.jidoka/invariants` (L56/58/62). |
 
 **Verify:** `jq -r '.clis[].name' build/cli-manifest.json` lists `jidoka`
@@ -181,12 +186,12 @@ and no `coaligned`; `bash -n products/gemba/actions/bootstrap/fit-install.sh`.
 
 **Verify:** `bun run invariants`, `bun run context` green.
 
-## Step 1.8 — Golden fixtures
+## Step 1.8 — Golden fixtures and the replay test
 
-`git mv libraries/libcoaligned/test/golden/coaligned
-products/jidoka/test/golden/jidoka` (moves with the Step 1.3 `git mv`;
-relocate from the renamed library), then regenerate all five cases from
-actual output:
+`git mv libraries/libinvariant/test/golden/coaligned
+products/jidoka/test/golden/jidoka` (the golden dir travels into
+`libinvariant` with Step 1.3's rename; this moves it out), then regenerate
+all five cases from actual output:
 
 ```sh
 node scripts/capture-cli-golden.mjs --bin jidoka \
@@ -198,27 +203,37 @@ node scripts/capture-cli-golden.mjs --bin jidoka \
 three subcommand helps — 10 snapshot files). The capture script itself names
 no CLI and needs no edit.
 
+**Created:** `products/jidoka/test/golden.test.js` — the goldens gain an
+automated consumer: for each `cases.json` entry, spawn the bin with the
+case's args, apply its `transform` regexes, and byte-compare stdout/stderr
+and exit code against the snapshots. Spawn-based (unlike
+`products/gemba/test/golden.test.js`'s in-process replay) because the
+jidoka definition lives inline in the bin, not behind a library export.
+
 **Verify:** `git diff --stat products/jidoka/test/golden/jidoka` shows every
 `.txt` regenerated; no `coaligned` token remains in the snapshots
-(`rg -n coaligned products/jidoka/test`); re-running the capture command
-produces no further diff.
+(`rg -n coaligned products/jidoka/test`); `bun test products/jidoka` green;
+re-running the capture command produces no further diff.
 
 ## Step 1.9 — Part gate
 
-Blanket-check the part's three families across the tree, excluding the
-surfaces later parts own:
+First `bun install` (regenerates `bun.lock` for the renamed workspace) and
+`bun run context:fix` (regenerates the `libraries/README.md` catalog and
+jobs blocks, whose `libcoaligned` tokens flip to `libinvariant` from the
+renamed package). Then blanket-check the part's two families across the
+tree, excluding the surfaces later parts own:
 
 ```sh
 rg -n -i --hidden --no-ignore 'libcoaligned|\.coaligned' \
   --glob '!.git/**' --glob '!node_modules/**' --glob '!specs/**' \
   --glob '!wiki/**' --glob '!**/CHANGELOG.md' --glob '!bun.lock' \
   --glob '!.claude/skills/**' --glob '!benchmarks/**' --glob '!websites/**' \
-  --glob '!references/**' --glob '!COALIGNED.md'
+  --glob '!references/**' --glob '!/COALIGNED.md' \
+  --glob '!/.github/workflows/publish-skills.yml'
 ```
 
 Inspect every returned line — the expected result is empty
 (`CONTRIBUTING.md` and `MONOREPO.md` path references were updated in Steps
 1.4/1.7; the excluded globs are Part 2/3 surfaces — skills, benchmarks,
-websites, living templates, and the standard). Then `bun install`
-(regenerates `bun.lock`), `bun run context:fix`, `bun run check`, `bun run
-test` green.
+websites, living templates, the standard, and the pack leg's `version-file`
+lines that Step 3.4 owns). Then `bun run check` and `bun run test` green.

--- a/specs/2260-jidoka-product-reframe/plan-a-02.md
+++ b/specs/2260-jidoka-product-reframe/plan-a-02.md
@@ -1,0 +1,106 @@
+# Plan 2260-a Part 2: Actions + CI axis — the published action and the eval lane
+
+Depends on Part 1 (the `jidoka` bin the action invokes and the renamed
+config directory the eval hooks grep for).
+
+## Step 2.1 — Move, rename, and document the action
+
+`git mv .github/actions/coaligned-check products/jidoka/actions/jidoka`,
+then edit `action.yml`:
+
+- `name: Jidoka`; description reframed — run the jidoka checks (built-in
+  quality: stop the line at the first drifted layer), referencing
+  `JIDOKA.md`; the bootstrap prerequisite sentence names `jidoka` as the
+  pinned gear binary.
+- The run step and comments invoke bare `jidoka` from PATH; inputs
+  (`command`, `fix`, `working-directory`) and dispatch logic unchanged.
+
+**Created:** `products/jidoka/actions/jidoka/README.md` — sibling-repo
+usage doc in the `harness`/`kata-agent` shape: what the action does, the
+bootstrap prerequisite (`forwardimpact/bootstrap@v1` installs `jidoka` as a
+default tool), a `uses: forwardimpact/jidoka@v1` YAML example with the three
+inputs, and the migration pointer for `coaligned-check` adopters.
+
+**Verify:** `test ! -d .github/actions/coaligned-check`;
+`products/jidoka/actions/jidoka/action.yml` parses (`bunx js-yaml` or CI).
+
+## Step 2.2 — Repoint internal consumers
+
+**Modified:** `.github/workflows/check-context.yml` — the three
+`uses: ./.github/actions/coaligned-check` steps (`instructions`, `jtbd`,
+`invariants` jobs) → `./products/jidoka/actions/jidoka`; `command:` inputs
+unchanged.
+
+**Verify:** `rg -n 'coaligned-check' .github/` returns nothing.
+
+## Step 2.3 — Publish the action
+
+**Modified:** `.github/workflows/publish-actions.yml`:
+
+- `on.push.paths` gains `"products/jidoka/actions/jidoka/**"`.
+- Matrix gains `- prefix: products/jidoka/actions/jidoka` / `repo: jidoka`.
+- Header comment: "six co-located composite actions … four agent-run … two
+  Kata" → seven, adding the Jidoka product's one.
+
+The addition is additive — no existing `prefix:`/`repo:` pair changes
+(design § Interfaces). The `forwardimpact/jidoka` sibling must exist before
+this merges: Step 4.0.
+
+**Verify:** matrix parses; the diff touches no existing leg.
+
+## Step 2.4 — `.github/CLAUDE.md` and the sibling enum
+
+**Modified:** `.github/CLAUDE.md`, `CLAUDE.md`, `KATA.md`.
+
+- `.github/CLAUDE.md` § Third-party actions table gains the row
+  `[jidoka](https://github.com/forwardimpact/jidoka) | Jidoka checks
+  (instructions, jtbd, invariants) — stop the line on instruction drift`;
+  the intro sentence's count and homes update ("under
+  `products/{gemba,jidoka,kata}/actions/`"). § Local composite actions
+  table drops the `coaligned-check` row.
+- `KATA.md` L44 local-actions sentence drops `coaligned-check/` (only
+  `audit/` remains).
+- Refresh the three `sibling-composite-actions` enum fences (source of
+  truth is the table just edited): `bunx jidoka invariants --seed
+  enumeration-drift` prints the canonical bodies; update the `CLAUDE.md`
+  list fence, the `KATA.md` count+list fences, and the `.github/CLAUDE.md`
+  count fence to match.
+
+**Verify:** `bun run invariants` green (enumeration-drift agrees across the
+four consumers).
+
+## Step 2.5 — Rename the eval lane
+
+`git mv .github/workflows/eval-coaligned.yml .github/workflows/eval-jidoka.yml`
+and `git mv benchmarks/coaligned-skills benchmarks/jidoka-skills`, then:
+
+| File | Change |
+| --- | --- |
+| `eval-jidoka.yml` | `name: "Eval: Jidoka"`; concurrency group `eval-jidoka-…`; comment "coaligned-skills family" → jidoka; `family: ./benchmarks/jidoka-skills`. The SHA-pinned `forwardimpact/benchmark` reusable-workflow `uses:` is untouched. |
+| `apm.yml` | `name: jidoka-skills-benchmark`; dependency `forwardimpact/jidoka-skills` (spec SC14). |
+| `README.md` | Title, pack name, skill names (`jidoka-setup`, `jidoka-jtbd`), workflow name, `--family=benchmarks/jidoka-skills`, `.jidoka/invariants/` table cell, "`jidoka-*` skill" prose. |
+| `judge.md` | Family name in frontmatter description and body. |
+| `tasks/author-job/{agent.task.md,hooks/preflight.sh}` | Skill name `jidoka-jtbd`; `test -d "$AGENT_CWD/.claude/skills/jidoka-jtbd"`. |
+| `tasks/bootstrap-repo/{agent.task.md,hooks/preflight.sh}` | Skill name `jidoka-setup`; `test -d …/jidoka-setup`. |
+| `tasks/bootstrap-repo/hooks/invariants.sh` | `STARTER` path → `.jidoka/invariants/no-conflict-markers.rules.mjs`; the CONTRIBUTING grep → `'jidoka invariants\|\.jidoka/invariants'`; comment tokens. |
+| `tasks/bootstrap-repo/workdir/package.json` | `repository.directory` → `benchmarks/jidoka-skills/tasks/bootstrap-repo/workdir` (workdir fixtures then carry no `coaligned` token — SC14). |
+| `benchmarks/README.md` | Families row → `[jidoka-skills/](jidoka-skills/) | forwardimpact/jidoka-skills | eval-jidoka.yml`. |
+
+The pass@k series restarts under the new family name (design § Key
+Decisions); no ledger migration.
+
+**Verify:**
+`rg -n -i --hidden --no-ignore coaligned benchmarks/ .github/workflows/eval-jidoka.yml`
+returns nothing; `test ! -e .github/workflows/eval-coaligned.yml`.
+
+## Step 2.6 — Part gate
+
+`bun run context:fix`, `bun run check`, `bun run test` green. Then the
+part-scoped sweep:
+
+```sh
+rg -n -i --hidden --no-ignore coaligned .github/ benchmarks/ products/jidoka/
+```
+
+Expected: only `publish-skills.yml` lines (Part 3 owns the pack leg) and
+`website-coaligned.yaml`/`website.yml` (Part 3 owns the site).

--- a/specs/2260-jidoka-product-reframe/plan-a-02.md
+++ b/specs/2260-jidoka-product-reframe/plan-a-02.md
@@ -19,7 +19,9 @@ then edit `action.yml`:
 usage doc in the `harness`/`kata-agent` shape: what the action does, the
 bootstrap prerequisite (`forwardimpact/bootstrap@v1` installs `jidoka` as a
 default tool), a `uses: forwardimpact/jidoka@v1` YAML example with the three
-inputs, and the migration pointer for `coaligned-check` adopters.
+inputs, and a pointer for adopters of the predecessor check action —
+phrased without the old name, linking the `JIDOKA.md` migration note, so
+the rename gates (Steps 2.6, 3.6, spec SC5) stay clean.
 
 **Verify:** `test ! -d .github/actions/coaligned-check`;
 `products/jidoka/actions/jidoka/action.yml` parses (`bunx js-yaml` or CI).
@@ -60,11 +62,11 @@ this merges: Step 4.0.
   table drops the `coaligned-check` row.
 - `KATA.md` L44 local-actions sentence drops `coaligned-check/` (only
   `audit/` remains).
-- Refresh the three `sibling-composite-actions` enum fences (source of
+- Refresh the four `sibling-composite-actions` enum fences (source of
   truth is the table just edited): `bunx jidoka invariants --seed
   enumeration-drift` prints the canonical bodies; update the `CLAUDE.md`
-  list fence, the `KATA.md` count+list fences, and the `.github/CLAUDE.md`
-  count fence to match.
+  list fence, the `KATA.md` count and list fences, and the
+  `.github/CLAUDE.md` count fence to match.
 
 **Verify:** `bun run invariants` green (enumeration-drift agrees across the
 four consumers).

--- a/specs/2260-jidoka-product-reframe/plan-a-03.md
+++ b/specs/2260-jidoka-product-reframe/plan-a-03.md
@@ -1,0 +1,146 @@
+# Plan 2260-a Part 3: Brand surfaces — standard, website, skills, pack, catalogs
+
+Depends on Parts 1–2 (the `jidoka` bin the skills invoke, the renamed rules
+the skill-family scanners enforce, the product package that versions the
+pack).
+
+## Step 3.1 — Rebrand the standard
+
+`git mv COALIGNED.md JIDOKA.md`, rewritten framing: same eight layers, layer
+rules, and length caps; the identity section grounds the architecture in
+jidoka (built-in quality, stop the line, never pass a defect downstream)
+alongside the existing JTBD and Checklist Manifesto groundings; the title
+becomes "Jidoka Instruction Architecture". Add the downstream migration
+note — one short section: `git mv .coaligned .jidoka`, reinstall the pack
+(`apm install forwardimpact/jidoka-skills`), swap the CLI name; an
+unmigrated repo fails loudly with the loader's `rules directory not found`
+error naming the expected location.
+
+Reference repoints in the same commit:
+
+| File | Change |
+| --- | --- |
+| `.rgignore` | `COALIGNED.md` → `JIDOKA.md` (the fixture-safety shield follows the file). |
+| `MONOREPO.md` | L12/109/121/127 links and "Co-Aligned" prose → Jidoka forms. |
+| `CONTRIBUTING.md` | L31 skill link → `jidoka-invariant`; any remaining standard-name prose. |
+| `KATA.md` | L19/357 `COALIGNED.md` links → `JIDOKA.md`. |
+| `.claude/skills/CLAUDE.md` | "COALIGNED.md § Length" → JIDOKA.md; the bare-CLI exception list `coaligned` → `jidoka`; the two rule-module paths → `.jidoka/invariants/…`. |
+| `libraries/libharness/src/{facilitator,discusser,discuss-tools,supervisor,profile-prompt}.js` | Doc-comment references "COALIGNED.md § L0" etc. → JIDOKA.md (7 lines). |
+| `libraries/libharness/test/prompts.test.js` | The 8 `describe("COALIGNED L0 — …")` labels → `JIDOKA L0 — …` (labels only; assertions untouched). |
+
+**Verify:** `test ! -e COALIGNED.md`; `rg -n -i --hidden --no-ignore
+'COALIGNED' --glob '!.git/**' --glob '!node_modules/**' --glob '!specs/**'
+--glob '!wiki/**' --glob '!**/CHANGELOG.md'` returns only the JIDOKA.md
+migration note (spec SC9).
+
+## Step 3.2 — Rename and reframe the website
+
+`git mv websites/coaligned websites/jidoka` and
+`git mv .github/workflows/website-coaligned.yaml .github/workflows/website-jidoka.yaml`,
+then:
+
+| File | Change |
+| --- | --- |
+| `websites/jidoka/CNAME` | `www.jidoka.team` (spec SC10). |
+| `robots.txt` | Sitemap URL → `https://www.jidoka.team/sitemap.xml`. |
+| `llms.txt` | Rewrite: `# Jidoka`, the Toyota-concept story (same layer facts), install line → `apm install forwardimpact/jidoka-skills`, wire-in line → the installed `jidoka` binary or `npx @forwardimpact/jidoka`, standard link → JIDOKA.md. |
+| `index.md` | Frontmatter title "Jidoka Instruction Architecture"; hero/story reframed to built-in quality with the same layer-stack visual language; CSS classes `coaligned-*` → `jidoka-*`; terminal snippet → `apm install forwardimpact/jidoka-skills` + scoped/bare CLI forms. |
+| `index.template.html` | `<title>`, brand spans → Jidoka; both GitHub links → `forwardimpact/jidoka-skills`. |
+| `assets/main.css` | Header comment and the `.coaligned-{section,hero,section-cool}` selectors → `jidoka-*` — same commit as `index.md` (coupled pair). |
+| `website-jidoka.yaml` | `name: "Website: Jidoka Standard"`; paths → `websites/jidoka/**` + self-path; `site: jidoka`. |
+| `.github/workflows/website.yml` | Input description site list → `(fit, monorepo, kata, jidoka)`. |
+| `websites/CLAUDE.md` | Row → `Jidoka \| websites/jidoka/ \| www.jidoka.team`; serve example `--src=websites/jidoka`. |
+
+Other-site brand references: `websites/README.md` L136 (`libcoaligned` →
+`libinvariant`), `websites/fit/index.template.html` L95 and
+`websites/fit/meta/index.md` L26 (footer/meta links → `jidoka.team`),
+`websites/fit/docs/internals/release/index.md` L123 (CLI inventory →
+`jidoka`), `websites/fit/docs/libraries/service-lifecycle/index.md`
+L379-380, `websites/monorepo/index.md` L185/189,
+`websites/monorepo/index.template.html` L54, `websites/monorepo/llms.txt`
+L26/32 (install line, brand prose, domain).
+
+**Verify:** `bunx fit-doc build --src=websites/jidoka` succeeds;
+`rg -n -i coaligned websites/` returns nothing.
+
+## Step 3.3 — Rename and reframe the five skills
+
+`git mv` each of `.claude/skills/coaligned-{setup,audit,invariant,jtbd,layer}`
+→ `.claude/skills/jidoka-*`, then per skill: frontmatter `name` → the new
+id, `description` reframed to Jidoka vocabulary (what stays: the
+trigger-condition structure); body prose swaps "Co-Aligned" → "Jidoka
+instruction architecture"; CLI invocations stay **bare** (`jidoka`,
+`jidoka instructions`, `jidoka jtbd --fix`, `jidoka invariants --seed …`);
+asset paths self-update (`.claude/skills/jidoka-setup/assets/…`); the
+`## Documentation` lists carry the same two entries as the bin's
+`documentation` array (Step 1.2): the JIDOKA.md standard and the
+`libinvariant` README URLs.
+
+Cross-reference inventory (all in the same commit):
+
+| Surface | Change |
+| --- | --- |
+| Intra-pack links | setup → {layer, jtbd, invariant, audit}; audit → {layer, jtbd}; layer → {setup}; `structure-decision.md` uses `../../jidoka-jtbd/…`. |
+| `jidoka-setup` assets | `jobs-and-checklists.md` L6 CLI prose; `no-conflict-markers.rules.mjs` L5 skill-name comment. Step 4 wiring prose: the published CLI package is `@forwardimpact/jidoka`. |
+| `.claude/skills/monorepo-setup/SKILL.md` | Every `coaligned-setup` → `jidoka-setup` (9 sites); L83 → `apm install forwardimpact/jidoka-skills forwardimpact/kata-skills --target claude`; L148 brand link → `https://www.jidoka.team/`; L46/112 `.coaligned/` → `.jidoka/`. |
+| `monorepo-setup/references/check-workflows.md` | Generated CI templates: `npx coaligned <sub>` → `npx @forwardimpact/jidoka <sub>` (clean runners resolve from the registry; the bare name is squatted — plan-a.md § invocation rule); prose skill names. |
+| `monorepo-setup/references/repo-skeleton.md` | devDependency → `"@forwardimpact/jidoka": "^0.2.0"`; `"check": "jidoka"`; resolution prose (the bin comes from the product package). |
+| `monorepo-setup/references/wiki-init.md` | L6/57 skill names. |
+| `references/bionova-apps/{spec.md,plan-a.md,plan-a-01.md}` | Living templates: `coaligned-setup` → `jidoka-setup`, `coaligned-skills` → `jidoka-skills`, `.coaligned/` → `.jidoka/`, CLI tokens (16 lines per the sweep). |
+
+**Verify:** `ls .claude/skills/ | rg coaligned` empty (spec SC8);
+`bun run invariants` green — `skill-template` and `skill-genericity` now
+scan the `jidoka-*` dirs via the Part 1 regex flips, and no
+`npx jidoka`/`bunx jidoka` token exists anywhere in `.claude/skills/`.
+
+## Step 3.4 — Repoint the skill pack
+
+**Modified:** `.github/workflows/publish-skills.yml`:
+
+- Path filters: `.claude/skills/coaligned-*/**` → `jidoka-*/**`;
+  `libraries/libcoaligned/package.json` → `products/jidoka/package.json`.
+- The leg: `prefix: jidoka`, `repo: jidoka-skills`,
+  `version-file: products/jidoka/package.json`, `readme-title: Jidoka
+  Skills`, `readme-intro` reframed (Jidoka instruction architecture, the
+  `jidoka` CLI, JIDOKA.md link) **carrying the one-line migration pointer**
+  (renamed from `coaligned-skills`; `git mv .coaligned .jidoka`, swap the
+  CLI), `apm-description` reframed.
+
+The sibling repo rename itself is Step 4.0, pre-merge.
+
+**Verify:** `rg -n coaligned .github/workflows/publish-skills.yml` empty.
+
+## Step 3.5 — Product framing, catalogs, and counts
+
+- `CLAUDE.md`: § Secondary Products — the "Co-Aligned Instructions
+  Standard" entry becomes **Jidoka — `jidoka-skills`** ("Built-in quality
+  for agent instructions: the check suite that stops the line when an
+  instruction layer drifts. [JIDOKA.md](JIDOKA.md)"); § Distribution Model
+  pack list → `forwardimpact/{fit-skills,kata-skills,jidoka-skills}`.
+- Run `bun run context:fix`: regenerates `JTBD.md` (the Jidoka Big Hire
+  appears under Teams Using Agents), the `products/README.md` catalog row,
+  and the `libraries/README.md` catalog/jobs rows (`libinvariant`).
+- Hand edits: `products/README.md` intro count sentence (reconcile the
+  existing "eight products" against the now-ten catalog rows before writing
+  the new number — the sentence lagged 2250); `libraries/README.md` L280/287
+  hand-maintained lists (`libcoaligned` → `libinvariant`) if `context:fix`
+  does not own them.
+
+**Verify:** `bun run context:fix` produces no further diff; `bun run check`
+green (spec SC13/SC15).
+
+## Step 3.6 — Final rename gate (spec SC5)
+
+```sh
+rg --hidden --no-ignore -n -i coaligned \
+  --glob '!.git/**' --glob '!node_modules/**' --glob '!specs/**' \
+  --glob '!wiki/**' --glob '!**/CHANGELOG.md' --glob '!bun.lock'
+```
+
+Inspect every returned line. Allowed remainders: the migration note in
+`JIDOKA.md` and the pack `readme-intro` in `publish-skills.yml` — nothing
+else (the workflow-pin remainder class the spec reserves is empty: no
+`clis:` list or pin line carries the token). Then `bun run context:fix`,
+`bun run check`, and `bun run test` green — final gate for the PR. Confirm
+the diff touches neither deferred decision (no DNS config, no bare-name
+launcher — spec SC17).

--- a/specs/2260-jidoka-product-reframe/plan-a-03.md
+++ b/specs/2260-jidoka-product-reframe/plan-a-03.md
@@ -72,9 +72,10 @@ trigger-condition structure); body prose swaps "Co-Aligned" → "Jidoka
 instruction architecture"; CLI invocations stay **bare** (`jidoka`,
 `jidoka instructions`, `jidoka jtbd --fix`, `jidoka invariants --seed …`);
 asset paths self-update (`.claude/skills/jidoka-setup/assets/…`); the
-`## Documentation` lists carry the same two entries as the bin's
-`documentation` array (Step 1.2): the JIDOKA.md standard and the
-`libinvariant` README URLs.
+`## Documentation` lists carry the same two entries, same order, as the
+bin's `documentation` array (Step 1.2): the JIDOKA.md standard and the
+Jidoka website — replacing the current standard + `libcoaligned`-README
+pair (the parity rule, `.claude/skills/CLAUDE.md` § Parity with CLIs).
 
 Cross-reference inventory (all in the same commit):
 
@@ -82,11 +83,11 @@ Cross-reference inventory (all in the same commit):
 | --- | --- |
 | Intra-pack links | setup → {layer, jtbd, invariant, audit}; audit → {layer, jtbd}; layer → {setup}; `structure-decision.md` uses `../../jidoka-jtbd/…`. |
 | `jidoka-setup` assets | `jobs-and-checklists.md` L6 CLI prose; `no-conflict-markers.rules.mjs` L5 skill-name comment. Step 4 wiring prose: the published CLI package is `@forwardimpact/jidoka`. |
-| `.claude/skills/monorepo-setup/SKILL.md` | Every `coaligned-setup` → `jidoka-setup` (9 sites); L83 → `apm install forwardimpact/jidoka-skills forwardimpact/kata-skills --target claude`; L148 brand link → `https://www.jidoka.team/`; L46/112 `.coaligned/` → `.jidoka/`. |
+| `.claude/skills/monorepo-setup/SKILL.md` | Every `coaligned-setup` → `jidoka-setup` (10 sites); L83 → `apm install forwardimpact/jidoka-skills forwardimpact/kata-skills --target claude`; L148 brand link → `https://www.jidoka.team/`; L46/112 `.coaligned/` → `.jidoka/`. **Semantic rewrite at L74-77** — the token codemod would produce a false claim there: the passage becomes "the `jidoka` bin ships in the product package `@forwardimpact/jidoka` (no bare launcher), so add it as a devDependency" with the version parenthetical → `0.2.0+`; no `rg` gate can catch this one, so it is named here. |
 | `monorepo-setup/references/check-workflows.md` | Generated CI templates: `npx coaligned <sub>` → `npx @forwardimpact/jidoka <sub>` (clean runners resolve from the registry; the bare name is squatted — plan-a.md § invocation rule); prose skill names. |
 | `monorepo-setup/references/repo-skeleton.md` | devDependency → `"@forwardimpact/jidoka": "^0.2.0"`; `"check": "jidoka"`; resolution prose (the bin comes from the product package). |
 | `monorepo-setup/references/wiki-init.md` | L6/57 skill names. |
-| `references/bionova-apps/{spec.md,plan-a.md,plan-a-01.md}` | Living templates: `coaligned-setup` → `jidoka-setup`, `coaligned-skills` → `jidoka-skills`, `.coaligned/` → `.jidoka/`, CLI tokens (16 lines per the sweep). |
+| `references/bionova-apps/{spec.md,plan-a.md,plan-a-01.md}` | Living templates: `coaligned-setup` → `jidoka-setup`, `coaligned-skills` → `jidoka-skills`, `.coaligned/` → `.jidoka/`, CLI tokens (14 lines per the sweep). |
 
 **Verify:** `ls .claude/skills/ | rg coaligned` empty (spec SC8);
 `bun run invariants` green — `skill-template` and `skill-genericity` now
@@ -140,7 +141,11 @@ rg --hidden --no-ignore -n -i coaligned \
 Inspect every returned line. Allowed remainders: the migration note in
 `JIDOKA.md` and the pack `readme-intro` in `publish-skills.yml` — nothing
 else (the workflow-pin remainder class the spec reserves is empty: no
-`clis:` list or pin line carries the token). Then `bun run context:fix`,
+`clis:` list or pin line carries the token; the action README's migration
+pointer is phrased without the old name — Step 2.1). The `!bun.lock` glob
+is a deliberate addition over SC5's pinned command: Step 1.9's `bun
+install` already regenerated the lock, and the glob only guards a stale
+interim run. Then `bun run context:fix`,
 `bun run check`, and `bun run test` green — final gate for the PR. Confirm
 the diff touches neither deferred decision (no DNS config, no bare-name
 launcher — spec SC17).

--- a/specs/2260-jidoka-product-reframe/plan-a-04.md
+++ b/specs/2260-jidoka-product-reframe/plan-a-04.md
@@ -1,0 +1,100 @@
+# Plan 2260-a Part 4: Release train — sibling ops, cuts, repin, cutover
+
+Executor `release-engineer`, following `kata-release-cut` for every cut.
+Step 4.0 runs **before** the Parts 1–3 PR merges; everything else runs
+immediately after, same-day (plan-a.md § Risks: the window between merge
+and Step 4.3 breaks `jidoka`-invoking CI jobs on PATH lookup). Assumes spec
+2250's train is complete — the installer and pins being flipped are the
+post-2250 ones.
+
+## Step 4.0 — Sibling repository operations (pre-merge)
+
+In the authenticated `gh` environment:
+
+1. Rename the GitHub repository `forwardimpact/coaligned-skills` →
+   `forwardimpact/jidoka-skills` (GitHub's redirect keeps the old name
+   serving; retained `v0.1.x` tags stay — the product version seeds above
+   them). Update the repo description to the Jidoka framing.
+2. Create `forwardimpact/jidoka` (empty, default branch `main`) for the
+   action subtree split, description matching the action README.
+
+Only then merge the monorepo PR — the merge push fires `publish-skills.yml`
+and `publish-actions.yml` against these names.
+
+**Verify:** both repos resolve; after the merge, the `jidoka-skills` pack
+publish (tag `v0.2.0`) and the `jidoka` action split both run green.
+
+## Step 4.1 — npm release cuts, in dependency order
+
+| Order | Tag                  | What ships                                                                                                                                                            | Bump rationale                                                       |
+| ----- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| 1     | `libinvariant@v0.2.0` | `@forwardimpact/libinvariant` — first cut under the new name; no `bin`, no branded discovery default                                                                  | 0.x minor over `libcoaligned` 0.1.18 signals the breaking rename     |
+| 2     | `jidoka@v0.2.0`       | `@forwardimpact/jidoka` — bin + deps only; no launcher accompanies it (`publish-npm.yml` stamps launchers only for computed public CLIs, and `jidoka` is not one) | first release; matches the pack seed above the sibling's tag floor |
+| 3     | `gear@v0.x`           | npm meta-package, plus the same tag fires `publish-binaries.yml`: `jidoka`-named binaries from `cli-manifest.json`, cask/formula regenerated, `fit-install.sh` staged stamped with the new `FIT_GEAR_RELEASE` | 0.x minor — binary set renamed                                      |
+
+`kata-release-cut` owns final version arithmetic; the table records expected
+magnitudes and the ordering constraint (jidoka's dependency must exist on
+the registry before its smoke install; the gear binary build compiles the
+product bin, which resolves only after the merge).
+
+**Verify:** `npm view @forwardimpact/libinvariant version` and
+`npm view @forwardimpact/jidoka version` both `0.2.0`; the gear release
+lists `jidoka-bun-linux-x64` (and sibling targets) assets with `.sha256`
+sidecars (spec SC16).
+
+## Step 4.2 — Bootstrap pin bump (one small PR)
+
+**Modified:** `products/gemba/actions/bootstrap/fit-install.sh` —
+`FIT_GEAR_RELEASE` default → the Step 4.1 gear tag.
+
+Merge; `publish-actions.yml` splits to the sibling `bootstrap` repo; tag the
+sibling release (next `v1.0.x`) per the standing sibling-tag process.
+
+**Verify:** the new bootstrap tag's `fit-install.sh` installs `jidoka` on a
+scratch runner (`jidoka --version` reports 0.2.0).
+
+## Step 4.3 — Repin PR (one PR)
+
+**Modified:** `.github/workflows/*.yml` — every
+`uses: forwardimpact/bootstrap@<SHA>` → the Step 4.2 tag's SHA. No `clis:`
+value names the old binary (Part 1 inventory), so no invocation flips ride
+along. Every pinned SHA must resolve on its sibling (citation integrity).
+
+**Verify:** full CI green on the repin PR — the first run that installs and
+invokes `jidoka` end to end (`check-context.yml`'s three jobs through the
+relocated action). Re-run the plan-a-03 Step 3.6 gate; the remainder set is
+unchanged (migration note + pack intro only).
+
+## Step 4.4 — Deprecate the superseded npm names
+
+Per the standing release process, never unpublishing (spec § Excluded):
+
+```sh
+npm deprecate coaligned "renamed: the Jidoka CLI ships as @forwardimpact/jidoka (npx @forwardimpact/jidoka)"
+npm deprecate @forwardimpact/libcoaligned "renamed to @forwardimpact/libinvariant"
+```
+
+**Verify:** `npm view coaligned` and `npm view @forwardimpact/libcoaligned`
+show the notices.
+
+## Step 4.5 — Website cutover
+
+The merge push already built and published `websites/jidoka/` via
+`website-jidoka.yaml`. Hand the repository owner the deferred items (spec
+§ Deferred decisions): provision `www.jidoka.team` DNS + Pages custom
+domain, and settle the `www.coaligned.team` disposition. The train is
+complete when the new domain serves the reframed site; the old-domain call
+stays the owner's.
+
+**Verify:** `https://www.jidoka.team/` serves the Jidoka page (after owner
+DNS action); no repo change made for the old domain.
+
+## Step 4.6 — Follow-up scope note
+
+Locate the open follow-up issue spec 2250's Part 4 filed for distribution
+and docs placement (gemba CLIs shipping in the `gear` bundle/cask) and
+comment to add the `jidoka` binary to its scope — the same
+one-product's-CLI-in-another's-vehicle condition, per spec § Excluded. File
+nothing new.
+
+**Verify:** the issue carries the comment linking spec 2260 and this plan.

--- a/specs/2260-jidoka-product-reframe/plan-a-04.md
+++ b/specs/2260-jidoka-product-reframe/plan-a-04.md
@@ -9,6 +9,11 @@ post-2250 ones.
 
 ## Step 4.0 — Sibling repository operations (pre-merge)
 
+Pre-flight: confirm spec 2250's train actually completed — its repin PR
+merged and the workflows' `clis:` values install `gemba-*` names (at plan
+time they still read `fit-wiki`/`fit-harness fit-trace fit-wiki`, i.e. the
+2250 train was pending). Do not start this train on a pre-repin tree.
+
 In the authenticated `gh` environment:
 
 1. Rename the GitHub repository `forwardimpact/coaligned-skills` →

--- a/specs/2260-jidoka-product-reframe/plan-a.md
+++ b/specs/2260-jidoka-product-reframe/plan-a.md
@@ -1,0 +1,132 @@
+# Plan 2260-a: Reframe Co-Aligned as the Jidoka product
+
+Executes [design 2260-a](./design-a.md) for [spec 2260](./spec.md).
+
+## Approach
+
+Land the monorepo change as three sequential parts on one branch — Part 1 the
+CLI and library axis (product package, moved bin, `libinvariant` rename with
+the one signature change, `.jidoka/invariants/` move, launcher retirement,
+distribution wiring), Part 2 the actions and CI axis (action move and publish,
+`check-context` repoint, eval-lane rename), Part 3 the brand surfaces
+(`JIDOKA.md`, website, five skills, pack repoint, catalogs and counts) —
+merged as one PR so the clean break is atomic, then run Part 4, the
+release-and-repin chain whose first step (sibling repo operations) executes
+**before** the merge. The rename follows the spec-2110/2250 codemod method:
+blanket replace of the token families with a keep-list, verified by scoped
+`rg` gates, with golden fixtures regenerated from actual CLI output.
+
+Libraries used: none.
+
+## 2250 interaction points, re-verified
+
+Per the design, the shared surfaces are confirmed at their post-2250 homes:
+installer at `products/gemba/actions/bootstrap/fit-install.sh` (`coaligned`
+in `DEFAULT_TOOLS` L61, `is_gear_binary` L127); `public-cli-set.rules.mjs`
+already gemba-aware with `PUBLISHED_NON_FIT_CLIS = ["coaligned"]` (L57);
+the `CLAUDE.md` enum and `.github/CLAUDE.md` table carry six sibling actions
+(source of truth: the `.github/CLAUDE.md` § Third-party actions table, per
+`enumeration-drift.topics.yml`); `publish-actions.yml` carries six legs;
+`publish-skills.yml` carries the `coaligned` leg versioned by
+`libraries/libcoaligned/package.json`.
+
+## Rename map and token-classification rule
+
+| Old token                                   | New token                          |
+| ------------------------------------------- | ---------------------------------- |
+| `coaligned` (CLI, binary, launcher, action) | `jidoka`                           |
+| `@forwardimpact/libcoaligned`, `libcoaligned` | `@forwardimpact/libinvariant`, `libinvariant` |
+| `.coaligned/invariants`                     | `.jidoka/invariants`               |
+| `COALIGNED.md`, "Co-Aligned" brand prose    | `JIDOKA.md`, "Jidoka"              |
+| `coaligned-*` skill dirs and links          | `jidoka-*`                         |
+| `coaligned-skills` (pack, repo, eval family) | `jidoka-skills`                    |
+| `coaligned-check` (composite action)        | `jidoka` at `products/jidoka/actions/jidoka` |
+| `www.coaligned.team`                        | `www.jidoka.team`                  |
+| CSS classes `coaligned-{section,hero,section-cool}` | `jidoka-*` (index.md and main.css move together) |
+
+**Keep** every match in: `specs/**`, `wiki/**`, `**/CHANGELOG.md` historical
+entries, `.git/`, `node_modules/`. `bun.lock` regenerates via `bun install`
+after the workspace rename — never hand-edited. Two post-merge remainders are
+deliberate (spec SC4/SC5): the one-line downstream migration note in
+`JIDOKA.md` and the pack README intro, naming `.coaligned/` and the old
+names; and any workflow surface held for the release train (inventoried:
+none carry the token — no `clis:` list names `coaligned`, and bootstrap pins
+are opaque SHAs — so the expected workflow remainder set is empty).
+
+**Published invocation rule:** the bare installed binary `jidoka`, or
+`npx @forwardimpact/jidoka` where a clean runner needs registry resolution.
+Never bare `npx jidoka`/`bunx jidoka` — that resolves the squatted
+third-party `jidoka` npm package (spec § Deferred decisions).
+
+## Codemod method
+
+Each part blanket-replaces its assigned families across its whole surface;
+the per-step tables are a verified inventory of exemplars and non-obvious
+sites, not an allowlist. The completeness gate is each part's family-scoped
+`rg` verify line — always line-level (`rg -n`, never `-l`), run with
+`--hidden --no-ignore` and explicit `--glob` exclusions: `.rgignore` shields
+`benchmarks/**` and `COALIGNED.md` from normal searches, and this rename
+must reach both, so the gates never rely on it. Golden CLI fixtures are
+regenerated via `scripts/capture-cli-golden.mjs`, never hand-edited. The
+`.coaligned/invariants/` rule modules rename their own self-referential
+tokens (paths, seed commands, skill-family regexes) in lockstep with the
+directory move — a missed regex silently shrinks lint coverage, so Part 1
+asserts the expected scanner behavior after the flip.
+
+## Parts
+
+| Part                        | Scope                                                                                                                                                                                          | Executor         |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| [plan-a-01](./plan-a-01.md) | CLI + library axis: `products/jidoka/` package, moved bin, `libinvariant` rename and signature change, `.jidoka/invariants/` move and rule-module self-edits, launcher retirement, goldens, distribution wiring, root scripts | staff-engineer   |
+| [plan-a-02](./plan-a-02.md) | Actions + CI axis: action move/rename/publish, `check-context.yml` repoint, `.github/CLAUDE.md` + enum refresh, eval lane rename                                                               | staff-engineer   |
+| [plan-a-03](./plan-a-03.md) | Brand surfaces: `JIDOKA.md`, website, five skills + cross-reference codemod, pack repoint, catalogs and counts, final `rg` gate                                                                | staff-engineer   |
+| [plan-a-04](./plan-a-04.md) | Release train: sibling ops (pre-merge), npm cuts, gear release, bootstrap re-tag, repin PR, deprecations, website cutover, follow-up scope note                                                | release-engineer |
+
+## Execution
+
+Parts 1–3 are strictly sequential commits on one branch
+(`feat/2260-jidoka-reframe`), merged as **one PR** — the `public-cli-set`,
+`skill-template`, and `skill-genericity` invariants couple the bin, the
+skill dirs, and the scanner prefix lists, so the rename must reach `main`
+atomically. Each part ends with `bun run context:fix`, then `bun run check`
+and `bun run test` green. Part 4's step 4.0 (sibling repo rename + creation)
+runs **before** the PR merges; the remaining steps run immediately after, by
+`release-engineer`, same-day. No parts run in parallel. PR editorial review
+covers the `JIDOKA.md` and website reframes (spec SC9/SC10).
+
+## Risks
+
+- **The rename window.** Between the merge and the Step 4.3 repin, the
+  pinned bootstrap installs the `coaligned` binary while merged surfaces
+  (check-context jobs, the renamed action) invoke `jidoka` — those jobs fail
+  on PATH lookup. Mitigation is ordering, not aliasing: execute Part 4
+  same-day; pause scheduled agent workflows if the window stretches (2250
+  precedent).
+- **Merge-triggered publishes need the siblings first.** The merge push
+  fires `publish-skills.yml` (targeting `jidoka-skills`) and
+  `publish-actions.yml` (targeting `jidoka`). Step 4.0 must complete before
+  the merge or both legs fail; GitHub's rename redirect keeps the old pack
+  name serving in the interim.
+- **Pack version floor.** The renamed `jidoka-skills` sibling retains its
+  `v0.1.x` tags and the pack publisher skips existing tags — seeding
+  `products/jidoka/package.json` below `0.2.0` would make the first publish
+  a silent no-op.
+- **Silent registry fallback.** A missed `bunx coaligned`/`npx coaligned`
+  resolves the deprecated launcher and runs stale code; a rewritten-but-bare
+  `npx jidoka`/`bunx jidoka` resolves the squatted third-party package. The
+  `rg` gates plus the new skill-lint pattern (Step 1.4) are the guard; run
+  the gates exactly as written.
+- **Scanner prefix lockstep.** `skill-template.rules.mjs` (`PACK_SKILL`,
+  globs), `skill-genericity.rules.mjs` (npx and website patterns), and
+  `public-cli-set.rules.mjs` (`PUBLISHED_NON_FIT_CLIS`) all hardcode the old
+  tokens. Flipping the skill dirs (Part 3) without the Part 1 rule edits —
+  or vice versa across an aborted rebase — silently un-scans the renamed
+  skills; the parts land on one branch precisely so CI sees them together.
+- **Goldens have no automated consumer.** `test/golden/coaligned/` (5 cases,
+  10 snapshot files + `cases.json`) is consumed only by the capture script's
+  conventions; nothing fails CI if regeneration is skipped. Step 1.8 makes
+  regeneration explicit and its verify line diffs the output.
+- **`publish-npm.yml` inline check.** Its build-kit import and rules path
+  flip in Part 1; a tag cut between merge and any missed edit would fail the
+  publish loudly (import error), not silently — acceptable, but keep the
+  edit in the same commit as the directory move.

--- a/specs/2260-jidoka-product-reframe/plan-a.md
+++ b/specs/2260-jidoka-product-reframe/plan-a.md
@@ -16,7 +16,9 @@ release-and-repin chain whose first step (sibling repo operations) executes
 blanket replace of the token families with a keep-list, verified by scoped
 `rg` gates, with golden fixtures regenerated from actual CLI output.
 
-Libraries used: none.
+Libraries used: libinvariant (the renamed library's existing handlers —
+`checkInstructions`, `checkJtbd`, the invariant kit — consumed by the moved
+bin); no new library dependencies.
 
 ## 2250 interaction points, re-verified
 
@@ -91,8 +93,11 @@ skill dirs, and the scanner prefix lists, so the rename must reach `main`
 atomically. Each part ends with `bun run context:fix`, then `bun run check`
 and `bun run test` green. Part 4's step 4.0 (sibling repo rename + creation)
 runs **before** the PR merges; the remaining steps run immediately after, by
-`release-engineer`, same-day. No parts run in parallel. PR editorial review
-covers the `JIDOKA.md` and website reframes (spec SC9/SC10).
+`release-engineer`, same-day. No parts run in parallel. Part 3 stays with
+`staff-engineer` despite its docs weight — its scanner regexes, pack leg,
+and skill dirs must land in lockstep with Parts 1–2 on the one branch; PR
+editorial review covers the `JIDOKA.md` and website reframes (spec
+SC9/SC10).
 
 ## Risks
 
@@ -122,10 +127,10 @@ covers the `JIDOKA.md` and website reframes (spec SC9/SC10).
   tokens. Flipping the skill dirs (Part 3) without the Part 1 rule edits —
   or vice versa across an aborted rebase — silently un-scans the renamed
   skills; the parts land on one branch precisely so CI sees them together.
-- **Goldens have no automated consumer.** `test/golden/coaligned/` (5 cases,
-  10 snapshot files + `cases.json`) is consumed only by the capture script's
-  conventions; nothing fails CI if regeneration is skipped. Step 1.8 makes
-  regeneration explicit and its verify line diffs the output.
+- **Goldens previously had no automated consumer.** `test/golden/coaligned/`
+  (5 cases, 10 snapshot files + `cases.json`) is consumed only by the
+  capture script's conventions today; Step 1.8 regenerates it and wires a
+  spawn-replay test in the product so a stale snapshot fails CI from now on.
 - **`publish-npm.yml` inline check.** Its build-kit import and rules path
   flip in Part 1; a tag cut between merge and any missed edit would fail the
   publish loudly (import error), not silently — acceptable, but keep the


### PR DESCRIPTION
Implementation plan for [spec 2260](https://github.com/forwardimpact/monorepo/blob/main/specs/2260-jidoka-product-reframe/spec.md) executing the approved [design 2260-a](https://github.com/forwardimpact/monorepo/blob/main/specs/2260-jidoka-product-reframe/design-a.md).

## Shape

`plan-a.md` (approach, rename map + keep-list, codemod method, risks) plus four parts:

- **Part 1 — CLI + library axis**: `products/jidoka/` package (seeded 0.2.0 above the pack tag floor), the bin moved from the library with the caller-supplied `.jidoka/invariants` discovery convention, `libcoaligned` → `libinvariant` at 0.2.0 with the one signature change (`findInvariantsRoot` gains a directory parameter; branded defaults removed), the config-dir move with rule-module self-edits, launcher retirement (`PUBLISHED_NON_FIT_CLIS` → `[]`), distribution wiring (cli-manifest, installer, publish-npm), goldens regenerated and wired to a new spawn-replay test.
- **Part 2 — Actions + CI axis**: `coaligned-check` → `products/jidoka/actions/jidoka` with a sibling README, `check-context.yml` repoint, additive `publish-actions.yml` leg (`repo: jidoka`), sibling-enum refresh, eval lane rename (`eval-jidoka.yml`, `benchmarks/jidoka-skills/`).
- **Part 3 — Brand surfaces**: `JIDOKA.md` with the downstream migration note, `websites/jidoka/` at `www.jidoka.team`, the five `jidoka-*` skills plus the full cross-reference codemod (including the `monorepo-setup` L74-77 semantic rewrite the token codemod cannot express), pack leg repoint (product-versioned), catalogs/counts, final SC5 sweep.
- **Part 4 — Release train** (`release-engineer`): step 4.0 sibling ops run **pre-merge** (rename `coaligned-skills` → `jidoka-skills`, create `forwardimpact/jidoka`), then npm cuts (`libinvariant`, `jidoka`, gear), bootstrap re-tag, repin PR, deprecations, website cutover, and a scope note on 2250's distribution follow-up issue.

Parts 1–3 land as one PR (the scanner regexes, pack leg, and skill dirs must reach `main` in lockstep); clean break throughout — no shims, aliases, or successor launcher; old npm names deprecated only.

## Panel

Two panels of three (technical + devex) per the kata-review caller protocol: **0 blockers**. Consensus highs/mediums all addressed on this branch (library version seed, part-gate ordering and exclusions, `enumeration-drift.test.js` live-repo path, skill/bin documentation parity, the monorepo-setup semantic rewrite, action-README pointer phrased without the old token). Singletons addressed or dismissed with recorded rationale in the amendment commit message.

Panel-reviewed SHA: 75874a1 · amendment SHA: ec30113 (dual-SHA coverage per kata-plan § Post-panel coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiD7fUtnNXkoU3EArKCMxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiD7fUtnNXkoU3EArKCMxQ)_