### PR TITLE
chore(release): spec 2250 Part 4 version bumps

### DIFF
--- a/libraries/libharness/package.json
+++ b/libraries/libharness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libharness",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Autonomous agent team harness — coordinate a lead and participant agents in one async session, with eval, benchmark, and trace tooling to prove the changes worked.",
   "keywords": [
     "orchestration",

--- a/libraries/libwiki/package.json
+++ b/libraries/libwiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libwiki",
-  "version": "0.2.35",
+  "version": "0.3.0",
   "description": "Wiki lifecycle for agent teams — persistent memory, declarative integrity audits, and a collision ledger so coordination survives across sessions and parallel work.",
   "keywords": [
     "wiki",
@@ -45,11 +45,11 @@
   "dependencies": {
     "@forwardimpact/libcli": "^0.1.0",
     "@forwardimpact/libconfig": "^0.1.77",
-    "@forwardimpact/libharness": "^2.0.0",
+    "@forwardimpact/libharness": "^3.0.0",
     "@forwardimpact/libpreflight": "^0.1.0",
     "@forwardimpact/libtelemetry": "^0.1.47",
     "@forwardimpact/libutil": "^0.1.0",
-    "@forwardimpact/libxmr": "^2.0.0"
+    "@forwardimpact/libxmr": "^3.0.0"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/libraries/libxmr/package.json
+++ b/libraries/libxmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/libxmr",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "description": "Wheeler/Vacanti XmR control charts — distinguish signal from noise so agent teams act on real changes, not fluctuations.",
   "keywords": [
     "xmr",

--- a/products/gear/package.json
+++ b/products/gear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/gear",
-  "version": "0.1.23",
+  "version": "0.2.0",
   "description": "Shared libraries and services for platform builders and agents — CLIs, retrieval, evaluation, and infrastructure published to npm.",
   "keywords": [
     "agent",

--- a/products/gemba/package.json
+++ b/products/gemba/package.json
@@ -52,9 +52,9 @@
     "test": "bun test test/*.test.js"
   },
   "dependencies": {
-    "@forwardimpact/libharness": "^2.0.0",
-    "@forwardimpact/libwiki": "^0.2.35",
-    "@forwardimpact/libxmr": "^2.2.1",
+    "@forwardimpact/libharness": "^3.0.0",
+    "@forwardimpact/libwiki": "^0.3.0",
+    "@forwardimpact/libxmr": "^3.0.0",
     "@forwardimpact/libcli": "^0.1.17",
     "@forwardimpact/libconfig": "^0.1.85",
     "@forwardimpact/libpreflight": "^0.1.4",


### PR DESCRIPTION
Step 4.1 of [plan 2250-a Part 4](specs/2250-agent-platform-product/plan-a-04.md): version arithmetic for the release chain. libharness and libxmr take majors (bin field and `./bin/*` exports removed — breaking); libwiki takes the 0.x minor signaling the same break and re-ranges onto `^3.0.0`; gemba stays at its first-release 0.1.0 and re-ranges onto the cut versions; gear takes the 0.x minor for the dependency break.

Tags follow after merge via the `Release: Tag` workflow, tier by tier: libharness@v3.0.0 + libxmr@v3.0.0 → libwiki@v0.3.0 → gemba@v0.1.0 → gear@v0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)