### PR TITLE
chore(bootstrap): default FIT_GEAR_RELEASE to gear@v0.2.0 (#2250)

### DIFF
--- a/products/gemba/actions/bootstrap/fit-install.sh
+++ b/products/gemba/actions/bootstrap/fit-install.sh
@@ -68,7 +68,7 @@ DEFAULT_TOOLS=(apm just gh rg gitleaks claude coaligned
 # caller may override via the environment to pin a different release. On Darwin
 # the fit-gear cask supersedes this — the tap versions the gear set there.
 FIT_RELEASE_REPO="${FIT_RELEASE_REPO:-forwardimpact/monorepo}"
-FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.14}"
+FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.2.0}"
 
 # ── tool classification ──────────────────────────────────────────
 # System-package-manager token for the four third-party CLIs a distro packages.


### PR DESCRIPTION
Step 4.2 of [plan 2250-a Part 4](specs/2250-agent-platform-product/plan-a-04.md): the bundled installer's default gear pin moves to `gear@v0.2.0`, the first release shipping the gemba-named binaries. Merging republishes the `bootstrap` sibling via subtree split; the sibling then gets its next `v1.0.x` tag per the standing process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)