### PR TITLE
chore(ci): repin agent-run actions and flip CLI names to gemba (#2250)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - name: Ensure codegen is current
         run: just codegen
       - name: Compile

--- a/.github/workflows/check-context.yml
+++ b/.github/workflows/check-context.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - uses: ./.github/actions/coaligned-check
         with:
           command: instructions
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun run context:check-metadata
 
   jtbd:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - uses: ./.github/actions/coaligned-check
         with:
           command: jtbd
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - uses: ./.github/actions/coaligned-check
         with:
           command: invariants
@@ -66,5 +66,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun run wiki:rules

--- a/.github/workflows/check-data.yml
+++ b/.github/workflows/check-data.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun run data:check-schema
 
   prose:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun run data:check-prose

--- a/.github/workflows/check-quality.yml
+++ b/.github/workflows/check-quality.yml
@@ -14,33 +14,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun run format:js
 
   lint-js:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun run lint:js
 
   format-md:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun run format:md
 
   lint-md:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun run lint:md
 
   jsdoc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun run jsdoc

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
@@ -37,5 +37,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - run: bun scripts/check-dependabot.mjs

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:

--- a/.github/workflows/curate-wiki.yml
+++ b/.github/workflows/curate-wiki.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
         with:
-          clis: fit-wiki
+          clis: gemba-wiki
       - name: Checkout wiki (read-only)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -39,4 +39,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           FIT_GH_REPO: ${{ github.repository }}
-        run: fit-wiki curate
+        run: gemba-wiki curate

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -104,14 +104,14 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team
           app-id: ${{ secrets.KATA_APP_ID }}
           # gemba-harness (the eval run) needs gemba-harness + gemba-trace on PATH;
           # the gemba-wiki push step needs gemba-wiki. All resolve as binaries.
-          clis: fit-harness fit-trace fit-wiki
+          clis: gemba-harness gemba-trace gemba-wiki
 
       - name: Build data pipeline
         shell: bash
@@ -160,7 +160,7 @@ jobs:
         run: echo "dir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Run eval
-        uses: forwardimpact/harness@b7409ad9a1df4ff75eca8fe68041b5384f75bd7e # v1.0.3
+        uses: forwardimpact/harness@f1943c61188049a86436913af157852b70331813 # v1.0.4
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Push wiki changes
         if: always()
-        uses: forwardimpact/wiki@f88ea81402d4d3411baf9ca0a38cafb11dfa7f60 # v1.0.1
+        uses: forwardimpact/wiki@ad0042953508240d061ecfb288ce6990247cbd9d # v1.0.2
         with:
           command: push
           app-id: ${{ secrets.KATA_APP_ID }}

--- a/.github/workflows/eval-wiki.yml
+++ b/.github/workflows/eval-wiki.yml
@@ -17,11 +17,11 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
         with:
           # gemba-benchmark runs the benchmark binary straight off PATH.
-          clis: fit-benchmark
-      - uses: forwardimpact/benchmark@f0ed6cd1bd94ba00a494a19d8c8d858b68cbefd2 # v1.0.4
+          clis: gemba-benchmark
+      - uses: forwardimpact/benchmark@9cf5ddb6f86afa13931bd204addd14e4517aa4a9 # v1.0.6
         with:
           family: ./benchmarks/fit-wiki
           runs: "5"

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -125,7 +125,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team
@@ -133,7 +133,7 @@ jobs:
           # gemba-harness (the Assess and Act step), the cost/callback steps, and
           # the gemba-wiki push step all run their binaries straight off PATH —
           # no bunx fallback.
-          clis: fit-harness fit-trace fit-wiki
+          clis: gemba-harness gemba-trace gemba-wiki
 
       # Select discuss mode when a discussion_id is supplied (the bridge
       # path resuming or starting a threaded conversation); otherwise run a
@@ -151,7 +151,7 @@ jobs:
       # this surface preserves the same template-injection-safe contract.
       - name: Assess and Act
         id: assess
-        uses: forwardimpact/harness@b7409ad9a1df4ff75eca8fe68041b5384f75bd7e # v1.0.3
+        uses: forwardimpact/harness@f1943c61188049a86436913af157852b70331813 # v1.0.4
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
@@ -178,13 +178,13 @@ jobs:
         shell: bash
         env:
           TRACE_FILE: ${{ steps.assess.outputs.trace-file }}
-        run: fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
+        run: gemba-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
 
       # Push agent memory back with a freshly minted token — the token from
       # job start expires after an hour and this run can take up to five.
       - name: Push wiki changes
         if: always()
-        uses: forwardimpact/wiki@f88ea81402d4d3411baf9ca0a38cafb11dfa7f60 # v1.0.1
+        uses: forwardimpact/wiki@ad0042953508240d061ecfb288ce6990247cbd9d # v1.0.2
         with:
           command: push
           app-id: ${{ secrets.KATA_APP_ID }}
@@ -208,7 +208,7 @@ jobs:
           set -euo pipefail
           if [ -n "$TRACE_FILE" ] && [ -f "$TRACE_FILE" ]; then
             echo "Using trace file: $TRACE_FILE"
-            fit-harness callback \
+            gemba-harness callback \
               --trace-file="$TRACE_FILE" \
               --callback-url="$CALLBACK_URL" \
               --correlation-id="$CORRELATION_ID" \

--- a/.github/workflows/outpost-determinism-probe.yml
+++ b/.github/workflows/outpost-determinism-probe.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
       - name: Install diffoscope
         run: brew install diffoscope
       - name: First build

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
 
       - uses: ./.github/actions/audit
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -34,12 +34,11 @@ jobs:
       fail-fast: false
       matrix:
         pack:
-          # The fit leg stays single-prefix while the pinned bootstrap installs
-          # a fit-pack binary that parses only one --prefix (last flag wins):
-          # "fit gemba" would silently stage a fit-skills pack stripped of
-          # every fit-* skill. Flipping it to "fit gemba" requires a bootstrap
-          # pin whose fit-pack accepts repeated --prefix flags.
-          - prefix: fit
+          # The fit leg carries two prefixes: the fit-* skills plus the gemba
+          # product and gemba-* capability skills ship in the same fit-skills
+          # pack. Requires a bootstrap pin whose fit-pack accepts repeated
+          # --prefix flags (gear@v0.2.0+).
+          - prefix: fit gemba
             repo: fit-skills
             version-file: products/gear/package.json
             sync-agents: "false"
@@ -127,7 +126,7 @@ jobs:
           vulnerability-scanning: "false"
           secret-scanning: "true"
 
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
         with:
           clis: fit-pack
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/bootstrap@3d474156f8e1c77f7ed94609912d9de3756896ff # v1.0.15
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
         with:
           clis: fit-doc
 

--- a/products/gemba/actions/benchmark/.github/workflows/benchmark.yml
+++ b/products/gemba/actions/benchmark/.github/workflows/benchmark.yml
@@ -114,13 +114,13 @@ jobs:
       LIBHARNESS_WORK_TRACKER: filesystem
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
         with:
           # gemba-benchmark runs the benchmark binary straight off PATH — the
           # action has no bunx/npx fallback. Requires a bootstrap pin whose
           # gear release publishes the gemba-* binaries.
           clis: gemba-benchmark
-      - uses: forwardimpact/benchmark@v1.0.2
+      - uses: forwardimpact/benchmark@v1.0.6
         with:
           mode: run
           family: ${{ inputs.family }}
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
-      - uses: forwardimpact/benchmark@v1.0.2
+      - uses: forwardimpact/benchmark@v1.0.6
         with:
           mode: merge
           # family is a required action input but unused in merge mode.


### PR DESCRIPTION
Step 4.3 (stage 1) of [plan 2250-a Part 4](specs/2250-agent-platform-product/plan-a-04.md) — the first CI that installs and invokes the gemba binaries end to end.

- `forwardimpact/bootstrap` → `71bd7553` (v1.0.17, defaults to `gear@v0.2.0` which ships the `gemba-*` binaries) on every workflow.
- `forwardimpact/harness` → `f1943c61` (v1.0.4), `forwardimpact/wiki` → `ad004295` (v1.0.2), `forwardimpact/benchmark` → `9cf5ddb6` (v1.0.6) — the re-seeded post-move projections.
- Every held `clis:` value and bare-PATH invocation flips to gemba names (`gemba-trace cost`, `gemba-harness callback`, `gemba-wiki curate`).
- `publish-skills.yml` fit leg goes multi-prefix (`fit gemba`) — merging re-fires the pack publish and restores the runtime skills plus the `gemba` product skill to the published fit-skills pack.
- The nested reusable workflow inside the benchmark action source takes the same bootstrap pin and `benchmark@v1.0.6` (review-panel finding). `eval-kata.yml`/`eval-coaligned.yml` repin in stage 2, against the benchmark sibling SHA this merge produces.
- Untouched: `kata-agent`/`kata-interview` pins (#1978) and the `benchmarks/fit-wiki` path reference (permanent keep).

All pinned SHAs verified resolvable on their sibling repos (`harness@f1943c61…`=v1.0.4, `wiki@ad004295…`=v1.0.2, `benchmark@9cf5ddb6…`=v1.0.6, `bootstrap@71bd7553…`=v1.0.17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)