### PR TITLE
chore(ci): repin the reusable benchmark workflow to v1.0.7 (#2250)

### DIFF
--- a/.github/workflows/eval-coaligned.yml
+++ b/.github/workflows/eval-coaligned.yml
@@ -17,7 +17,7 @@ jobs:
   # caller only picks the family and shard count; the filesystem work-tracker is
   # the reusable workflow's env contract.
   benchmark:
-    uses: forwardimpact/benchmark/.github/workflows/benchmark.yml@66b7dad6715d32d64bdc81614cd7b2edad9b1cae # v1.0.3
+    uses: forwardimpact/benchmark/.github/workflows/benchmark.yml@24c4d1fd309a7a62c2838f26c2389fdd1a7f9031 # v1.0.7
     with:
       family: ./benchmarks/coaligned-skills
       runs: "5"

--- a/.github/workflows/eval-kata.yml
+++ b/.github/workflows/eval-kata.yml
@@ -17,7 +17,7 @@ jobs:
   # GitHub Actions ceiling. The filesystem work-tracker is the reusable
   # workflow's env contract; this caller only picks the family and shard count.
   benchmark:
-    uses: forwardimpact/benchmark/.github/workflows/benchmark.yml@66b7dad6715d32d64bdc81614cd7b2edad9b1cae # v1.0.3
+    uses: forwardimpact/benchmark/.github/workflows/benchmark.yml@24c4d1fd309a7a62c2838f26c2389fdd1a7f9031 # v1.0.7
     with:
       family: ./benchmarks/kata-skills
       runs: "5"


### PR DESCRIPTION
Step 4.3 stage 2 of [plan 2250-a Part 4](specs/2250-agent-platform-product/plan-a-04.md): `eval-kata.yml` and `eval-coaligned.yml` repin `forwardimpact/benchmark/.github/workflows/benchmark.yml` to `24c4d1fd` (v1.0.7) — the projection produced by the stage-1 merge, whose nested bootstrap pin (v1.0.17) installs the `gemba-benchmark` binary its own `clis:` line requests. SHA verified on the sibling (`v1.0.7` → `24c4d1fd…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)