### PR TITLE
chore(gear): bump to 0.3.0 (#2260)

### DIFF
--- a/products/gear/package.json
+++ b/products/gear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/gear",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared libraries and services for platform builders and agents — CLIs, retrieval, evaluation, and infrastructure published to npm.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Spec 2260 release train step 4.1 (third cut): the `jidoka` binary replaces `coaligned` in the gear bundle, so the next gear release carries the renamed binary set — 0.x minor per the plan's bump table. Tag `gear@v0.3.0` follows this merge; the tag fires `publish-binaries.yml` (jidoka-named binaries from `cli-manifest.json`, cask/formula regenerated, `fit-install.sh` staged stamped).

`@forwardimpact/libinvariant@0.2.0` and `@forwardimpact/jidoka@0.2.0` are already live on npm. The red `check-context` jobs are the known rename window, closed by the train's repin step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)