### PR TITLE
chore(bootstrap): default FIT_GEAR_RELEASE to gear@v0.3.0 (#2260)

### DIFF
--- a/products/gemba/actions/bootstrap/fit-install.sh
+++ b/products/gemba/actions/bootstrap/fit-install.sh
@@ -68,7 +68,7 @@ DEFAULT_TOOLS=(apm just gh rg gitleaks claude jidoka
 # caller may override via the environment to pin a different release. On Darwin
 # the fit-gear cask supersedes this — the tap versions the gear set there.
 FIT_RELEASE_REPO="${FIT_RELEASE_REPO:-forwardimpact/monorepo}"
-FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.2.0}"
+FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.3.0}"
 
 # ── tool classification ──────────────────────────────────────────
 # System-package-manager token for the four third-party CLIs a distro packages.


### PR DESCRIPTION
Spec 2260 release train step 4.2: gear@v0.3.0 (published, 103 assets) carries the `jidoka` binary that replaced `coaligned`; this bumps the installer default so bootstrapped runners install it.

After merge: `publish-actions.yml` splits to the `bootstrap` sibling; the sibling gets its next `v1.0.x` tag, then the repin PR (step 4.3) flips workflow pins and closes the rename window. The 3 red `check-context` jobs on this PR are that window (this PR's own change only reaches runners via the sibling re-tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)