### PR TITLE
fix(benchmark): install the report CLI in the merge job via fit-install.sh --only

### DIFF
--- a/products/gear/package.json
+++ b/products/gear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/gear",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Shared libraries and services for platform builders and agents — CLIs, retrieval, evaluation, and infrastructure published to npm.",
   "keywords": [
     "agent",

--- a/products/gemba/actions/benchmark/.github/workflows/benchmark.yml
+++ b/products/gemba/actions/benchmark/.github/workflows/benchmark.yml
@@ -120,7 +120,7 @@ jobs:
           # action has no bunx/npx fallback. Requires a bootstrap pin whose
           # gear release publishes the gemba-* binaries.
           clis: gemba-benchmark
-      - uses: forwardimpact/benchmark@v1.0.6
+      - uses: forwardimpact/benchmark@v1.0.8
         with:
           mode: run
           family: ${{ inputs.family }}
@@ -153,12 +153,12 @@ jobs:
       # tool set the installer would otherwise add.
       - name: Install report CLI
         env:
-          GEAR_RELEASE: gear@v0.3.0
+          GEAR_RELEASE: gear@v0.3.1
         run: |
           curl -fsSL "https://github.com/forwardimpact/monorepo/releases/download/${GEAR_RELEASE}/fit-install.sh" \
             | bash -s -- --only gemba-benchmark
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - uses: forwardimpact/benchmark@v1.0.6
+      - uses: forwardimpact/benchmark@v1.0.8
         with:
           mode: merge
           # family is a required action input but unused in merge mode.

--- a/products/gemba/actions/benchmark/.github/workflows/benchmark.yml
+++ b/products/gemba/actions/benchmark/.github/workflows/benchmark.yml
@@ -140,20 +140,24 @@ jobs:
           # renders the full report over the combined ledger.
           summary-detail: compact
 
-  # Merge job: no agent scaffold — only Node for the report CLI. Download every
-  # shard's partial ledger and aggregate one combined pass@k report.
+  # Merge job: no agent scaffold — only the report CLI. Download every shard's
+  # partial ledger and aggregate one combined pass@k report.
   merge:
     needs: shard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "22"
       # The action runs gemba-benchmark straight off PATH. The shard job gets
       # it from forwardimpact/bootstrap, but bootstrap needs a repo checkout
-      # and this job carries none — install the published npm launcher instead.
+      # and this job carries none — so install the pinned, SHA-verified gear
+      # binary through the released installer. --only skips the default dev/CI
+      # tool set the installer would otherwise add.
       - name: Install report CLI
-        run: npm install -g gemba-benchmark
+        env:
+          GEAR_RELEASE: gear@v0.3.0
+        run: |
+          curl -fsSL "https://github.com/forwardimpact/monorepo/releases/download/${GEAR_RELEASE}/fit-install.sh" \
+            | bash -s -- --only gemba-benchmark
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - uses: forwardimpact/benchmark@v1.0.6
         with:
           mode: merge

--- a/products/gemba/actions/benchmark/.github/workflows/benchmark.yml
+++ b/products/gemba/actions/benchmark/.github/workflows/benchmark.yml
@@ -149,6 +149,11 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
+      # The action runs gemba-benchmark straight off PATH. The shard job gets
+      # it from forwardimpact/bootstrap, but bootstrap needs a repo checkout
+      # and this job carries none — install the published npm launcher instead.
+      - name: Install report CLI
+        run: npm install -g gemba-benchmark
       - uses: forwardimpact/benchmark@v1.0.6
         with:
           mode: merge

--- a/products/gemba/actions/benchmark/action.yml
+++ b/products/gemba/actions/benchmark/action.yml
@@ -100,20 +100,18 @@ runs:
     - name: Install apm
       if: inputs.mode == 'run'
       shell: bash
+      env:
+        GEAR_RELEASE: gear@v0.3.0
       run: |
+        # The released installer owns the pinned, SHA-verified apm version, so
+        # this action carries no duplicate pin. bootstrap usually provides apm
+        # already; the guard skips the download then.
         if command -v apm &>/dev/null; then
           echo "apm already available: $(apm --version)"
         else
-          APM_VERSION="0.12.4"
-          ARCH=$(uname -m)
-          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-          APM_DIR="$HOME/.local/lib/apm"
-          mkdir -p "$APM_DIR" "$HOME/.local/bin"
-          curl -fsSL "https://github.com/microsoft/apm/releases/download/v${APM_VERSION}/apm-${OS}-${ARCH}.tar.gz" \
-            | tar -xz -C "$APM_DIR" --strip-components=1
-          ln -sf "$APM_DIR/apm" "$HOME/.local/bin/apm"
+          curl -fsSL "https://github.com/forwardimpact/monorepo/releases/download/${GEAR_RELEASE}/fit-install.sh" \
+            | bash -s -- --only apm
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          echo "Installed apm $("$APM_DIR/apm" --version)"
         fi
 
     - name: Resolve paths

--- a/products/gemba/actions/benchmark/action.yml
+++ b/products/gemba/actions/benchmark/action.yml
@@ -101,7 +101,7 @@ runs:
       if: inputs.mode == 'run'
       shell: bash
       env:
-        GEAR_RELEASE: gear@v0.3.0
+        GEAR_RELEASE: gear@v0.3.1
       run: |
         # The released installer owns the pinned, SHA-verified apm version, so
         # this action carries no duplicate pin. bootstrap usually provides apm

--- a/products/gemba/actions/bootstrap/fit-install.sh
+++ b/products/gemba/actions/bootstrap/fit-install.sh
@@ -27,8 +27,9 @@
 # Two tools stay on the pinned download path on BOTH platforms (no brew): `claude`
 # is the SDK-embedded Claude Code CLI whose version must track
 # @anthropic-ai/claude-agent-sdk in libraries/libharness/package.json, and `apm`
-# is pinned to a version other tooling (benchmarks, the benchmark action) agrees
-# on. Moving either onto brew later is a one-line TOOL_TABLE edit.
+# is pinned here as the single source of its version — the benchmark action
+# installs it via `--only apm`. Moving either onto brew later is a one-line
+# TOOL_TABLE edit.
 #
 # This file is published verbatim as a GitHub Release asset (fit-install.sh),
 # so any environment can bootstrap with a single line, no repo checkout needed:
@@ -36,7 +37,7 @@
 #   curl -fsSL <release-url>/fit-install.sh | bash -s -- gemba-trace gemba-wiki
 #
 # Usage:
-#   fit-install.sh [--paths] [NAME ...]
+#   fit-install.sh [--paths] [--only] [NAME ...]
 #
 #   NAME   An external tool (apm, just, gh, rg, gitleaks, claude) or a gear binary —
 #          any fit-*/gemba-* CLI (gemba-trace, gemba-harness, gemba-wiki, …) or jidoka.
@@ -45,6 +46,9 @@
 #            and exit. Consumed by fit-bootstrap to scope its actions/cache.
 #            On Darwin, brew-managed tools emit nothing (brew installs globally
 #            and is idempotent); only the $HOME/.local download tools are cached.
+#   --only   Install only the named tools, skipping the default set. For a job
+#            that needs a single CLI without the dev/CI toolchain (e.g. a
+#            report-only merge job). Requires at least one NAME.
 set -euo pipefail
 
 PREFIX="${INSTALL_PREFIX:-$HOME/.local}"
@@ -129,25 +133,36 @@ is_gear_binary() { case "$1" in fit-*|gemba-*|jidoka) return 0 ;; *) return 1 ;;
 # ── --paths / argument parsing ───────────────────────────────────
 # The default set is ALWAYS installed; named gear CLIs add to it (deduped). So
 # `clis: fit-doc` yields the external tools plus fit-doc, never fit-doc alone —
-# bootstrap.sh still finds `just`.
+# bootstrap.sh still finds `just`. --only inverts this: install nothing but the
+# named tools, for a job that needs one CLI without the toolchain.
 PRINT_PATHS=0
 SOFT=0
+ONLY=0
 EXTRA=()
 for arg in "$@"; do
   case "$arg" in
     --paths) PRINT_PATHS=1 ;;
     --soft)  SOFT=1 ;;         # best-effort: report unavailable tools, still exit 0
+    --only)  ONLY=1 ;;         # skip the default set; install only the named tools
     *)       EXTRA+=("$arg") ;;
   esac
 done
-NAMES=("${DEFAULT_TOOLS[@]}")
-if [ "${#EXTRA[@]}" -gt 0 ]; then
-  for n in "${EXTRA[@]}"; do
-    case " ${NAMES[*]} " in
-      *" $n "*) ;;            # already in the default set
-      *)        NAMES+=("$n") ;;
-    esac
-  done
+if [ "$ONLY" = 1 ]; then
+  if [ "${#EXTRA[@]}" -eq 0 ]; then
+    echo "::error::--only requires at least one tool name" >&2
+    exit 1
+  fi
+  NAMES=("${EXTRA[@]}")
+else
+  NAMES=("${DEFAULT_TOOLS[@]}")
+  if [ "${#EXTRA[@]}" -gt 0 ]; then
+    for n in "${EXTRA[@]}"; do
+      case " ${NAMES[*]} " in
+        *" $n "*) ;;            # already in the default set
+        *)        NAMES+=("$n") ;;
+      esac
+    done
+  fi
 fi
 
 if [ "$PRINT_PATHS" = "1" ]; then

--- a/products/gemba/actions/bootstrap/fit-install.sh
+++ b/products/gemba/actions/bootstrap/fit-install.sh
@@ -72,7 +72,7 @@ DEFAULT_TOOLS=(apm just gh rg gitleaks claude jidoka
 # caller may override via the environment to pin a different release. On Darwin
 # the fit-gear cask supersedes this — the tap versions the gear set there.
 FIT_RELEASE_REPO="${FIT_RELEASE_REPO:-forwardimpact/monorepo}"
-FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.3.0}"
+FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.3.1}"
 
 # ── tool classification ──────────────────────────────────────────
 # System-package-manager token for the four third-party CLIs a distro packages.


### PR DESCRIPTION
## Summary

- Fix the "Eval: Kata" failure (`gemba-benchmark: command not found`, exit 127): the benchmark reusable workflow's merge job invoked the action in merge mode without any step installing the report CLI.
- Teach `fit-install.sh` a `--only` flag: install exactly the named tools, skipping the default dev/CI set. Errors when no tool is named; default additive behaviour unchanged.
- Merge job now installs `gemba-benchmark` as the pinned, SHA-verified gear binary through the released installer (`--only gemba-benchmark`); `setup-node` dropped since the compiled binary needs no Node.
- Benchmark action's apm step delegates to the released installer (`--only apm`), removing its duplicated apm version pin and gaining SHA verification.
- Release prep: bump `@forwardimpact/gear` to 0.3.1 (carries the new installer) and point the pins at `gear@v0.3.1` and benchmark action `v1.0.8`, so tags cut after this merge are self-consistent. Consumers pinned ahead fail closed until the tags publish, per CONTRIBUTING § Releasing.

## Test plan

- [x] `bash -n` and YAML parse on all touched files
- [x] `fit-install.sh --only gemba-benchmark` installs the single CLI and nothing else; `--only` with no names exits 1; `--paths` output unchanged
- [x] `bunx jidoka invariants` passes
- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMPZXTtLLYsrB6Q1YuQ2V4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMPZXTtLLYsrB6Q1YuQ2V4)_