### PR TITLE
chore(ci): bump benchmark reusable workflow to v1.0.8

### DIFF
--- a/.github/workflows/eval-jidoka.yml
+++ b/.github/workflows/eval-jidoka.yml
@@ -17,7 +17,7 @@ jobs:
   # caller only picks the family and shard count; the filesystem work-tracker is
   # the reusable workflow's env contract.
   benchmark:
-    uses: forwardimpact/benchmark/.github/workflows/benchmark.yml@24c4d1fd309a7a62c2838f26c2389fdd1a7f9031 # v1.0.7
+    uses: forwardimpact/benchmark/.github/workflows/benchmark.yml@027b1a5947f5e1bf6752fba7b68a753d8957fde9 # v1.0.8
     with:
       family: ./benchmarks/jidoka-skills
       runs: "5"

--- a/.github/workflows/eval-kata.yml
+++ b/.github/workflows/eval-kata.yml
@@ -17,7 +17,7 @@ jobs:
   # GitHub Actions ceiling. The filesystem work-tracker is the reusable
   # workflow's env contract; this caller only picks the family and shard count.
   benchmark:
-    uses: forwardimpact/benchmark/.github/workflows/benchmark.yml@24c4d1fd309a7a62c2838f26c2389fdd1a7f9031 # v1.0.7
+    uses: forwardimpact/benchmark/.github/workflows/benchmark.yml@027b1a5947f5e1bf6752fba7b68a753d8957fde9 # v1.0.8
     with:
       family: ./benchmarks/kata-skills
       runs: "5"


### PR DESCRIPTION
## Summary

- Point `eval-kata.yml` and `eval-jidoka.yml` at `forwardimpact/benchmark` workflow `v1.0.8` (`027b1a59`), the release that installs the report CLI in the merge job — fixing the `gemba-benchmark: command not found` failure both eval workflows hit at the merge step.
- Final consumer tier of the release chain: gear@v0.3.2 (installer with `--only` + binaries) and benchmark v1.0.8 are already published.

## Test plan

- [x] `gear@v0.3.2` release carries `fit-install.sh` and `gemba-benchmark-bun-linux-x64` (+ `.sha256`)
- [x] Sibling tag `v1.0.8` created at `027b1a59`, `v1` alias moved
- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMPZXTtLLYsrB6Q1YuQ2V4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMPZXTtLLYsrB6Q1YuQ2V4)_