### PR TITLE
fix(kata): migrate kata-agent and kata-interview actions to gemba CLIs

### DIFF
--- a/products/kata/actions/kata-agent/action.yml
+++ b/products/kata/actions/kata-agent/action.yml
@@ -1,6 +1,6 @@
 name: Kata Agent
 description: >
-  Run a Kata agent workflow — generates an installation token, checks out the repository, bootstraps the environment, and executes the agent via fit-harness.
+  Run a Kata agent workflow — generates an installation token, checks out the repository, bootstraps the environment, and executes the agent via gemba-harness.
 
 inputs:
   # --- Authentication ---
@@ -38,11 +38,11 @@ inputs:
     description: Comma-separated agent profile names (facilitate and discuss modes)
     required: false
   agent-model:
-    description: Claude model for agents (all modes); empty uses the fit-harness CLI default
+    description: Claude model for agents (all modes); empty uses the gemba-harness CLI default
     required: false
     default: ""
   lead-model:
-    description: Claude model for the lead role (supervise / facilitate / discuss modes); empty uses the fit-harness CLI default
+    description: Claude model for the lead role (supervise / facilitate / discuss modes); empty uses the gemba-harness CLI default
     required: false
     default: ""
   max-turns:
@@ -111,20 +111,20 @@ outputs:
       (empty when `trace` is disabled). Wraps each
       agent/supervisor/facilitator/chair/orchestrator event in
       `{source, seq, event}` envelopes. Read it directly to post-process the
-      run — e.g. `fit-trace cost <file>` to sum spend across every
-      participant. Passed through from the internal `fit-harness` action.
+      run — e.g. `gemba-trace cost <file>` to sum spend across every
+      participant. Passed through from the internal `gemba-harness` action.
     value: ${{ steps.assess.outputs.trace-file }}
   trace-dir:
     description: >
       Absolute path of the temp directory holding all trace files for this
       run (empty when `trace` is disabled). Use it to read the raw or split
       trace files without globbing the runner's temp space. Passed through
-      from the internal `fit-harness` action.
+      from the internal `gemba-harness` action.
     value: ${{ steps.assess.outputs.trace-dir }}
   case:
     description: >
       Effective case identifier embedded in the trace filenames. Passed
-      through from the internal `fit-harness` action.
+      through from the internal `gemba-harness` action.
     value: ${{ steps.assess.outputs.case }}
 
 runs:
@@ -158,19 +158,19 @@ runs:
     # ./scripts/bootstrap.sh. The `token:` input gates wiki checkout —
     # leave it empty to skip wiki sync. The wiki is pushed back after the
     # agent run via forwardimpact/wiki below.
-    - uses: forwardimpact/bootstrap@c852d29b38edbb2e6c037bf3952aac339e9fe8b8 # v1.0.12
+    - uses: forwardimpact/bootstrap@a5d9098c2a1e68277f02fad39583a34ee003d9c9 # v1.0.18
       with:
         token: ${{ inputs.wiki == 'true' && steps.ci-app.outputs.token || '' }}
         app-slug: ${{ inputs.app-slug }}
         app-id: ${{ inputs.app-id }}
-        # Install the pre-compiled CLIs the run uses onto PATH; fit-wiki only
-        # when wiki sync is enabled. The fit-harness/fit-wiki steps below
+        # Install the pre-compiled CLIs the run uses onto PATH; gemba-wiki only
+        # when wiki sync is enabled. The gemba-harness/gemba-wiki steps below
         # resolve these binaries before any npx path.
-        clis: ${{ inputs.wiki == 'true' && 'fit-wiki fit-harness fit-trace' || 'fit-harness fit-trace' }}
+        clis: ${{ inputs.wiki == 'true' && 'gemba-wiki gemba-harness gemba-trace' || 'gemba-harness gemba-trace' }}
 
     # Render the storyboard from current issue + CSV state before the agent
     # reads it, so the facilitator and participants see an up-to-date Current
-    # Condition and Active/Concluded lists rather than stale markdown. fit-wiki
+    # Condition and Active/Concluded lists rather than stale markdown. gemba-wiki
     # mints a fresh token for the `gh issue list` calls refresh makes.
     - name: Refresh wiki (pre-run)
       if: inputs.wiki == 'true'
@@ -182,13 +182,13 @@ runs:
 
     - name: Assess and Act
       id: assess
-      uses: forwardimpact/harness@b7409ad9a1df4ff75eca8fe68041b5384f75bd7e # v1.0.3
+      uses: forwardimpact/harness@f1943c61188049a86436913af157852b70331813 # v1.0.4
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         GH_TOKEN: ${{ steps.ci-app.outputs.token }}
         CLAUDE_CODE_USE_BEDROCK: "0"
         # The agent runs in bypass-permissions mode, which Claude Code refuses
-        # under uid 0 unless the process is marked sandboxed. fit-harness@v1 sets
+        # under uid 0 unless the process is marked sandboxed. gemba-harness@v1 sets
         # this on its own run step; set it here too so the requirement is
         # explicit at the workflow level. Harmless on non-root runners.
         IS_SANDBOX: "1"
@@ -226,7 +226,7 @@ runs:
         app-id: ${{ inputs.app-id }}
         app-private-key: ${{ inputs.app-private-key }}
 
-    # Push agent memory back. fit-wiki mints a fresh token (the one minted
+    # Push agent memory back. gemba-wiki mints a fresh token (the one minted
     # at job start expires after an hour, so a long agent run would leave a
     # cleanup-time push unauthenticated) and runs under always() so memory
     # is durable whether the agent step succeeded, failed, or timed out.
@@ -238,7 +238,7 @@ runs:
         app-id: ${{ inputs.app-id }}
         app-private-key: ${{ inputs.app-private-key }}
 
-    # Sum spend across every participant. fit-trace cost tolerates a missing
+    # Sum spend across every participant. gemba-trace cost tolerates a missing
     # trace (the run may have failed before producing one), so this needs no
     # file guard.
     - name: Report run cost
@@ -246,4 +246,4 @@ runs:
       shell: bash
       env:
         TRACE_FILE: ${{ steps.assess.outputs.trace-file }}
-      run: fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
+      run: gemba-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"

--- a/products/kata/actions/kata-interview/action.yml
+++ b/products/kata/actions/kata-interview/action.yml
@@ -84,12 +84,12 @@ outputs:
   trace-file:
     description: >
       Absolute path of the raw NDJSON trace file from the interview run.
-      Passed through from the internal fit-harness action.
+      Passed through from the internal gemba-harness action.
     value: ${{ steps.interview.outputs.trace-file }}
   trace-dir:
     description: >
       Absolute path of the temp directory holding all trace files for this run.
-      Passed through from the internal fit-harness action.
+      Passed through from the internal gemba-harness action.
     value: ${{ steps.interview.outputs.trace-dir }}
 
 runs:
@@ -123,12 +123,12 @@ runs:
     # fit-terrain now also provides the generic substrate bring-up, so fit-map
     # is NOT installed here — a consumer's FI substrate command runs it via bunx
     # as its own documented exception.
-    - uses: forwardimpact/bootstrap@c852d29b38edbb2e6c037bf3952aac339e9fe8b8 # v1.0.12
+    - uses: forwardimpact/bootstrap@a5d9098c2a1e68277f02fad39583a34ee003d9c9 # v1.0.18
       with:
         token: ${{ steps.ci-app.outputs.token }}
         app-slug: ${{ inputs.app-slug }}
         app-id: ${{ inputs.app-id }}
-        clis: fit-terrain fit-trace fit-harness fit-wiki
+        clis: fit-terrain gemba-trace gemba-harness gemba-wiki
 
     - name: Prepare interview workspace
       id: workspace
@@ -178,7 +178,7 @@ runs:
 
     - name: Run interview
       id: interview
-      uses: forwardimpact/harness@b7409ad9a1df4ff75eca8fe68041b5384f75bd7e # v1.0.3
+      uses: forwardimpact/harness@f1943c61188049a86436913af157852b70331813 # v1.0.4
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         GH_TOKEN: ${{ steps.ci-app.outputs.token }}
@@ -209,13 +209,13 @@ runs:
         supervisor-allowed-tools: ${{ inputs.supervisor-allowed-tools }}
         task-amend: ${{ steps.amend.outputs.amend }}
 
-    # fit-trace cost tolerates a missing trace, so no file guard is needed.
+    # gemba-trace cost tolerates a missing trace, so no file guard is needed.
     - name: Report run cost
       if: always()
       shell: bash
       env:
         TRACE_FILE: ${{ steps.interview.outputs.trace-file }}
-      run: fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
+      run: gemba-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
 
     - name: Push wiki changes
       if: always()
@@ -227,7 +227,7 @@ runs:
 
     # Scan the run's own logs for secret literals on the substrate path. The
     # persona-JWT stash is written by the persona-select command inside the
-    # harness step; the missing-file guard covers an unset command. fit-harness
+    # harness step; the missing-file guard covers an unset command. gemba-harness
     # scan-logs owns the archive download and fails closed.
     - name: Scan logs for sensitive values
       if: always() && inputs.substrate-setup-command != ''
@@ -249,7 +249,7 @@ runs:
         [ -n "$JWT_SECRET" ] && secrets+=(--secret "jwt-secret=$JWT_SECRET")
         [ -n "$SERVICE_ROLE_KEY" ] && secrets+=(--secret "service-role-key=$SERVICE_ROLE_KEY")
 
-        fit-harness scan-logs \
+        gemba-harness scan-logs \
           --run-id "${{ github.run_id }}" \
           --repo "${{ github.repository }}" \
           "${secrets[@]}"

--- a/references/bionova-apps/design-a.md
+++ b/references/bionova-apps/design-a.md
@@ -266,9 +266,10 @@ against (and kept in sync with `kong.yml`).
 
 ## Prerequisite library changes
 
-This design depends on two monorepo capabilities that do not exist yet. They
-are not `bionova-apps` work; they ship from the monorepo and publish to npm
-before `bionova-apps` implementation begins. Each needs its own spec.
+This design depends on two monorepo capabilities that did not exist when it
+was written. They are not `bionova-apps` work; both have since shipped from
+the monorepo and publish on npm in `fit-terrain` 0.1.41 and later. The tables
+below record what changed and where, as designed.
 
 ### A — `fit-terrain` runs outside the monorepo
 
@@ -321,7 +322,7 @@ the mandated `discipline`/`level`/`track` columns. `substrate.evidence` and
 with the degradation that declares: structural-only pick invariants, and an
 identity-only `.substrate.json` from `issue`.
 
-`.github/workflows/interview.yml` in `bionova-apps`:
+`.github/workflows/kata-interview.yml` in `bionova-apps`:
 
 ```yaml
 jobs:
@@ -335,14 +336,15 @@ jobs:
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           website-url: https://polaris.bionova.example
-          # Generic Supabase bring-up, Polaris' own migrations + embed seed,
-          # then the contract gate and identity provisioning.
+          # Polaris' own compose stack (not the Supabase CLI): boot, render +
+          # apply the seed via setup.sh, then the contract gate and identity
+          # provisioning. `fit-terrain` is on PATH via the action's bootstrap.
           substrate-setup-command: >-
-            npx fit-terrain substrate up --cwd . --emit-env "$GITHUB_ENV"
-            && supabase db push
-            && ./data/synthetic/setup.sh
-            && npx fit-terrain substrate check
-            && npx fit-terrain substrate provision
+            cp .env.example .env
+            && docker compose up -d --wait
+            && ./setup.sh
+            && fit-terrain substrate check
+            && fit-terrain substrate provision
           jwt-secret: ${{ secrets.SUPABASE_JWT_SECRET }}
           service-role-key: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
 ```
@@ -355,9 +357,9 @@ token name (and, if diversification across runs matters, a Polaris-scoped
 `--memory` path):
 
 ```sh
-persona=$(npx fit-terrain substrate pick --format json) \
+persona=$(fit-terrain substrate pick --format json) \
 && email=$(printf '%s' "$persona" | jq -r '.personas[0].email') \
-&& npx fit-terrain substrate issue --email "$email" --cwd "$AGENT_CWD" \
+&& fit-terrain substrate issue --email "$email" --cwd "$AGENT_CWD" \
   --token-env PRODUCT_POLARIS_TOKEN --stash "$RUNNER_TEMP/.persona-jwt"
 ```
 
@@ -365,10 +367,10 @@ This satisfies the same `.env` / `.substrate.json` / stash contract the action
 documents; `--token-env` carries the Polaris token name, so nothing
 Landmark-specific enters the flow.
 
-The substrate command brings Supabase up from the repo checkout (`--cwd .`,
-using Polaris' own `supabase/` config), while the interview itself stages its
-working files into the temp `agent-cwd` the action creates — the whole loop
-runs on `fit-terrain` plus Polaris' own migrations and seed, with no Polaris
-application code running in the runner. Prerequisite A (`fit-terrain` runs
+The substrate command brings Polaris' own compose stack up from the repo
+checkout and seeds it through `setup.sh`, while the interview itself stages
+its working files into the temp `agent-cwd` the action creates — the whole
+loop runs on `fit-terrain` plus Polaris' own migrations and seed, with no
+Polaris application code running in the runner. Prerequisite A (`fit-terrain` runs
 outside the monorepo) is the same dependency the seed pipeline already relies
 on.

--- a/references/bionova-apps/design-a.md
+++ b/references/bionova-apps/design-a.md
@@ -368,9 +368,9 @@ documents; `--token-env` carries the Polaris token name, so nothing
 Landmark-specific enters the flow.
 
 The substrate command brings Polaris' own compose stack up from the repo
-checkout and seeds it through `setup.sh`, while the interview itself stages
-its working files into the temp `agent-cwd` the action creates — the whole
-loop runs on `fit-terrain` plus Polaris' own migrations and seed, with no
-Polaris application code running in the runner. Prerequisite A (`fit-terrain` runs
+checkout and seeds it through `setup.sh`, while the interview itself stages its
+working files into the temp `agent-cwd` the action creates — the whole loop runs
+on `fit-terrain` plus Polaris' own migrations and seed, with no Polaris
+application code running in the runner. Prerequisite A (`fit-terrain` runs
 outside the monorepo) is the same dependency the seed pipeline already relies
 on.

--- a/references/bionova-apps/plan-a-01.md
+++ b/references/bionova-apps/plan-a-01.md
@@ -48,7 +48,7 @@ Created / extended:
 | `MONOREPO.md` | Repo's layout doc (three-shippable / three-support), scoped to bionova-apps |
 | `LICENSE` | Apache-2.0 |
 | `.nvmrc` | `20` (Node major) |
-| `.tool-versions` | `bun 1.2.0`, `nodejs 20.11.1` (`supabase` added in part 02, `deno` in part 04) |
+| `.tool-versions` | `bun 1.3.11`, `nodejs 20.19.0` (`supabase` added in part 02, `deno` in part 04). Bun must stay >= 1.2.9: `apm install` calls `Bun.YAML.parse`, absent in older bun |
 | `package.json` | **extend** the skeleton manifest — add `"type": "module"`, `engines`, the Polaris workspaces, the bionova scripts, and app devDependencies (below); keep the skeleton's `check`/`jidoka` entries |
 | `.gitignore` | **append** the bionova ignores (below) to the skeleton's |
 | `justfile` | Recipes: `up` (`docker compose up -d`), `down`, `setup`, `seed` (`bash scripts/build-seed.sh`), `cli`, `dev:site`, `test`, `lint` |
@@ -64,7 +64,7 @@ devDependencies (do **not** drop the skeleton's `check` / `jidoka` entries):
 {
   "type": "module",
   "workspaces": ["products/*/cli", "products/*/site", "products/*/handlers"],
-  "engines": { "node": ">=20", "bun": ">=1.2" },
+  "engines": { "node": ">=20.19.0", "bun": ">=1.2" },
   "scripts": {
     "setup": "./setup.sh",
     "seed": "bash scripts/build-seed.sh",
@@ -80,20 +80,20 @@ devDependencies (do **not** drop the skeleton's `check` / `jidoka` entries):
     "typescript": "5.9.3",
     "@eslint/js": "9.39.4",
     "eslint": "9.39.4",
-    "eslint-config-prettier": "9.1.2",
-    "prettier": "3.9.4",
-    "@forwardimpact/libterrain": "<pinned in part 03>"
+    "eslint-config-prettier": "10.1.8",
+    "prettier": "3.9.5",
+    "fit-terrain": "0.1.41"
   }
 }
 ```
 
 The Deno service `services/polaris-functions/` is **not** a Bun workspace — it
 carries `deno.json`, not `package.json`, so `lint`/`test` run JS and Deno
-tooling in separate steps. `@forwardimpact/libterrain` is a
+tooling in separate steps. `fit-terrain` is a
 **build-time devDependency only** — `setup.sh` and
 `scripts/build-seed.sh` invoke `fit-terrain build` to render the seed from the
-vendored `story.dsl`; no surface imports them. Part 03 pins the exact versions
-that carry prerequisites A (`--output-root`) and B (prose→SQL).
+vendored `story.dsl`; no surface imports it. Part 03 verifies the pinned
+version carries prerequisites A (`--output-root`) and B (prose→SQL).
 
 `.gitignore` — append the rendered-seed and runtime-data ignores (the skeleton
 already ignores `node_modules/`, `.env`, `*.log`, `wiki/`, `dist/`, `build/`,
@@ -372,10 +372,11 @@ those do not cover — **one workflow per concern, never folded into a single
 | `.github/CODEOWNERS` | `* @forwardimpact/agent-team` (extend only if `kata-setup` did not already set it) |
 | `.github/pull_request_template.md` | Summary, Test plan (if not already scaffolded) |
 
-The seed and e2e jobs skip cleanly with a `::warning::` until the
-`@forwardimpact/libterrain` release carrying `--output-root` (prerequisite A) is
-resolvable from npm; until then they point `fit-terrain` at a pinned checkout
-via `FIT_TERRAIN`. Do not add a monolithic `ci.yml` — a failing compose
+The seed and e2e jobs run against the pinned `fit-terrain` devDependency —
+`bun install` drops its bin at `node_modules/.bin/fit-terrain`, so no live
+fetch is needed. The `FIT_TERRAIN` env var points `build-seed.sh` at a local
+checkout only when rendering with an unreleased build.
+Do not add a monolithic `ci.yml` — a failing compose
 validation and a failing edge-function test must read as two distinct red
 checks, per the check-workflow rule the skill enforces.
 

--- a/references/bionova-apps/plan-a-03.md
+++ b/references/bionova-apps/plan-a-03.md
@@ -40,7 +40,7 @@ Write `data/synthetic/PROVENANCE.md` (one page):
 - Vendored verbatim: `story.dsl` (`seed 42`) + `prose-cache.json`
 - Render command: `bunx fit-terrain build --story data/synthetic/story.dsl
   --cache data/synthetic/prose-cache.json --output-root data/synthetic/.build`
-- libterrain version that produced the committed `SEED.sha256`: `<pinned>`
+- `fit-terrain` version that produced the committed `SEED.sha256`: `<pinned>`
 - SC7 verify: run the render command here, then `sha256sum -c SEED.sha256`
   against `data/synthetic/.build/.../migrations/`; running the same command in
   the monorepo at `$PROVENANCE_SHA` reproduces identical bytes.
@@ -49,20 +49,19 @@ Verify: `sha256sum -c SOURCE.sha256` passes; `PROVENANCE.md` carries a real
 40-char SHA reachable on `forwardimpact/monorepo:main`; `story.dsl` is
 byte-identical to the monorepo's at `$PROVENANCE_SHA` (`diff` is empty).
 
-## Step 2 — Pin the libterrain version that carries prereqs A+B
+## Step 2 — Verify the fit-terrain pin carries prereqs A+B
 
-Part 01 added `@forwardimpact/libterrain` as a
-`devDependency`. Pin the exact version that include `--output-root` (A) and
-prose-to-SQL rendering (B):
+Part 01 added `fit-terrain` as a pinned `devDependency` (0.1.41, the first
+release carrying `--output-root` (A) and prose-to-SQL rendering (B)). Confirm
+the resolved version is at least that:
 
 ```sh
-npm view @forwardimpact/libterrain version       # must be ≥ the A+B release
+npm view fit-terrain version       # must be >= 0.1.41
 ```
 
-Record the resolved version in this part's PR body. If the A+B release is not
-yet on npm, **stop** — this part is blocked (plan-a.md § Prerequisites).
+Record the resolved version in this part's PR body.
 
-Verify: `bun pm ls | grep libterrain` shows the pinned
+Verify: `bun pm ls | grep fit-terrain` shows the pinned
 version; `bunx fit-terrain --help` lists `--output-root` and `--schema-dir`.
 
 ## Step 3 — Author `scripts/build-seed.sh`
@@ -238,16 +237,23 @@ Verify: file present; renders cleanly on GitHub.
 
 ## Step 10 — Add CI step that proves the local build is deterministic
 
-Edit `.github/workflows/ci.yml` (from part 01):
+Fill in `.github/workflows/check-seed.yml` (scaffolded in part 01; SHA-pin
+both actions per part 01 step 9):
 
 ```yaml
+jobs:
   seed-build:
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@<pinned-sha> # v7
+      - uses: oven-sh/setup-bun@<pinned-sha> # v2
+        with:
+          bun-version-file: .tool-versions
       - run: bun install
+      # fit-terrain (prereqs A+B) is a devDependency, so `bun install` above
+      # drops its bin locally and build-seed.sh resolves it without a live
+      # `bunx` fetch.
       - run: bash scripts/build-seed.sh
       - run: |
           MIG=products/polaris/site/supabase/migrations
@@ -258,9 +264,9 @@ Edit `.github/workflows/ci.yml` (from part 01):
           grep -Eq '[0-9a-f]{40}' data/synthetic/PROVENANCE.md
 ```
 
-The job needs npm (libterrain) but **no LLM credential** — `build` renders from
-the committed cache. The `sha256sum -c` against `SEED.sha256` is the SC7
-determinism gate: a non-deterministic render or a libterrain version drift
+The job needs npm (fit-terrain) but **no LLM credential** — `build` renders
+from the committed cache. The `sha256sum -c` against `SEED.sha256` is the SC7
+determinism gate: a non-deterministic render or a fit-terrain version drift
 fails here.
 
 Verify: PR CI runs `seed-build`; passes on the vendored-DSL layout.
@@ -270,11 +276,11 @@ Verify: PR CI runs `seed-build`; passes on the vendored-DSL layout.
 ```sh
 git checkout -b data/vendored-dsl
 git add scripts/build-seed.sh setup.sh docker-compose.yml data/synthetic/ \
-        .github/workflows/ci.yml .gitignore package.json
+        .github/workflows/check-seed.yml .gitignore package.json
 git commit -m "data: vendor story.dsl verbatim; render seed locally with fit-terrain"
 git push -u origin data/vendored-dsl
 gh pr create --title "data: vendor story.dsl verbatim; render seed locally" \
-  --body "Implements plan-a-03 (r3) of spec 1160. bionova-apps vendors data/synthetic/story.dsl + prose-cache.json verbatim from monorepo@<PROVENANCE_SHA> and runs fit-terrain build --output-root to render the seed locally (no LLM key; prose cache committed). Requires libterrain prereqs A (--output-root) and B (prose→SQL), pinned at <versions>. SEED.sha256 is the determinism anchor (SC7). Supersedes r2's vendor-the-SQL approach."
+  --body "Implements plan-a-03 (r3) of spec 1160. bionova-apps vendors data/synthetic/story.dsl + prose-cache.json verbatim from monorepo@<PROVENANCE_SHA> and runs fit-terrain build --output-root to render the seed locally (no LLM key; prose cache committed). Requires fit-terrain >= 0.1.41 (prereqs A --output-root and B prose→SQL), pinned in package.json. SEED.sha256 is the determinism anchor (SC7). Supersedes r2's vendor-the-SQL approach."
 ```
 
 Verify: PR CI green (lint + seed-build jobs).
@@ -286,7 +292,7 @@ Verify: PR CI green (lint + seed-build jobs).
       `SOURCE.sha256`, `SEED.sha256`, `PROVENANCE.md`, `README.md`, all
       committed.
 - [ ] `PROVENANCE.md` pins a real 40-char SHA on `forwardimpact/monorepo:main`
-      and the libterrain version used.
+      and the fit-terrain version used.
 - [ ] `bunx fit-terrain --help` shows `--output-root` (prereq A present).
 - [ ] `scripts/build-seed.sh` renders into `data/synthetic/.build/`, asserts the
       six prose tables, stages ≥ 15 SQL files, and refuses to run if the output

--- a/references/bionova-apps/plan-a-04.md
+++ b/references/bionova-apps/plan-a-04.md
@@ -310,14 +310,14 @@ Created:
 Test runner:
 `deno test --allow-net --allow-read --allow-env services/polaris-functions/`.
 
-Verify: `deno test` exits 0; CI runs this in a new job `edge-functions` in
-`.github/workflows/ci.yml`.
+Verify: `deno test` exits 0; CI runs this in the `edge-functions` job of
+`.github/workflows/check-edge.yml` (scaffolded in part 01).
 
 ## Step 7 — Open part-04 PR
 
 ```sh
 git checkout -b services/polaris-functions
-git add services/polaris-functions/ products/polaris/site/supabase/migrations/20260601000002_notify_trigger.sql products/polaris/site/supabase/migrations/20260601000003_sync_schedule.sql docker-compose.yml setup.sh .github/workflows/ci.yml
+git add services/polaris-functions/ products/polaris/site/supabase/migrations/20260601000002_notify_trigger.sql products/polaris/site/supabase/migrations/20260601000003_sync_schedule.sql docker-compose.yml setup.sh .github/workflows/check-edge.yml
 git commit -m "services: polaris-functions edge functions"
 git push -u origin services/polaris-functions
 gh pr create --title "services: polaris-functions edge functions" --body "Implements plan-a-04 of spec 1160. Adds embed-seed, eligibility-check, notify-updates, sync-listings; wires pg_net + cron triggers."

--- a/references/bionova-apps/plan-a-05.md
+++ b/references/bionova-apps/plan-a-05.md
@@ -40,7 +40,7 @@ Created:
     "./templates": "./src/templates-dir.js"
   },
   "dependencies": {
-    "@forwardimpact/libtemplate": "0.2.10"
+    "@forwardimpact/libtemplate": "0.2.14"
   }
 }
 ```

--- a/references/bionova-apps/plan-a-06.md
+++ b/references/bionova-apps/plan-a-06.md
@@ -28,10 +28,10 @@ Created:
   "type": "module",
   "bin": { "bionova-polaris": "bin/bionova-polaris.js" },
   "dependencies": {
-    "@forwardimpact/libcli": "0.1.9",
-    "@forwardimpact/librepl": "0.1.12",
-    "@forwardimpact/libformat": "0.1.15",
-    "@forwardimpact/libtemplate": "0.2.10",
+    "@forwardimpact/libcli": "0.1.17",
+    "@forwardimpact/librepl": "0.1.16",
+    "@forwardimpact/libformat": "0.1.21",
+    "@forwardimpact/libtemplate": "0.2.14",
     "@bionova/polaris-handlers": "workspace:*"
   }
 }

--- a/references/bionova-apps/plan-a-07.md
+++ b/references/bionova-apps/plan-a-07.md
@@ -45,8 +45,8 @@ Edit `package.json` to add workspace deps:
 
 ```json
 "dependencies": {
-  "@forwardimpact/libui": "1.2.1",
-  "@forwardimpact/libformat": "0.1.15",
+  "@forwardimpact/libui": "1.4.1",
+  "@forwardimpact/libformat": "0.1.21",
   "@bionova/polaris-handlers": "workspace:*",
   "next": "14.2.5",
   "react": "18.3.1",

--- a/references/bionova-apps/plan-a-08.md
+++ b/references/bionova-apps/plan-a-08.md
@@ -71,26 +71,40 @@ name: deploy
 on:
   push:
     branches: [main]
+# Deploys run `railway up` with the RAILWAY_TOKEN secret; the GITHUB_TOKEN is
+# only used to check out the repo. Least privilege is read-only.
+permissions:
+  contents: read
 jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.changes.outputs.services }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@<pinned-sha> # v7 — SHA-pin, per part 01 step 9
         with: { fetch-depth: 2 }
       - id: changes
         run: |
           changed=$(git diff --name-only HEAD~1 HEAD)
+          # Map each watched directory to its real Railway service name (the
+          # compose/Railway service key, not the dir basename).
+          declare -A svc=(
+            [infrastructure/postgres]=postgres
+            [infrastructure/kong]=kong
+            [infrastructure/postgrest]=postgrest
+            [infrastructure/gotrue]=gotrue
+            [infrastructure/storage]=storage
+            [infrastructure/tei]=tei
+            [products/polaris/site]=polaris-site
+            [services/polaris-functions]=polaris-functions
+          )
           services=()
-          for d in infrastructure/postgres infrastructure/kong infrastructure/postgrest infrastructure/gotrue infrastructure/storage infrastructure/tei products/polaris/site services/polaris-functions; do
-            if echo "$changed" | grep -q "^$d/"; then
-              services+=("$(basename "$d")")
-            fi
+          for d in "${!svc[@]}"; do
+            if echo "$changed" | grep -q "^$d/"; then services+=("${svc[$d]}"); fi
           done
-          # polaris-site also depends on handlers
-          if echo "$changed" | grep -q "^products/polaris/handlers/" && [[ ! " ${services[*]} " =~ " site " ]]; then
-            services+=("site")
+          # The site bundles the shared handlers; redeploy it when they change.
+          if echo "$changed" | grep -q "^products/polaris/handlers/" && [[ ! " ${services[*]} " =~ " polaris-site " ]]; then
+            services+=("polaris-site")
           fi
           echo "services=$(printf '%s\n' "${services[@]}" | jq -R -s 'split("\n") | map(select(length>0))' -c)" >> $GITHUB_OUTPUT
   deploy:
@@ -101,8 +115,8 @@ jobs:
       matrix:
         service: ${{ fromJson(needs.detect.outputs.services) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@<pinned-sha> # v7
+      - uses: actions/setup-node@<pinned-sha> # v4
         with: { node-version: '20' }
       # Install Railway CLI from a pinned npm version. The upstream
       # `curl -fsSL https://railway.app/install.sh | sh` flow resolves
@@ -115,12 +129,15 @@ jobs:
 ```
 
 Document RAILWAY_TOKEN setup in `infrastructure/railway/README.md` —
-project-scoped token from Railway dashboard, set as repo secret.
+project-scoped token from Railway dashboard, set as repo secret. If no
+Railway project is linked yet, gate the `deploy` job on the secret being
+non-empty so it skips cleanly instead of standing red (a red `deploy`
+should mean a genuine deploy failure).
 
 Verify: a no-op commit to `main` runs the `detect` job, which emits an
 empty `services` array, and the `deploy` job is skipped. A commit
-touching `products/polaris/site/src/app/page.tsx` triggers a `site`-only
-deploy.
+touching `products/polaris/site/src/app/page.tsx` triggers a
+`polaris-site`-only deploy.
 
 ## Step 4 — Author the success-criteria smoke script
 
@@ -402,32 +419,41 @@ SCs pass.
 
 ## Step 5 — Wire smoke script into CI
 
-Edit `.github/workflows/ci.yml`:
+Fill in `.github/workflows/check-e2e.yml` (scaffolded in part 01; SHA-pin
+both actions per part 01 step 9). It is a standalone per-concern workflow —
+no `needs:` on other jobs; the other concerns run as their own workflows:
 
 ```yaml
+jobs:
   e2e:
     runs-on: ubuntu-latest
-    needs: [lint, seed-stage, edge-functions]
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
-      - run: docker compose up -d --wait
-      - run: ./setup.sh
-        env:
-          POSTGRES_PASSWORD: test
-          JWT_SECRET: ${{ secrets.TEST_JWT_SECRET }}
-          ANON_KEY: ${{ secrets.TEST_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.TEST_SERVICE_ROLE_KEY }}
-      - run: ./scripts/smoke.sh
-        env:
-          ANON_KEY: ${{ secrets.TEST_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.TEST_SERVICE_ROLE_KEY }}
+      - uses: actions/checkout@<pinned-sha> # v7
+      - uses: oven-sh/setup-bun@<pinned-sha> # v2
+        with:
+          bun-version-file: .tool-versions
+      - run: bun install
+      - run: cp .env.example .env
+      - run: |
+          # Render the seed BEFORE compose up — polaris-functions bind-mounts the JSONL.
+          bash scripts/build-seed.sh
+          # Pre-fetch the TEI model on the host and point tei at the local
+          # copy — the container cannot fetch through the runner's
+          # TLS-inspecting proxy (part 01 step 7).
+          TEI_MODEL_CACHE="$HOME/.cache/bionova-tei-model/bge-small-en-v1.5" \
+            bash scripts/fetch-tei-model.sh
+          printf 'TEI_MODEL_ID=/data\nTEI_MODEL_SOURCE=%s\n' \
+            "$HOME/.cache/bionova-tei-model/bge-small-en-v1.5" >> .env
+          docker compose up -d --wait
+          ./setup.sh
+          SMOKE_DESTRUCTIVE=1 ./scripts/smoke.sh
       - if: failure()
         run: docker compose logs --tail=200
 ```
 
-Token values are test-only (low-entropy is fine — Anon and service-role
-keys are scoped to the ephemeral CI Postgres instance).
+The `.env.example` placeholder values suffice — the anon and service-role
+keys are scoped to the ephemeral CI Postgres instance, so no repository
+secrets are needed.
 
 Verify: CI e2e job runs against a fresh stack and reports green.
 

--- a/references/bionova-apps/plan-a.md
+++ b/references/bionova-apps/plan-a.md
@@ -21,7 +21,7 @@ around synthetic data: `bionova-apps` vendors `data/synthetic/story.dsl` and
 `prose-cache.json` verbatim and runs `fit-terrain build` against them itself.**
 The DSL is the repository's domain source of truth; the SQL migrations and
 embeddings JSONL are rendered locally, never authored or vendored as output.
-This depends on two monorepo prerequisites that must publish to npm first (see
+This depends on two monorepo prerequisites, both published to npm (see
 Prerequisites): an `--output-root` flag so the build renders into a disposable
 directory instead of deleting `products/polaris/`, and prose-to-SQL rendering
 so the six clinical prose tables are emitted. The build is credential-free —
@@ -68,25 +68,22 @@ this spec; the monorepo PR (`plan-implemented`) updates only
 | --- | --- | --- |
 | Spec 1140 — clinical-output pipeline | implemented (commits `8bbf8f1c`, `0c921e81`) | `libterrain` clinical-output stage emits `supabase_migration` + `embeddings_jsonl` files |
 | Spec 1150 — story.dsl clinical rewrite | **implemented** (`wiki/STATUS.md` row `1150 plan implemented`; live-verified 2026-06-11 — `bunx fit-terrain build` at `6010964b`: 0 cache misses, all seed artifacts produced) | story.dsl carries `clinical {}` + `output … supabase_migration {…}` blocks at `data/synthetic/story.dsl:1250–1272` |
-| **Prerequisite A — `fit-terrain` external execution** | **NOT YET SPECCED — blocks implementation.** Needs `--output-root` (route the write sink off the project root so it does not `rm -rf products/polaris/`) and `--schema-dir` defaulting to `@forwardimpact/libskill`'s published `schema/json` (a hard dependency of `libterrain`). Must publish in a new `@forwardimpact/libterrain` minor. | `libterrain/bin/fit-terrain.js` sink wiring (~233–241) + `src/sinks.js` `writeFiles` (~262–285); `bin/fit-terrain.js` `defaultSchemaDir()`. See design § Prerequisite library changes A. |
-| **Prerequisite B — clinical prose → SQL** | **NOT YET SPECCED — blocks parts 05/07 prose surfaces.** Materialize the six prose types as records, add their `TABLE_SPEC` entries, and pass the prose cache into `renderSql`. Must publish in the same `libterrain`/`libsyntheticrender`/`libsyntheticgen` release train. | `libsyntheticgen/src/engine/clinical-entities.js` (~100–107); `libsyntheticrender/src/render/render-sql.js` `TABLE_SPEC` (~12–66); `libterrain/src/nodes.js` `renderClinicalOutput` (~543–545). See design § Prerequisite library changes B. |
-| `@forwardimpact/libcli@0.1.12`, `libui@1.3.0`, `libformat@0.1.18`, `libtemplate@0.2.12`, `librepl@0.1.14` on npm | published — versions verified via `npm view @forwardimpact/<lib> version` at panel-review time | part 01 pins these exact versions; implementer re-runs `npm view @forwardimpact/{libcli,libui,libformat,libtemplate,librepl} version` immediately before `bun install` and bumps in the part-01 PR if any further patch level published since. **libui crossed a minor (1.2 → 1.3): the implementer must scan `CHANGELOG.md` (or the GitHub release notes for `@forwardimpact/libui@1.3.0`) for breaking changes to `createBoundRouter`, `render`, `freezeInvocationContext`, and the exported `components` surface used by plan-a-07; record the scan result in the part-01 PR body** even when no breakage is found. |
-| `@forwardimpact/libterrain` on npm | required at the version that carries prerequisites A and B | part 01 adds it as a `devDependency`; part 03 pins the exact version that includes `--output-root` and prose-to-SQL rendering, and records it in its PR body |
+| **Prerequisite A — `fit-terrain` external execution** | **implemented** — `--output-root` (routes the write sink off the project root so it does not `rm -rf products/polaris/`) and `--schema-dir` (defaults to `@forwardimpact/libskill`'s published `schema/json`, a hard dependency of `libterrain`) ship in `fit-terrain` 0.1.41 on npm | `bunx fit-terrain --help` lists `--output-root` and `--schema-dir`. See design § Prerequisite library changes A. |
+| **Prerequisite B — clinical prose → SQL** | **implemented** — the six prose types materialize as records with `TABLE_SPEC` entries and the prose cache reaches `renderSql`; ships in the same `fit-terrain` release | the rendered build output contains the six prose seed tables (part 03 asserts this). See design § Prerequisite library changes B. |
+| `@forwardimpact/libcli@0.1.17`, `libui@1.4.1`, `libformat@0.1.21`, `libtemplate@0.2.14`, `librepl@0.1.16` on npm | published — versions verified via `npm view @forwardimpact/<lib> version` at the last reference pass | part 01 pins these exact versions; implementer re-runs `npm view @forwardimpact/{libcli,libui,libformat,libtemplate,librepl} version` immediately before `bun install` and bumps in the part-01 PR if any further patch level published since. **If any of the five crossed a minor (or major) since these pins, the implementer must scan its `CHANGELOG.md` (or GitHub release notes) for breaking changes to the symbols plan-a-06 (CLI) and plan-a-07 (web) import — `createCli`, `createBoundRouter`, `render`, `freezeInvocationContext`, and the exported `components` surface — and record the scan result in the part-01 PR body** even when no breakage is found. |
+| `fit-terrain` on npm | published — 0.1.41 carries prerequisites A and B | part 01 adds it as a pinned `devDependency` (0.1.41); part 03 verifies the pinned version carries `--output-root` and prose-to-SQL rendering, and records it in its PR body |
 
-**This plan must not enter implementation until prerequisites A and B are
-implemented and published to npm, in addition to spec 1150 (done).** Part 01
-(bootstrap + infrastructure) is the only part that can land without A/B; every
-part from 03 onward needs `fit-terrain build` to run externally (A) and the
-prose tables to exist (B). Approval recommendation: hold this plan in `plan
-approved` state until both prerequisite specs show `plan implemented` in
-`wiki/STATUS.md` and their npm releases are live; route `kata-implement` only
-after both signals flip.
+**Prerequisites A and B are implemented and published to npm** (they ship in
+`fit-terrain` 0.1.41 and later), in addition to spec 1150 (done). The plan is
+unblocked end to end; every part from 03 onward relies on `fit-terrain build`
+running externally (A) and the prose tables existing (B), both satisfied by
+the pinned devDependency.
 
 ## Part Index
 
 | Part | Title | Scope | Depends on |
 | --- | --- | --- | --- |
-| [01](plan-a-01.md) | Repo bootstrap + infrastructure | Repo skeleton via the **monorepo-setup skill**, then layered: `package.json`/`.gitignore`/CI extensions (+ `libterrain`/`map` devDeps), `docker-compose.yml`, all `infrastructure/{service}/` dirs, Kong config, `setup.sh` skeleton | A |
+| [01](plan-a-01.md) | Repo bootstrap + infrastructure | Repo skeleton via the **monorepo-setup skill**, then layered: `package.json`/`.gitignore`/CI extensions (+ the `fit-terrain` devDep), `docker-compose.yml`, all `infrastructure/{service}/` dirs, Kong config, `setup.sh` skeleton | A |
 | [02](plan-a-02.md) | Schema + RLS + interest_signals migration | Hand-written migration for `interest_signals`, RLS policies (prose tables get `public_read` from terrain), schema verification | 01 |
 | [03](plan-a-03.md) | Data pipeline (r3) | vendored `story.dsl` + `prose-cache.json` verbatim + `PROVENANCE.md`; `scripts/build-seed.sh` runs `fit-terrain build --output-root`; `setup.sh` data steps | 01, 02, prereqs A+B, spec 1150 |
 | [04](plan-a-04.md) | Edge functions | `embed-seed`, `eligibility-check`, `notify-updates`, `sync-listings` under `services/polaris-functions/` | 03 |
@@ -102,25 +99,18 @@ freezeInvocationContext), `@forwardimpact/libui` (createBoundRouter, render,
 components, freezeInvocationContext), `@forwardimpact/libformat`
 (createHtmlFormatter, createTerminalFormatter), `@forwardimpact/libtemplate`
 (createTemplateLoader), `@forwardimpact/librepl` (Repl). Build-time only:
-`@forwardimpact/libterrain` (`fit-terrain build --output-root`; schema
-resolution ships via its `libskill` dependency) — invoked by `setup.sh` and
-the `build-seed` script, never imported by a surface.
+`fit-terrain` (`fit-terrain build --output-root`; schema resolution ships
+via its `libskill` dependency) — invoked by `setup.sh` and the `build-seed`
+script, never imported by a surface.
 
 ## Risks
 
-- **Prerequisites A and B are not yet specced or published.** This is the
-  gating risk. r3 deliberately depends on `fit-terrain` running externally
-  (A) and emitting prose tables (B); neither exists today. If either slips,
-  this plan cannot start past part 01. Mitigation: the two prerequisites are
-  small, well-scoped library changes (design § Prerequisite library changes
-  lists the exact files and line ranges). They must be specced, implemented,
-  and published as an `@forwardimpact/libterrain` (+`libsyntheticrender`,
-  `libsyntheticgen`, `map`) release train before `kata-implement` is routed
-  here. Part 03 pins the exact npm versions that carry them. **Fallback:** if
-  A/B cannot ship, revert to r2's vendor-the-rendered-SQL pipeline (preserved
-  in git history) — the app loses local regeneration and the prose surfaces,
-  but still boots. That fallback is a different spec revision, not a silent
-  degrade.
+- **Building against a `fit-terrain` that predates prerequisites A and B.**
+  Both prerequisites are implemented and published (`fit-terrain` 0.1.41+),
+  so the residual risk is version drift: an implementer resolving an older
+  version loses external execution (A) or the prose tables (B). Part 01 pins
+  the devDependency and part 03 verifies the pinned version carries
+  `--output-root` and the prose seed tables before proceeding.
 - **`fit-terrain build` deleting `products/polaris/`.** Without
   `--output-root`, the write sink `rm -rf`s the first two path segments of
   each output path (`sinks.js` `writeFiles` ~262–285), i.e. `products/polaris`
@@ -132,7 +122,7 @@ the `build-seed` script, never imported by a surface.
   the monorepo at the provenance SHA reproduces the same bytes.
 - **Prose tables are silently dropped if prerequisite B is missing at
   build time.** `render-sql.js` ignores unknown entities in the output
-  block's `entities[]` (no error). If part 03 runs against a `libterrain`
+  block's `entities[]` (no error). If part 03 runs against a `fit-terrain`
   that predates B, the six prose tables simply will not appear and parts
   05/07 prose surfaces will 404 on empty tables. Part 03 step 1 asserts the
   prose tables are present in the build output before proceeding, and part 08
@@ -152,16 +142,14 @@ the `build-seed` script, never imported by a surface.
   `CREATE UNIQUE INDEX condition_embeddings_condition_id_uidx ON
   condition_embeddings(condition_id)` so PostgREST `on_conflict` upsert
   works in `embed-seed`.
-- **Forward Impact library versions** are pinned at panel-review time
-  (libcli 0.1.12, libui 1.3.0, libformat 0.1.18, libtemplate 0.2.12,
-  librepl 0.1.14). Patches may publish between approval and
-  implementation; part 01's PR description must record the resolved
-  versions. libui already crossed a minor (1.2 → 1.3) between plan-write
-  and panel review, and any further minor (or major) bump on any of the
-  five requires a breaking-change scan recorded in the part-01 PR — the
-  scan reads the relevant `CHANGELOG.md` and confirms the symbols
-  imported by plan-a-06 (CLI) and plan-a-07 (web) still behave as the
-  plan assumes.
+- **Forward Impact library versions** are pinned at the last reference pass
+  (libcli 0.1.17, libui 1.4.1, libformat 0.1.21, libtemplate 0.2.14,
+  librepl 0.1.16). Patches may publish between passes; part 01's PR
+  description must record the resolved versions. Any minor (or major) bump
+  on any of the five requires a breaking-change scan recorded in the
+  part-01 PR — the scan reads the relevant `CHANGELOG.md` and confirms the
+  symbols imported by plan-a-06 (CLI) and plan-a-07 (web) still behave as
+  the plan assumes.
 - **Postgres extension surface.** The plan uses `pgvector`, `pg_cron`,
   `pg_net`, `pgjwt`, `pgsodium`, `pgaudit`, `pgcrypto`, `uuid-ossp`. Only
   `supabase/postgres` ships all of these in one image. Part 01 step 6

--- a/references/bionova-apps/spec.md
+++ b/references/bionova-apps/spec.md
@@ -93,7 +93,7 @@ with pgvector for data and semantic search. PostgREST for auto-generated REST
 API. GoTrue for auth. HuggingFace TEI for embeddings. Supabase Edge Functions
 for eligibility scoring and embedding generation. Next.js App Router with
 Tailwind and shadcn/ui for the frontend. Forward Impact shared libraries from
-npm. `@forwardimpact/libterrain` from npm provides the synthetic-data build.
+npm. The `fit-terrain` package from npm provides the synthetic-data build.
 
 ### Data seeding
 
@@ -144,10 +144,13 @@ calls.
 
 ## Prerequisites
 
-These capabilities do not exist today and must ship before this spec can be
-implemented. Each needs its own spec, design, and plan.
+These capabilities were missing when the spec was first written and gated
+implementation. All have since shipped: the published `fit-terrain` package
+(0.1.41 and later) carries items 1 and 2, so a fresh build needs no
+unreleased code.
 
-1. **External `fit-terrain` execution.** `fit-terrain` hardcodes monorepo
+1. **External `fit-terrain` execution** (implemented — ships in
+   `fit-terrain` on npm). `fit-terrain` hardcodes monorepo
    paths: it writes output relative to the resolved project root and would
    `rm -rf` `products/polaris/` (the app code) in an external repo. It needs an
    `--output-root` flag so output renders into a disposable build directory
@@ -156,7 +159,8 @@ implemented. Each needs its own spec, design, and plan.
    hard dependency of `libterrain` — so `--schema-dir` resolves it by default
    and the verbatim DSL's `standard {}` block renders with no extra package.
    `--story` and `--cache` overrides already exist.
-2. **Prose entities rendered to SQL.** The clinical `content {}` block already
+2. **Prose entities rendered to SQL** (implemented — ships in the same
+   `fit-terrain` release). The clinical `content {}` block already
    generates condition explainers, trial FAQs, consent summaries, site
    descriptions, patient stories, and therapy descriptions into the prose
    cache, but the pipeline materializes them only as text fields on HTML


### PR DESCRIPTION
Fixes the version skew that breaks every consumer of the published kata-agent and kata-interview actions since the Gemba release.

The published kata-agent v1.0.7 mixes generations: its pinned internal bootstrap (v1.0.12) installs the old `fit-*` gear binaries, while its wiki steps track the floating `forwardimpact/wiki@v1` tag, which now invokes `gemba-wiki`. Every run fails the wiki refresh and push steps with `gemba-wiki: command not found` — live evidence in bionova-apps: https://github.com/forwardimpact/bionova-apps/actions/runs/29894048289/job/88840356518. kata-interview v1.0.0 carries the same skew.

Changes to both actions:

- bootstrap pin: v1.0.12 → v1.0.18 (`a5d9098c`)
- harness pin: v1.0.3 → v1.0.4 (`f1943c61`)
- `clis:` input and the cost/scan-logs commands: `fit-wiki fit-harness fit-trace` → `gemba-wiki gemba-harness gemba-trace` (`fit-terrain` keeps its name)
- comments updated to match

The branch also carries one docs commit reconciling `references/bionova-apps` with the current tooling (fit-terrain 0.1.41 pins, per-concern check workflows, current library versions), from the same workstream.

Release steps after merge (`Publish: Actions` fires automatically on this path):

1. Dispatch `Release: Tag` with `repo: kata-agent`, `tags: v1.0.8`.
2. Dispatch `Release: Tag` with `repo: kata-interview`, `tags: v1.0.1`.
3. Bump the pins in bionova-apps workflows to the new tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdE8eQkxfCLnB4Pmkxo4xN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdE8eQkxfCLnB4Pmkxo4xN)_