### PR TITLE
design(2270): benchmark trace parity — one trace pipeline for both drivers

### DIFF
--- a/specs/2270-benchmark-trace-parity/design-a.md
+++ b/specs/2270-benchmark-trace-parity/design-a.md
@@ -7,21 +7,22 @@ with cell identity taking the place of the matrix case.
 ## Architecture
 
 One trace pipeline, two drivers. The harness action drives it per workflow
-run; the benchmark runner drives it per cell. Both converge on the same three
-contracts: the file-naming convention, the shared split implementation, and
-the `trace--*` workflow-artifact shape that `gemba-trace` discovery reads.
+run; the benchmark runner drives it per cell. Both converge on three shared
+contracts: the identity grammar (one module), the split implementation (one
+module), and the `trace--*` workflow-artifact shape `gemba-trace` discovery
+reads.
 
 ```mermaid
 flowchart LR
-  subgraph cell["Benchmark cell (runs/&lt;slug&gt;/&lt;idx&gt;/)"]
+  subgraph cell["Benchmark cell (runs/&lt;taskId&gt;/&lt;idx&gt;/)"]
     SUP[Supervisor session] -->|redacted envelopes| RAW["trace--&lt;case&gt;.raw.ndjson (kept)"]
     RAW --> SPLIT[shared split module]
     SPLIT --> A["trace--&lt;case&gt;--agent.agent.ndjson"]
     SPLIT --> S["trace--&lt;case&gt;--supervisor.supervisor.ndjson"]
-    RAW -->|one read| SUM["cost + turns + submission"]
+    RAW -->|one read| SUM["raw-summary: cost + turns + submission"]
     J[Judge session] -->|redacted envelopes| JT["trace--&lt;case&gt;--judge.judge.ndjson"]
   end
-  cell -->|"always() upload runs/**/trace--*.ndjson"| ART["artifact trace--&lt;scope&gt;"]
+  cell -->|"always() upload, root pinned at &lt;output&gt;"| ART["artifact trace--&lt;scope&gt;"]
   ART --> CLI["gemba-trace runs / find / download / analysis verbs"]
 ```
 
@@ -29,88 +30,86 @@ flowchart LR
 
 | Component | Location | Change |
 | --- | --- | --- |
-| Shared split module | `libraries/libharness/src/trace-split.js` (new) | Owns bucket parsing, source-to-role classification, and convention naming, extracted from `commands/trace.js`. Both consumers call it. |
-| `gemba-trace split` command | `libraries/libharness/src/commands/trace.js` | Keeps CLI concerns only (`--mode` validation, arg handling); delegates splitting to the shared module. |
+| Trace identity module | `libraries/libharness/src/trace-identity.js` (new) | Single owner of the identity grammar: builds case ids and lane filenames, and parses them back — `parseIdentity` moves here from `trace-multi.js`, `participantInNames` from `trace-github.js`; both re-import. |
+| Shared split module | `libraries/libharness/src/trace-split.js` (new) | Owns bucket parsing and source-to-role classification, extracted from `commands/trace.js`; async streaming over `runtime.fs` (the runner's idiom); an ensured-sources option creates empty lanes for sources that emitted nothing. |
+| `gemba-trace split` command | `libraries/libharness/src/commands/trace.js` | Keeps CLI concerns only (`--mode` validation, args); awaits the shared module. |
 | Benchmark private splitter | `libraries/libharness/src/benchmark/trace-split.js` | **Deleted.** |
-| Benchmark runner | `libraries/libharness/src/benchmark/runner.js` | Writes the combined stream to `trace--<case>.raw.ndjson`; removes the unlink; one post-session read derives cost, turns, and submission; calls the shared split module. |
-| Workdir manager | `libraries/libharness/src/benchmark/workdir.js` | Allocates convention-named trace paths from the cell's case identity; exposes `rawTracePath`. |
-| Task family loader | `libraries/libharness/src/benchmark/task-family.js` | Rejects task ids containing `--` at load (case-identity delimiter). |
-| Result record | `libraries/libharness/src/benchmark/result.js` | Trace-path fields become run-output-relative; adds required `rawTracePath` to both branches. |
-| Judge adapter | `libraries/libharness/src/benchmark/judge.js` | Unchanged mechanics; writes to the convention-named judge path. |
-| Discovery | `libraries/libharness/src/trace-github.js` | `listRuns` default pattern gains eval workflows; `downloadTrace` lists extracted members recursively; participant matching keys on basenames. |
-| Benchmark action | `products/gemba/actions/benchmark/action.yml` | `trace` input, `trace-dir` output, `always()` trace-artifact upload step. |
+| Raw-trace summary | `libraries/libharness/src/benchmark/raw-summary.js` (new) | One-pass read of the preserved raw trace: cost via `sumTraceCost`, turns (orchestrator summary), submission (last agent assistant text). |
+| Benchmark runner | `libraries/libharness/src/benchmark/runner.js` | Streams the session to `trace--<case>.raw.ndjson`; no unlink; calls the shared split (agent+supervisor ensured), then raw-summary. |
+| Workdir manager | `libraries/libharness/src/benchmark/workdir.js` | Allocates convention-named trace paths from the identity module; exposes `rawTracePath`. |
+| Task family loader | `libraries/libharness/src/benchmark/task-family.js` | Rejects task ids containing `--` or with a leading/trailing `-` at load (case-grammar integrity). |
+| Result record | `libraries/libharness/src/benchmark/result.js` | Trace-path fields become run-output-relative and are present only when the file exists; adds `rawTracePath`. |
+| Judge adapter | `libraries/libharness/src/benchmark/judge.js` | Writes to the convention-named judge path; docblock drops the `agent.ndjson` reference. |
+| Discovery | `libraries/libharness/src/trace-github.js` | `listRuns` default pattern gains eval/benchmark workflows; `downloadTrace` lists extracted members recursively; `findByKey` resolves keys by identity segment; `download` auto-converts only single-member artifacts. |
+| Benchmark action | `products/gemba/actions/benchmark/action.yml` | `trace` input, `trace-dir` output, manifest-anchored `always()` trace-artifact upload. |
 | Reusable workflow | `products/gemba/actions/benchmark/.github/workflows/benchmark.yml` | Forwards a `trace` input (default on) to the action; no other change. |
 
 ## Key Decisions
 
 | # | Decision | Choice | Rejected alternative |
 | --- | --- | --- | --- |
-| 1 | Case identity | `<taskId with "/"→"__">-r<runIndex>`; family load rejects task ids containing `--` | Shard- or family-qualified case: redundant — shards partition one grid, so (task, runIndex) is already grid- and shard-unique. Silently sanitizing `--` in ids: corrupts identity round-trip between record and filename. |
-| 2 | Judge lane | Participant `judge`, role `judge`: `trace--<case>--judge.judge.ndjson`, written directly by the judge session | Classifying the judge under the `agent` role: hides which lane judged, and `find <run> judge` could not resolve it by name. Identity parsing accepts any role token, so no parser change is needed. |
-| 3 | Judge file content | Keep the judge's enveloped `{source:"judge", seq, event}` stream as-is | Unwrapping to match split-lane shape: needs a second write pass; `TraceCollector.addLine` unwraps envelopes transparently, so both shapes are already native `gemba-trace` input. |
-| 4 | Split module home | New top-level `libharness/src/trace-split.js` | Importing from `commands/trace.js`: a runtime library importing a CLI command module inverts layering. A new package: both consumers live in libharness. |
-| 5 | Turns/submission survival | One post-session read of the preserved raw file yields `sumTraceCost` + turns (orchestrator summary) + submission (last agent assistant text) | A summary callback inside the shared splitter: re-entangles splitting with summarization — the exact coupling that caused the original divergence. |
-| 6 | Record trace paths | Run-output-relative (`runs/<slug>/<idx>/trace--…`); new required `rawTracePath` | Absolute paths: the dead-runner defect itself. Dropping the fields: breaks requirement 8 — a record must locate its cell's traces inside a downloaded artifact. |
-| 7 | Artifact granularity | One `trace--<scope>` artifact per shard, members keeping their `runs/<slug>/<idx>/` paths | Per-cell artifacts: grid × runs artifacts per run, noisy in the API and the UI; the dispatch-host shape (one artifact, convention-named members) is already what discovery supports. |
-| 8 | Nested artifact members | `downloadTrace` lists extracted files recursively (paths relative to the extract dir); participant matching keys on basenames | Flattening trace files into a staging dir before upload: loses the `runs/<slug>/<idx>/` structure the record's relative paths point into (requirement 8). |
-| 9 | `runs` default pattern | `"kata|agent|eval"` — eval workflows list by default | A benchmark-specific flag or pattern override: the spec forbids benchmark-specific invocation shapes. |
+| 1 | Case identity | `<taskId>-r<runIndex>`, built by the identity module; family load rejects ids containing `--` or edge hyphens, so the `--` delimiter and the terminal `-r<digits>` suffix parse unambiguously | A `/`→`__` slug mapping: task ids are single directory names (`task-family.js` discovery), so the rule can never fire. Shard- or family-qualified case: redundant — shards partition one grid, so (task, runIndex) is already grid- and shard-unique. |
+| 2 | Identity grammar home | One module builds and parses case ids and lane filenames; workdir, split, and discovery all import it | Leaving construction in workdir, validation in task-family, and parsing in trace-multi/trace-github: three files agreeing by convention is the drifted-copies pattern this spec retires. |
+| 3 | Judge lane | Participant `judge`, role `judge`: `trace--<case>--judge.judge.ndjson`, written directly by the judge session; `judge` joins the splitter's structural-role set so direct write and split classification are one rule | Classifying the judge under the `agent` role: hides which lane judged in every filename, and leaves the splitter emitting `judge.agent.ndjson` for judge-source envelopes — two role rules for one participant. |
+| 4 | Judge file content | Keep the judge's enveloped `{source:"judge", seq, event}` stream as-is (deliberate exception: every other `.<role>.ndjson` lane is unwrapped) | Unwrapping to match split-lane shape: needs a second write pass; `TraceCollector.addLine` unwraps envelopes transparently, so both shapes are already native `gemba-trace` input. |
+| 5 | Split module home | New top-level `libharness/src/trace-split.js` | Importing from `commands/trace.js`: a runtime library importing a CLI command module inverts layering. A new package: both consumers live in libharness. |
+| 6 | Turns/submission survival | Named module `benchmark/raw-summary.js`: one post-session read of the preserved raw file | A summary callback inside the shared splitter: re-entangles splitting with summarization — the exact coupling that caused the original divergence. Inlining in `runner.js`: the runner is already the largest benchmark module. |
+| 7 | Record trace paths | Run-output-relative; each field present only when its file exists (raw + ensured agent/supervisor lanes on executed cells; judge lane on judged cells; none on preflight failure) | Absolute paths: the dead-runner defect itself. Always-required fields (today's shape): preflight and judgeless records would reference files that never exist, failing spec criterion 8. |
+| 8 | Artifact granularity | One `trace--<scope>` artifact per shard; a manifest file written at the run-output root joins the upload set, pinning the archive root to `<output>` so members extract as `runs/<taskId>/<idx>/trace--*` — exactly the record's relative paths | Per-cell artifacts: grid × runs artifacts per run, noisy in API and UI. Glob-only upload: `upload-artifact` v4 roots the archive at the matched files' common ancestor, stripping `runs/` (or all structure for a single-cell shard), breaking record-path resolution. |
+| 9 | Nested artifact members | `downloadTrace` lists extracted files recursively (paths relative to the extract dir); name matching keys on basenames | Flattening trace files into a staging dir before upload: loses the `runs/<taskId>/<idx>/` structure the record's relative paths point into (requirement 8). |
+| 10 | Eval-run lane addressing | The `find`/`download` key resolves against member identity: exact basename, case segment, or participant segment (via the identity module); when several members match, the verb errors listing the matches so the caller narrows the key — mirroring the existing multi-artifact disambiguation | First-match on participant (today's `findByKey`): every eval cell emits the same `agent`/`supervisor`/`judge` participants, so it silently returns an arbitrary cell's lane. A benchmark-specific selector flag: the spec forbids benchmark-specific invocation shapes. |
+| 11 | `runs` default pattern | `"kata|agent|eval|benchmark"` — covers the eval workflows and benchmark-named callers; listing stays a name heuristic, while `find`/`download` stay run-id-keyed and name-independent | A benchmark-specific pattern override: same spec prohibition as decision 10. |
 
 ## Contracts
 
-### File naming (per cell, under `runs/<slug>/<runIndex>/`)
+### File naming (per cell, under `runs/<taskId>/<runIndex>/`)
 
 | File | Content |
 | --- | --- |
 | `trace--<case>.raw.ndjson` | Combined redacted envelope stream (agent, supervisor, orchestrator). Preserved for the life of the run output. |
-| `trace--<case>--agent.agent.ndjson` | Unwrapped agent events (shared split output). |
-| `trace--<case>--supervisor.supervisor.ndjson` | Unwrapped supervisor events (shared split output; orchestrator events stay raw-only, as on the harness path). |
-| `trace--<case>--judge.judge.ndjson` | Judge session's enveloped stream, written through the judge's redactor. |
+| `trace--<case>--agent.agent.ndjson` | Unwrapped agent events (shared split output; created empty if the source emitted nothing). |
+| `trace--<case>--supervisor.supervisor.ndjson` | Unwrapped supervisor events (ditto; orchestrator events stay raw-only, as on the harness path). |
+| `trace--<case>--judge.judge.ndjson` | Judge session's enveloped stream (decision 4), written through the judge's redactor; exists only on judged cells. |
 
-`case = <taskId slug>-r<runIndex>` (slug: `/` → `__`). The case string never
-contains `--`, so `parseIdentity` and `participantInNames` resolve case and
-participant from every name above with no parser change.
-
-### Shared split module
-
-`splitTraceFile(runtime, { input, caseId, outputDir })` → writes one
-`trace--<caseId>--<source>.<role>.ndjson` per valid envelope source and
-returns the written paths. Classification is the current CLI policy, moved
-verbatim: structural sources (`agent`, `supervisor`, `facilitator`) use their
-own name as participant and role; other valid sources classify as role
-`agent` with the source as participant; orchestrator events and invalid
-source names are dropped. The CLI command validates `--mode` (UX-only — the
-splitter is mode-independent) and delegates.
+Split filenames resolve case and participant through the identity module with
+no grammar change. The raw file carries case-only identity through the
+existing basename fallback — the same behaviour a harness raw trace has
+today (spec requirement 7).
 
 ### Benchmark action surface
 
 | Surface | Contract |
 | --- | --- |
-| `trace` input | Default `"true"`. Gates the artifact-upload step and the trace outputs only. Capture is unconditional in the runner — cost and judge depend on it. |
-| `trace-dir` output | Absolute path of `<output>/runs`; every trace file of the run sits beneath it at `<slug>/<idx>/trace--*`. Empty when `trace` is disabled. Mirrors the harness action's `trace-dir` at the contract level. |
-| Trace artifact | Uploaded under `always()`, path `<output>/runs/**/trace--*.ndjson`. Name: `trace--<artifact-name>` unsharded, `trace--<artifact-name>-shard-<shard-index>` sharded — collision-safe across shards and across matrix callers that set distinct `artifact-name`s. Run mode only. |
+| `trace` input | Default `"true"`. Gates the artifact-upload step and the trace outputs only. Capture is unconditional in the runner — cost and judge depend on it. (Deliberate asymmetry with the harness action's same-named input, which disables capture; there, nothing downstream needs the trace.) |
+| `trace-dir` output | Absolute path of `<output>/runs`; every trace file of the run sits beneath it at `<taskId>/<idx>/trace--*`. Empty when `trace` is disabled. Mirrors the harness action's `trace-dir` at the contract level. |
+| Trace artifact | Uploaded under `always()`, run mode only. Upload set: the exact-depth glob `<output>/runs/*/*/trace--*.ndjson` — never `**`, so files an agent plants inside its `cwd/` can't enter the evidence — plus `<output>/trace-manifest.txt`, the root anchor listing every member (its name misses the `trace--` prefix, so name-based matching ignores it). |
+| Artifact name | `trace--<artifact-name>` unsharded, `trace--<artifact-name>-shard-<shard-index>` sharded — collision-safe across shards and across matrix callers. The action fails fast if `artifact-name` contains `--` (delimiter integrity for name-based matching). The results artifact keeps its existing `benchmark-shard-<i>` scheme — pre-existing, out of scope; recorded here so the divergence is deliberate. |
 
 The reusable workflow forwards `trace` to each shard's action invocation, so
 eval workflows mint trace artifacts with no caller-side steps.
 
 ### Records and judge template
 
-Record fields `agentTracePath`, `supervisorTracePath`, `judgeTracePath`, and
-the new `rawTracePath` carry paths relative to the run output directory —
-valid inside a downloaded artifact and on the runner alike. The workdir
-handle keeps absolute paths for runtime consumers; the runner derives the
-relative form when assembling the record. `{{AGENT_TRACE_PATH}}` in the judge
-template resolves to the absolute convention-named agent lane at runtime, so
-templates change only if they hard-code old filenames (none do — they use the
-placeholder).
+Record fields `rawTracePath`, `agentTracePath`, `supervisorTracePath`, and
+`judgeTracePath` carry paths relative to the run output directory — valid on
+the runner and inside a downloaded artifact alike (decision 8 makes the
+extracted tree match). Presence follows decision 7. The workdir handle keeps
+absolute paths for runtime consumers; the runner derives the relative form
+when assembling the record. `{{AGENT_TRACE_PATH}}` in the judge template
+resolves to the absolute convention-named agent lane at runtime (the lane is
+ensured, so the path always exists when the judge runs); templates use the
+placeholder, so none change.
 
 ### Discovery and analysis
 
 `runs`, `find`, and `download` work on eval runs through the existing
-dispatch-host path: `trace--` artifact-name prefix plus member-filename
-matching. The only changes are the default workflow pattern (decision 9) and
-recursive member listing (decision 8). File-consuming verbs need no change:
-split lanes are unwrapped events, raw and judge files are enveloped streams,
-and `loadTrace` already accepts both.
+dispatch-host path — `trace--` artifact-name prefix plus member-name
+matching — with decisions 9–11 applied. `download`'s structured-JSON
+auto-convert applies only when the artifact carries exactly one `.ndjson`
+member; multi-member eval artifacts skip it rather than converting an
+arbitrary lane. File-consuming verbs need no change: split lanes are
+unwrapped events, raw and judge files are enveloped streams, and `loadTrace`
+already accepts both.
 
 ## Clean break (removed)
 
@@ -118,9 +117,11 @@ and `loadTrace` already accepts both.
   `splitAndSummarize` interface — the second split implementation.
 - The `.combined.ndjson` temp name and the read-once-then-unlink behaviour.
 - Bare per-cell filenames `agent.ndjson`, `supervisor.ndjson`,
-  `judge.ndjson` — removed from workdir allocation, tests, goldens, skills,
-  and the run-benchmark guide; no aliases.
+  `judge.ndjson` — removed from workdir allocation, docblocks, tests,
+  goldens, skills, and the run-benchmark guide; no aliases.
 - Absolute trace paths in result records.
+- `parseIdentity` and `participantInNames` as module-local policy in
+  `trace-multi.js` / `trace-github.js` — both move to the identity module.
 
 ## Redaction
 
@@ -131,12 +132,13 @@ the existing redactor (spec requirement 9).
 
 ## Tests and documentation
 
-Runner and workdir tests move to convention names; split unit tests cover the
-benchmark (supervise-shape) input through the shared module; identity-parsing
-tests cover emitted names across tasks × run indexes × shards; an action-level
-assertion reads `trace-dir` and lists convention-named files beneath it.
-`gemba-benchmark` and `gemba-trace` skills, the Prove Agent Changes guides
-(run-benchmark, run-eval, trace-analysis), and the benchmark action README
-document the eval trace contract: what a run preserves, the artifact shape,
-and the download-then-analyze flow. Help-text goldens refresh where the
-`runs` description changes.
+Coverage contracts: runner integration (preserved convention-named files per
+cell), shared-split units over the benchmark shape, identity round-trip units
+(build → parse across tasks × run indexes × shards, including the rejected id
+forms), record validation asserting referenced files exist, an action-level
+assertion reading `trace-dir` and listing convention-named files beneath it,
+and redaction assertions per § Redaction. Documentation: `gemba-benchmark`
+and `gemba-trace` skills, the Prove Agent Changes guides (run-benchmark,
+run-eval, trace-analysis), and the benchmark action README state the eval
+trace contract — what a run preserves, the artifact shape, and the
+download-then-analyze flow.

--- a/specs/2270-benchmark-trace-parity/design-a.md
+++ b/specs/2270-benchmark-trace-parity/design-a.md
@@ -1,0 +1,142 @@
+# Design 2270-a — Benchmark Trace Parity
+
+Architecture for [spec.md](spec.md): the benchmark stops owning trace policy.
+Capture, naming, splitting, and artifact upload follow the harness contract,
+with cell identity taking the place of the matrix case.
+
+## Architecture
+
+One trace pipeline, two drivers. The harness action drives it per workflow
+run; the benchmark runner drives it per cell. Both converge on the same three
+contracts: the file-naming convention, the shared split implementation, and
+the `trace--*` workflow-artifact shape that `gemba-trace` discovery reads.
+
+```mermaid
+flowchart LR
+  subgraph cell["Benchmark cell (runs/&lt;slug&gt;/&lt;idx&gt;/)"]
+    SUP[Supervisor session] -->|redacted envelopes| RAW["trace--&lt;case&gt;.raw.ndjson (kept)"]
+    RAW --> SPLIT[shared split module]
+    SPLIT --> A["trace--&lt;case&gt;--agent.agent.ndjson"]
+    SPLIT --> S["trace--&lt;case&gt;--supervisor.supervisor.ndjson"]
+    RAW -->|one read| SUM["cost + turns + submission"]
+    J[Judge session] -->|redacted envelopes| JT["trace--&lt;case&gt;--judge.judge.ndjson"]
+  end
+  cell -->|"always() upload runs/**/trace--*.ndjson"| ART["artifact trace--&lt;scope&gt;"]
+  ART --> CLI["gemba-trace runs / find / download / analysis verbs"]
+```
+
+## Components
+
+| Component | Location | Change |
+| --- | --- | --- |
+| Shared split module | `libraries/libharness/src/trace-split.js` (new) | Owns bucket parsing, source-to-role classification, and convention naming, extracted from `commands/trace.js`. Both consumers call it. |
+| `gemba-trace split` command | `libraries/libharness/src/commands/trace.js` | Keeps CLI concerns only (`--mode` validation, arg handling); delegates splitting to the shared module. |
+| Benchmark private splitter | `libraries/libharness/src/benchmark/trace-split.js` | **Deleted.** |
+| Benchmark runner | `libraries/libharness/src/benchmark/runner.js` | Writes the combined stream to `trace--<case>.raw.ndjson`; removes the unlink; one post-session read derives cost, turns, and submission; calls the shared split module. |
+| Workdir manager | `libraries/libharness/src/benchmark/workdir.js` | Allocates convention-named trace paths from the cell's case identity; exposes `rawTracePath`. |
+| Task family loader | `libraries/libharness/src/benchmark/task-family.js` | Rejects task ids containing `--` at load (case-identity delimiter). |
+| Result record | `libraries/libharness/src/benchmark/result.js` | Trace-path fields become run-output-relative; adds required `rawTracePath` to both branches. |
+| Judge adapter | `libraries/libharness/src/benchmark/judge.js` | Unchanged mechanics; writes to the convention-named judge path. |
+| Discovery | `libraries/libharness/src/trace-github.js` | `listRuns` default pattern gains eval workflows; `downloadTrace` lists extracted members recursively; participant matching keys on basenames. |
+| Benchmark action | `products/gemba/actions/benchmark/action.yml` | `trace` input, `trace-dir` output, `always()` trace-artifact upload step. |
+| Reusable workflow | `products/gemba/actions/benchmark/.github/workflows/benchmark.yml` | Forwards a `trace` input (default on) to the action; no other change. |
+
+## Key Decisions
+
+| # | Decision | Choice | Rejected alternative |
+| --- | --- | --- | --- |
+| 1 | Case identity | `<taskId with "/"→"__">-r<runIndex>`; family load rejects task ids containing `--` | Shard- or family-qualified case: redundant — shards partition one grid, so (task, runIndex) is already grid- and shard-unique. Silently sanitizing `--` in ids: corrupts identity round-trip between record and filename. |
+| 2 | Judge lane | Participant `judge`, role `judge`: `trace--<case>--judge.judge.ndjson`, written directly by the judge session | Classifying the judge under the `agent` role: hides which lane judged, and `find <run> judge` could not resolve it by name. Identity parsing accepts any role token, so no parser change is needed. |
+| 3 | Judge file content | Keep the judge's enveloped `{source:"judge", seq, event}` stream as-is | Unwrapping to match split-lane shape: needs a second write pass; `TraceCollector.addLine` unwraps envelopes transparently, so both shapes are already native `gemba-trace` input. |
+| 4 | Split module home | New top-level `libharness/src/trace-split.js` | Importing from `commands/trace.js`: a runtime library importing a CLI command module inverts layering. A new package: both consumers live in libharness. |
+| 5 | Turns/submission survival | One post-session read of the preserved raw file yields `sumTraceCost` + turns (orchestrator summary) + submission (last agent assistant text) | A summary callback inside the shared splitter: re-entangles splitting with summarization — the exact coupling that caused the original divergence. |
+| 6 | Record trace paths | Run-output-relative (`runs/<slug>/<idx>/trace--…`); new required `rawTracePath` | Absolute paths: the dead-runner defect itself. Dropping the fields: breaks requirement 8 — a record must locate its cell's traces inside a downloaded artifact. |
+| 7 | Artifact granularity | One `trace--<scope>` artifact per shard, members keeping their `runs/<slug>/<idx>/` paths | Per-cell artifacts: grid × runs artifacts per run, noisy in the API and the UI; the dispatch-host shape (one artifact, convention-named members) is already what discovery supports. |
+| 8 | Nested artifact members | `downloadTrace` lists extracted files recursively (paths relative to the extract dir); participant matching keys on basenames | Flattening trace files into a staging dir before upload: loses the `runs/<slug>/<idx>/` structure the record's relative paths point into (requirement 8). |
+| 9 | `runs` default pattern | `"kata|agent|eval"` — eval workflows list by default | A benchmark-specific flag or pattern override: the spec forbids benchmark-specific invocation shapes. |
+
+## Contracts
+
+### File naming (per cell, under `runs/<slug>/<runIndex>/`)
+
+| File | Content |
+| --- | --- |
+| `trace--<case>.raw.ndjson` | Combined redacted envelope stream (agent, supervisor, orchestrator). Preserved for the life of the run output. |
+| `trace--<case>--agent.agent.ndjson` | Unwrapped agent events (shared split output). |
+| `trace--<case>--supervisor.supervisor.ndjson` | Unwrapped supervisor events (shared split output; orchestrator events stay raw-only, as on the harness path). |
+| `trace--<case>--judge.judge.ndjson` | Judge session's enveloped stream, written through the judge's redactor. |
+
+`case = <taskId slug>-r<runIndex>` (slug: `/` → `__`). The case string never
+contains `--`, so `parseIdentity` and `participantInNames` resolve case and
+participant from every name above with no parser change.
+
+### Shared split module
+
+`splitTraceFile(runtime, { input, caseId, outputDir })` → writes one
+`trace--<caseId>--<source>.<role>.ndjson` per valid envelope source and
+returns the written paths. Classification is the current CLI policy, moved
+verbatim: structural sources (`agent`, `supervisor`, `facilitator`) use their
+own name as participant and role; other valid sources classify as role
+`agent` with the source as participant; orchestrator events and invalid
+source names are dropped. The CLI command validates `--mode` (UX-only — the
+splitter is mode-independent) and delegates.
+
+### Benchmark action surface
+
+| Surface | Contract |
+| --- | --- |
+| `trace` input | Default `"true"`. Gates the artifact-upload step and the trace outputs only. Capture is unconditional in the runner — cost and judge depend on it. |
+| `trace-dir` output | Absolute path of `<output>/runs`; every trace file of the run sits beneath it at `<slug>/<idx>/trace--*`. Empty when `trace` is disabled. Mirrors the harness action's `trace-dir` at the contract level. |
+| Trace artifact | Uploaded under `always()`, path `<output>/runs/**/trace--*.ndjson`. Name: `trace--<artifact-name>` unsharded, `trace--<artifact-name>-shard-<shard-index>` sharded — collision-safe across shards and across matrix callers that set distinct `artifact-name`s. Run mode only. |
+
+The reusable workflow forwards `trace` to each shard's action invocation, so
+eval workflows mint trace artifacts with no caller-side steps.
+
+### Records and judge template
+
+Record fields `agentTracePath`, `supervisorTracePath`, `judgeTracePath`, and
+the new `rawTracePath` carry paths relative to the run output directory —
+valid inside a downloaded artifact and on the runner alike. The workdir
+handle keeps absolute paths for runtime consumers; the runner derives the
+relative form when assembling the record. `{{AGENT_TRACE_PATH}}` in the judge
+template resolves to the absolute convention-named agent lane at runtime, so
+templates change only if they hard-code old filenames (none do — they use the
+placeholder).
+
+### Discovery and analysis
+
+`runs`, `find`, and `download` work on eval runs through the existing
+dispatch-host path: `trace--` artifact-name prefix plus member-filename
+matching. The only changes are the default workflow pattern (decision 9) and
+recursive member listing (decision 8). File-consuming verbs need no change:
+split lanes are unwrapped events, raw and judge files are enveloped streams,
+and `loadTrace` already accepts both.
+
+## Clean break (removed)
+
+- `libraries/libharness/src/benchmark/trace-split.js` and its
+  `splitAndSummarize` interface — the second split implementation.
+- The `.combined.ndjson` temp name and the read-once-then-unlink behaviour.
+- Bare per-cell filenames `agent.ndjson`, `supervisor.ndjson`,
+  `judge.ndjson` — removed from workdir allocation, tests, goldens, skills,
+  and the run-benchmark guide; no aliases.
+- Absolute trace paths in result records.
+
+## Redaction
+
+No new machinery. The preserved raw file is the supervisor's already-redacted
+output stream; the judge lane is written through the judge's redactor.
+Redaction pipeline tests extend to assert both preserved files pass through
+the existing redactor (spec requirement 9).
+
+## Tests and documentation
+
+Runner and workdir tests move to convention names; split unit tests cover the
+benchmark (supervise-shape) input through the shared module; identity-parsing
+tests cover emitted names across tasks × run indexes × shards; an action-level
+assertion reads `trace-dir` and lists convention-named files beneath it.
+`gemba-benchmark` and `gemba-trace` skills, the Prove Agent Changes guides
+(run-benchmark, run-eval, trace-analysis), and the benchmark action README
+document the eval trace contract: what a run preserves, the artifact shape,
+and the download-then-analyze flow. Help-text goldens refresh where the
+`runs` description changes.

--- a/specs/2270-benchmark-trace-parity/design-a.md
+++ b/specs/2270-benchmark-trace-parity/design-a.md
@@ -30,35 +30,36 @@ flowchart LR
 
 | Component | Location | Change |
 | --- | --- | --- |
-| Trace identity module | `libraries/libharness/src/trace-identity.js` (new) | Single owner of the identity grammar: builds case ids and lane filenames, and parses them back — `parseIdentity` moves here from `trace-multi.js`, `participantInNames` from `trace-github.js`; both re-import. |
-| Shared split module | `libraries/libharness/src/trace-split.js` (new) | Owns bucket parsing and source-to-role classification, extracted from `commands/trace.js`; async streaming over `runtime.fs` (the runner's idiom); an ensured-sources option creates empty lanes for sources that emitted nothing. |
-| `gemba-trace split` command | `libraries/libharness/src/commands/trace.js` | Keeps CLI concerns only (`--mode` validation, args); awaits the shared module. |
+| Trace identity module | `libraries/libharness/src/trace-identity.js` (new) | Single owner of the identity grammar: builds case ids and lane filenames, exports the task-id validity predicate, and parses names back — `parseIdentity` moves here from `trace-multi.js`, `participantInNames` from `trace-github.js`. The libharness `index.js` export re-points here; no re-export shims remain in the old homes. |
+| Shared split module | `libraries/libharness/src/trace-split.js` (new) | Owns bucket parsing and source-to-role classification, extracted from `commands/trace.js`; async streaming over `runtime.fs` (the runner's idiom). |
+| `gemba-trace split` command | `libraries/libharness/src/commands/trace.js` | `split` keeps CLI concerns only and awaits the shared module (`--mode` stays required-but-inert — a deliberate carry-forward; the harness action passes it and that surface is out of scope). `download`'s structured-JSON auto-convert narrows to single-`.ndjson`-member artifacts. |
 | Benchmark private splitter | `libraries/libharness/src/benchmark/trace-split.js` | **Deleted.** |
 | Raw-trace summary | `libraries/libharness/src/benchmark/raw-summary.js` (new) | One-pass read of the preserved raw trace: cost via `sumTraceCost`, turns (orchestrator summary), submission (last agent assistant text). |
-| Benchmark runner | `libraries/libharness/src/benchmark/runner.js` | Streams the session to `trace--<case>.raw.ndjson`; no unlink; calls the shared split (agent+supervisor ensured), then raw-summary. |
-| Workdir manager | `libraries/libharness/src/benchmark/workdir.js` | Allocates convention-named trace paths from the identity module; exposes `rawTracePath`. |
-| Task family loader | `libraries/libharness/src/benchmark/task-family.js` | Rejects task ids containing `--` or with a leading/trailing `-` at load (case-grammar integrity). |
+| Benchmark runner | `libraries/libharness/src/benchmark/runner.js` | Streams the session to `trace--<case>.raw.ndjson`; no unlink; calls the shared split, then raw-summary. |
+| Workdir manager | `libraries/libharness/src/benchmark/workdir.js` | Allocates convention-named trace paths from the identity module and materializes the raw and agent/supervisor lane files empty at allocation — every path that reaches the judge, including a pre-session agent failure, finds them on disk. Exposes `rawTracePath`. |
+| Task family loader | `libraries/libharness/src/benchmark/task-family.js` | Invokes the identity module's validity predicate at load — rejects task ids containing `--` or with a leading/trailing `-`; the rule itself lives in the identity module. |
 | Result record | `libraries/libharness/src/benchmark/result.js` | Trace-path fields become run-output-relative and are present only when the file exists; adds `rawTracePath`. |
-| Judge adapter | `libraries/libharness/src/benchmark/judge.js` | Writes to the convention-named judge path; docblock drops the `agent.ndjson` reference. |
-| Discovery | `libraries/libharness/src/trace-github.js` | `listRuns` default pattern gains eval/benchmark workflows; `downloadTrace` lists extracted members recursively; `findByKey` resolves keys by identity segment; `download` auto-converts only single-member artifacts. |
-| Benchmark action | `products/gemba/actions/benchmark/action.yml` | `trace` input, `trace-dir` output, manifest-anchored `always()` trace-artifact upload. |
+| Judge adapter | `libraries/libharness/src/benchmark/judge.js` | Writes to the convention-named judge path. |
+| Discovery | `libraries/libharness/src/trace-github.js` | `listRuns` default pattern gains eval/benchmark workflows; `downloadTrace` lists extracted members recursively; `findByKey` resolves keys by identity segment; `runMatchesParticipant` imports the identity module (matching rule unchanged). |
+| Benchmark action | `products/gemba/actions/benchmark/action.yml` | `trace` input, `trace-dir` output, `always()` trace-artifact upload; the resolve-paths step writes the manifest anchor before the run. |
 | Reusable workflow | `products/gemba/actions/benchmark/.github/workflows/benchmark.yml` | Forwards a `trace` input (default on) to the action; no other change. |
 
 ## Key Decisions
 
 | # | Decision | Choice | Rejected alternative |
 | --- | --- | --- | --- |
-| 1 | Case identity | `<taskId>-r<runIndex>`, built by the identity module; family load rejects ids containing `--` or edge hyphens, so the `--` delimiter and the terminal `-r<digits>` suffix parse unambiguously | A `/`→`__` slug mapping: task ids are single directory names (`task-family.js` discovery), so the rule can never fire. Shard- or family-qualified case: redundant — shards partition one grid, so (task, runIndex) is already grid- and shard-unique. |
-| 2 | Identity grammar home | One module builds and parses case ids and lane filenames; workdir, split, and discovery all import it | Leaving construction in workdir, validation in task-family, and parsing in trace-multi/trace-github: three files agreeing by convention is the drifted-copies pattern this spec retires. |
-| 3 | Judge lane | Participant `judge`, role `judge`: `trace--<case>--judge.judge.ndjson`, written directly by the judge session; `judge` joins the splitter's structural-role set so direct write and split classification are one rule | Classifying the judge under the `agent` role: hides which lane judged in every filename, and leaves the splitter emitting `judge.agent.ndjson` for judge-source envelopes — two role rules for one participant. |
-| 4 | Judge file content | Keep the judge's enveloped `{source:"judge", seq, event}` stream as-is (deliberate exception: every other `.<role>.ndjson` lane is unwrapped) | Unwrapping to match split-lane shape: needs a second write pass; `TraceCollector.addLine` unwraps envelopes transparently, so both shapes are already native `gemba-trace` input. |
+| 1 | Case identity | `<taskId>-r<runIndex>`, built by the identity module; the validity predicate rejects ids containing `--` or edge hyphens, so the `--` delimiter and the terminal `-r<digits>` suffix parse unambiguously | A `/`→`__` slug mapping: task ids are single directory names (`task-family.js` discovery), so the rule can never fire — the existing dead mapping is removed. Shard- or family-qualified case: redundant — shards partition one grid, so (task, runIndex) is already grid- and shard-unique. |
+| 2 | Identity grammar home | One module builds, validates, and parses case ids and lane filenames; workdir, task-family, split, and discovery all invoke it | Leaving construction in workdir, validation in task-family, and parsing in trace-multi/trace-github: files agreeing by convention is the drifted-copies pattern this spec retires. |
+| 3 | Judge lane | Participant `judge`, role `judge`: `trace--<case>--judge.judge.ndjson`, written directly by the judge session; `judge` joins the splitter's structural-role set so classification is one rule. No current producer feeds judge-source envelopes through split (the judge is its own session), so kata split output is provably unchanged | Classifying the judge under the `agent` role: hides which lane judged in every filename, and leaves the splitter emitting `judge.agent.ndjson` for judge-source envelopes — two role rules for one participant. |
+| 4 | Judge file content | Keep the judge's enveloped `{source:"judge", seq, event}` stream as-is — a deliberate exception to lanes-are-unwrapped, affordable because the judge lane has exactly one producer (decision 3) and `TraceCollector.addLine` unwraps envelopes transparently | Unwrapping to match split-lane shape: needs a second write pass for no consumer benefit — both shapes are already native `gemba-trace` input. |
 | 5 | Split module home | New top-level `libharness/src/trace-split.js` | Importing from `commands/trace.js`: a runtime library importing a CLI command module inverts layering. A new package: both consumers live in libharness. |
 | 6 | Turns/submission survival | Named module `benchmark/raw-summary.js`: one post-session read of the preserved raw file | A summary callback inside the shared splitter: re-entangles splitting with summarization — the exact coupling that caused the original divergence. Inlining in `runner.js`: the runner is already the largest benchmark module. |
-| 7 | Record trace paths | Run-output-relative; each field present only when its file exists (raw + ensured agent/supervisor lanes on executed cells; judge lane on judged cells; none on preflight failure) | Absolute paths: the dead-runner defect itself. Always-required fields (today's shape): preflight and judgeless records would reference files that never exist, failing spec criterion 8. |
-| 8 | Artifact granularity | One `trace--<scope>` artifact per shard; a manifest file written at the run-output root joins the upload set, pinning the archive root to `<output>` so members extract as `runs/<taskId>/<idx>/trace--*` — exactly the record's relative paths | Per-cell artifacts: grid × runs artifacts per run, noisy in API and UI. Glob-only upload: `upload-artifact` v4 roots the archive at the matched files' common ancestor, stripping `runs/` (or all structure for a single-cell shard), breaking record-path resolution. |
+| 7 | Record trace paths | Run-output-relative; each field present only when its file exists — raw and agent/supervisor lanes are materialized at workdir allocation (so present on every executed cell), the judge lane exists on judged cells, preflight-failure records carry none | Absolute paths: the dead-runner defect itself. Always-required fields (today's shape): preflight and judgeless records would reference files that never exist, failing spec criterion 8. Ensuring lanes in the post-session split: a pre-session throw skips the split while the judge still runs, leaving `{{AGENT_TRACE_PATH}}` dangling. |
+| 8 | Artifact granularity | One `trace--<scope>` artifact per shard; the action's resolve-paths step writes `<output>/trace-manifest.txt` (root anchor carrying family/shard metadata) before the run, so even a timed-out shard's `always()` upload is rooted at `<output>` and members extract as `runs/<taskId>/<idx>/trace--*` — exactly the record's relative paths | Per-cell artifacts: grid × runs artifacts per run, noisy in API and UI. Glob-only upload: `upload-artifact` v4 roots the archive at the matched files' common ancestor, stripping `runs/` (or all structure for a single-cell shard), breaking record-path resolution. Writing the manifest post-run: a killed shard would upload unanchored. |
 | 9 | Nested artifact members | `downloadTrace` lists extracted files recursively (paths relative to the extract dir); name matching keys on basenames | Flattening trace files into a staging dir before upload: loses the `runs/<taskId>/<idx>/` structure the record's relative paths point into (requirement 8). |
-| 10 | Eval-run lane addressing | The `find`/`download` key resolves against member identity: exact basename, case segment, or participant segment (via the identity module); when several members match, the verb errors listing the matches so the caller narrows the key — mirroring the existing multi-artifact disambiguation | First-match on participant (today's `findByKey`): every eval cell emits the same `agent`/`supervisor`/`judge` participants, so it silently returns an arbitrary cell's lane. A benchmark-specific selector flag: the spec forbids benchmark-specific invocation shapes. |
+| 10 | Eval-run lane addressing | The `find`/`download` key resolves against member identity: exact basename, case segment, or participant segment (via the identity module); several matches → error listing them so the caller narrows the key. This deliberately replaces silent first-match on kata dispatch runs too — an accuracy fix on the shared surface | First-match on participant (today's `findByKey`): every eval cell emits the same `agent`/`supervisor`/`judge` participants, so it silently returns an arbitrary cell's lane. A benchmark-specific selector flag: the spec forbids benchmark-specific invocation shapes. |
 | 11 | `runs` default pattern | `"kata|agent|eval|benchmark"` — covers the eval workflows and benchmark-named callers; listing stays a name heuristic, while `find`/`download` stay run-id-keyed and name-independent | A benchmark-specific pattern override: same spec prohibition as decision 10. |
+| 12 | `download` auto-convert | `structured.json` is produced only when the artifact carries exactly one `.ndjson` member. Deliberate cross-surface change: kata dispatch bundles are already multi-member, so they stop minting it — today's output converts an arbitrary first member, which is actively misleading | Keeping first-member conversion: arbitrary-lane output multiplied by grid × runs members. Converting every member: unbounded work for a side output no verb consumes. |
 
 ## Contracts
 
@@ -67,23 +68,23 @@ flowchart LR
 | File | Content |
 | --- | --- |
 | `trace--<case>.raw.ndjson` | Combined redacted envelope stream (agent, supervisor, orchestrator). Preserved for the life of the run output. |
-| `trace--<case>--agent.agent.ndjson` | Unwrapped agent events (shared split output; created empty if the source emitted nothing). |
+| `trace--<case>--agent.agent.ndjson` | Unwrapped agent events (shared split output over the pre-materialized lane). |
 | `trace--<case>--supervisor.supervisor.ndjson` | Unwrapped supervisor events (ditto; orchestrator events stay raw-only, as on the harness path). |
 | `trace--<case>--judge.judge.ndjson` | Judge session's enveloped stream (decision 4), written through the judge's redactor; exists only on judged cells. |
 
 Split filenames resolve case and participant through the identity module with
-no grammar change. The raw file carries case-only identity through the
-existing basename fallback — the same behaviour a harness raw trace has
-today (spec requirement 7).
+no grammar change. The raw file parses through the existing basename
+fallback — the same behaviour a harness raw trace has today (spec
+requirement 7).
 
 ### Benchmark action surface
 
 | Surface | Contract |
 | --- | --- |
-| `trace` input | Default `"true"`. Gates the artifact-upload step and the trace outputs only. Capture is unconditional in the runner — cost and judge depend on it. (Deliberate asymmetry with the harness action's same-named input, which disables capture; there, nothing downstream needs the trace.) |
+| `trace` input | Default `"true"`. Gates the artifact-upload step and the trace outputs only. Capture is unconditional in the runner — cost and judge depend on it (spec requirement 1). Deliberate asymmetry with the harness action's same-named input, which disables capture; both actions' READMEs state it. |
 | `trace-dir` output | Absolute path of `<output>/runs`; every trace file of the run sits beneath it at `<taskId>/<idx>/trace--*`. Empty when `trace` is disabled. Mirrors the harness action's `trace-dir` at the contract level. |
-| Trace artifact | Uploaded under `always()`, run mode only. Upload set: the exact-depth glob `<output>/runs/*/*/trace--*.ndjson` — never `**`, so files an agent plants inside its `cwd/` can't enter the evidence — plus `<output>/trace-manifest.txt`, the root anchor listing every member (its name misses the `trace--` prefix, so name-based matching ignores it). |
-| Artifact name | `trace--<artifact-name>` unsharded, `trace--<artifact-name>-shard-<shard-index>` sharded — collision-safe across shards and across matrix callers. The action fails fast if `artifact-name` contains `--` (delimiter integrity for name-based matching). The results artifact keeps its existing `benchmark-shard-<i>` scheme — pre-existing, out of scope; recorded here so the divergence is deliberate. |
+| Trace artifact | Uploaded under `always()`, run mode only. Upload set: the exact-depth glob `<output>/runs/*/*/trace--*.ndjson` — never `**`, so files an agent plants inside its `cwd/` can't enter the evidence — plus the pre-written `<output>/trace-manifest.txt` anchor (decision 8; its name misses the `trace--` prefix, so name-based matching ignores it). |
+| Artifact name | `trace--<artifact-name>` unsharded, `trace--<artifact-name>-shard-<shard-index>` sharded — collision-safe across shards and across matrix callers. The action fails fast if `artifact-name` contains `--` (delimiter integrity). The results artifact keeps its existing `benchmark-shard-<i>` scheme — pre-existing, out of scope; the divergence is deliberate and its unification is a follow-up spec candidate. |
 
 The reusable workflow forwards `trace` to each shard's action invocation, so
 eval workflows mint trace artifacts with no caller-side steps.
@@ -96,20 +97,17 @@ the runner and inside a downloaded artifact alike (decision 8 makes the
 extracted tree match). Presence follows decision 7. The workdir handle keeps
 absolute paths for runtime consumers; the runner derives the relative form
 when assembling the record. `{{AGENT_TRACE_PATH}}` in the judge template
-resolves to the absolute convention-named agent lane at runtime (the lane is
-ensured, so the path always exists when the judge runs); templates use the
-placeholder, so none change.
+resolves to the absolute convention-named agent lane, materialized before any
+session runs; templates use the placeholder, so none change.
 
 ### Discovery and analysis
 
 `runs`, `find`, and `download` work on eval runs through the existing
 dispatch-host path — `trace--` artifact-name prefix plus member-name
-matching — with decisions 9–11 applied. `download`'s structured-JSON
-auto-convert applies only when the artifact carries exactly one `.ndjson`
-member; multi-member eval artifacts skip it rather than converting an
-arbitrary lane. File-consuming verbs need no change: split lanes are
-unwrapped events, raw and judge files are enveloped streams, and `loadTrace`
-already accepts both.
+matching — with decisions 9–12 applied. File-consuming verbs need no change:
+split lanes are unwrapped events, raw and judge files are enveloped streams,
+and `loadTrace` already accepts both. `find`'s help text and goldens refresh
+for the generalized key.
 
 ## Clean break (removed)
 
@@ -119,9 +117,11 @@ already accepts both.
 - Bare per-cell filenames `agent.ndjson`, `supervisor.ndjson`,
   `judge.ndjson` — removed from workdir allocation, docblocks, tests,
   goldens, skills, and the run-benchmark guide; no aliases.
+- The dead `task.id.replace("/", "__")` slug mapping in `workdir.js`.
 - Absolute trace paths in result records.
 - `parseIdentity` and `participantInNames` as module-local policy in
-  `trace-multi.js` / `trace-github.js` — both move to the identity module.
+  `trace-multi.js` / `trace-github.js` — both move to the identity module;
+  the public export re-points and no alias stays behind.
 
 ## Redaction
 
@@ -139,6 +139,6 @@ forms), record validation asserting referenced files exist, an action-level
 assertion reading `trace-dir` and listing convention-named files beneath it,
 and redaction assertions per § Redaction. Documentation: `gemba-benchmark`
 and `gemba-trace` skills, the Prove Agent Changes guides (run-benchmark,
-run-eval, trace-analysis), and the benchmark action README state the eval
-trace contract — what a run preserves, the artifact shape, and the
-download-then-analyze flow.
+run-eval, trace-analysis), and both action READMEs state the eval trace
+contract — what a run preserves, the artifact shape, the trace-input
+asymmetry, and the download-then-analyze flow.


### PR DESCRIPTION
## Summary

Adds `specs/2270-benchmark-trace-parity/design-a.md` (144 lines) for the approved spec 2270. The benchmark stops owning any trace policy: capture, naming, splitting, and artifact upload follow the harness contract, with cell identity (`<taskId>-r<runIndex>`) taking the place of the matrix case.

Key architectural decisions (each with a rejected alternative in the design):

- **One identity grammar module** (`libharness/src/trace-identity.js`) builds, validates, and parses case ids and lane filenames; `parseIdentity` and `participantInNames` move there, and workdir, task-family, split, and discovery all invoke it.
- **One split implementation** (`libharness/src/trace-split.js`), extracted from the `gemba-trace split` command; the benchmark's private `splitAndSummarize` is deleted. Turns/submission survive via a named `raw-summary` module reading the preserved raw trace in one pass.
- **Preserved, convention-named per-cell files**: `trace--<case>.raw.ndjson` plus agent/supervisor/judge lanes; lanes are materialized at workdir allocation so failed cells keep coherent records and the judge template placeholder never dangles.
- **Manifest-anchored per-shard trace artifacts** (`trace--<artifact-name>[-shard-<i>]`): a pre-run manifest anchor pins the archive root so members extract exactly at the record's run-output-relative paths, including for timed-out shards uploaded under `always()`.
- **Native discovery**: `runs` default pattern gains `eval|benchmark`; `find`/`download` keys resolve by identity segment with a disambiguation error replacing silent first-match; `download` auto-convert narrows to single-member artifacts (kata-side effect recorded as deliberate).

Two clean review-panel rounds (3 technical + 3 devex each) completed; all blocker/high/medium findings addressed, dismissals recorded in the commit messages.

Approval is human-only: this PR should merge only once `wiki/STATUS.md` shows spec 2270 at `design approved`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7BTGAAGoNYdap5usi9qVq

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7BTGAAGoNYdap5usi9qVq)_