### PR TITLE
plan(2270): benchmark trace parity — one trace pipeline, five-file plan

### DIFF
--- a/specs/2270-benchmark-trace-parity/plan-a-01.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-01.md
@@ -163,11 +163,19 @@ Files: modified `products/gemba/bin/gemba-trace.js`,
   participant; ambiguous keys error with candidates).
 - `download`: description notes `structured.json` is produced only for
   single-`.ndjson`-member artifacts.
+- Examples block: the twelve examples that pass `structured.json` as the
+  input file switch to a convention-named `.ndjson` lane file — after the
+  narrowing, virtually every artifact is multi-member and the file the
+  examples reference is no longer produced.
+- Deliberate reading of decision 10's "`find`/`download` key": keyed
+  member resolution applies to `findByKey`; `download` keeps
+  artifact-level `--artifact` selection, matching design § Components and
+  § Discovery.
 - Refresh the help golden: lines 6–8 (runs/find/download descriptions),
   the usage column for `find <run-id> <key>`, and the examples block
-  (`find 27401632821 release-engineer` keeps working as a participant key
-  — reword its comment if one exists). The refresh is unconditional; the
-  examples block does surface in the golden.
+  (both the `find` example wording and the `structured.json`
+  replacements above). The refresh is unconditional; the examples block
+  does surface in the golden.
 
 Verification: `cd products/gemba && bun test test/golden.test.js`.
 

--- a/specs/2270-benchmark-trace-parity/plan-a-01.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-01.md
@@ -35,7 +35,10 @@ export function nameMatchesKey(name, key)
 
 `nameMatchesKey` derives case/participant via `parseIdentity` on the
 basename and reuses the `participantInNames` single-name check; no second
-grammar.
+grammar. `parseIdentity` (member filenames, regex) and
+`participantInNames` (also artifact names with no extension) keep their
+distinct shapes deliberately — one matches bare artifact names the other
+cannot — now colocated under one owner.
 
 Verification: `bun test libraries/libharness/test/trace-identity.test.js`
 (step 7).
@@ -58,7 +61,8 @@ Files: created `libraries/libharness/src/trace-split.js`.
  * event JSON, one per line.
  * Async streaming: runtime.fs.createReadStream + node:readline in,
  * runtime.fs.createWriteStream out (lazily opened per source).
- * @returns {Promise<string[]>} absolute paths written
+ * @returns {Promise<string[]>} paths written, resolved against outputDir
+ *   (absolute iff outputDir is absolute)
  */
 export async function splitTrace(runtime, inputPath, { caseId, outputDir })
 ```
@@ -83,15 +87,23 @@ Files: modified `libraries/libharness/src/commands/trace.js`.
   `--output-dir` default `dirname(file)`, `mkdirSync`; then
   `await splitTrace(runtime, file, { caseId, outputDir })`. Delete the
   local `parseBuckets`, `STRUCTURAL_ROLES`, and `VALID_SOURCE_NAME`.
-- `runDownloadCommand`: produce `structured.json` only when the extracted
-  artifact carries exactly one `.ndjson` member
-  (`files.filter((f) => f.endsWith(".ndjson")).length === 1`); the
-  multi-member case writes no `structured.json` (decision 12).
-- `runFindCommand`: positional renames to `key`
-  (`ctx.args.key`), matching step 6's CLI definition.
+- `runDownloadCommand`: extract the auto-convert decision into an exported
+  pure helper so it is unit-testable:
+
+  ```js
+  /** The single `.ndjson` member to auto-convert, or null when the
+   *  artifact carries zero or several (decision 12). */
+  export function structuredConvertTarget(files)
+  ```
+
+  The handler converts only when the helper returns a member; the
+  multi-member case writes no `structured.json`.
+- `runFindCommand`: positional renames to `key` (`ctx.args.key`), matching
+  step 6's CLI definition.
 
 Verification: `bun test libraries/libharness/test/trace-split.test.js
-libraries/libharness/test/trace-resolve-files.test.js`.
+libraries/libharness/test/trace-resolve-files.test.js` plus the
+`structuredConvertTarget` units in step 7.
 
 ## Step 4 — Re-point trace-multi at the identity module
 
@@ -113,21 +125,29 @@ Files: modified `libraries/libharness/src/trace-github.js`,
   `trace-github.js` (design § Clean break).
 - `listRuns`: default `pattern` becomes `"kata|agent|eval|benchmark"`
   (decision 11); update the JSDoc default note.
-- `downloadTrace`: list extracted members recursively — `await
-  fs.readdir(dir, { recursive: true, withFileTypes: true })`, keep regular
-  files only, return paths relative to `dir`, still excluding `*.zip`
-  (decision 9). Basename-level name matching stays with callers via the
-  identity module.
-- `findByKey(runId, key, opts)`: matrix branch unchanged (artifact name
-  `trace--<key>` via `participantInNames`). Dispatch branch: download each
-  `trace--*` artifact, collect every member with
-  `nameMatchesKey(basename(member), key)` across all artifacts; exactly
-  one match returns `{runId, participant: key, host: "dispatch", artifact,
-  path}`; zero matches keeps the existing not-found error; several matches
-  throw an error listing the matching member names so the caller narrows
-  the key (decision 10 — deliberately replaces silent first-match).
-- `runMatchesParticipant`: unchanged rule, now via the imported
-  `participantInNames`.
+- `downloadTrace`: list extracted members recursively via a new exported
+  helper `listExtractedFiles(runtime, dir)` — `fs.readdir(dir,
+  { recursive: true, withFileTypes: true })`, regular files only, paths
+  relative to `dir`, `*.zip` excluded (decision 9).
+- **Name matching keys on basenames at every member call site**
+  (decision 9): members are now nested relative paths
+  (`runs/<taskId>/<idx>/trace--*`), so `runMatchesParticipant` and
+  `findByKey` map member paths through `basename()` before
+  `participantInNames` / `nameMatchesKey` — otherwise `runs
+  --participant` would silently omit every eval run (the
+  `startsWith("trace--")` check never matches a nested path).
+- `findByKey(runId, key, opts)`: matrix branch keeps its artifact-name
+  match; the result field `participant` renames to `key` on both
+  branches (the generalized contract — the key may be a case or exact
+  filename). Dispatch branch: download each `trace--*` artifact, collect
+  every member with `nameMatchesKey(basename(member), key)` across all
+  artifacts; exactly one match returns `{runId, key, host: "dispatch",
+  artifact, path}`; zero matches keeps the existing not-found error;
+  several matches throw an error listing the matching member names so the
+  caller narrows the key (decision 10 — deliberately replaces silent
+  first-match).
+- `runMatchesParticipant`: matching rule unchanged, now via the imported
+  `participantInNames` over basenames.
 
 Verification: `bun test libraries/libharness/test/trace-github.test.js`.
 
@@ -143,9 +163,11 @@ Files: modified `products/gemba/bin/gemba-trace.js`,
   participant; ambiguous keys error with candidates).
 - `download`: description notes `structured.json` is produced only for
   single-`.ndjson`-member artifacts.
-- Refresh the help golden to match (`cases.json` runner regenerates or
-  hand-edit lines 6–8 and the examples block if `find` example needs the
-  key wording).
+- Refresh the help golden: lines 6–8 (runs/find/download descriptions),
+  the usage column for `find <run-id> <key>`, and the examples block
+  (`find 27401632821 release-engineer` keeps working as a participant key
+  — reword its comment if one exists). The refresh is unconditional; the
+  examples block does surface in the golden.
 
 Verification: `cd products/gemba && bun test test/golden.test.js`.
 
@@ -163,18 +185,27 @@ modified `libraries/libharness/test/trace-split.test.js`,
   from `trace-multi.test.js`; `participantInNames` cases moved from
   `trace-github.test.js`; `nameMatchesKey` for basename/case/participant
   keys and non-matches.
-- `trace-split.test.js`: retarget the split assertions at `splitTrace`
-  (async runtime seeded via `createMockFs`; fall back to
-  `test/real-runtime.js` + `mkdtemp` if the mock read stream does not
-  compose with readline); add judge-source envelopes classifying to
-  `trace--<case>--judge.judge.ndjson` (spec criterion 2's benchmark
-  shape); keep `runSplitCommand`-level tests for `--mode` validation and
-  `--case`/`--output-dir` defaults.
+- `trace-split.test.js`: retarget the split assertions at `splitTrace`.
+  `createMockFs().createReadStream` returns a real `Readable`
+  (`libmock/src/mock/fs.js:274`), so the mock composes with
+  `node:readline` — no real-fs fallback needed here. Add judge-source
+  envelopes classifying to `trace--<case>--judge.judge.ndjson` (spec
+  criterion 2's benchmark shape); keep `runSplitCommand`-level tests for
+  `--mode` validation and `--case`/`--output-dir` defaults.
 - `trace-github.test.js`: new default-pattern expectations (an
   `eval-kata`- or `benchmark`-named run matches); `findByKey` dispatch
-  cases — case-segment key, exact-basename key, ambiguity error listing
-  candidates; recursive member listing (a member under
-  `runs/task/0/`).
+  cases over nested member paths — participant key, case-segment key,
+  exact-basename key, ambiguity error listing candidates;
+  `runMatchesParticipant` confirms a lane from nested member paths.
+  libmock's `readdir` ignores `recursive: true`, so test
+  `listExtractedFiles` against the real-fs runtime
+  (`test/real-runtime.js` + `mkdtemp`) with a nested
+  `runs/task/0/trace--*` tree; the `findByKey`/`runMatchesParticipant`
+  tests keep stubbing `downloadTrace` with nested relative member paths,
+  which needs no recursive mock.
+- New units for `structuredConvertTarget`: single `.ndjson` member →
+  that member; zero or several → null (covers the deliberate
+  cross-surface `download` narrowing).
 - `trace-multi.test.js`: `parseIdentity` moves out; keep `compareTwo`
   identity-threading coverage against the imported function.
 

--- a/specs/2270-benchmark-trace-parity/plan-a-01.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-01.md
@@ -1,0 +1,181 @@
+# Plan 2270-a — Part 01: Shared trace core
+
+Identity grammar and split implementation become single-owner libharness
+modules; discovery and the `gemba-trace` CLI adopt them. Design refs:
+[design-a.md](design-a.md) §§ Components, Key Decisions 1–5 and 9–12.
+
+## Step 1 — Create the trace identity module
+
+One module owns building, validating, and parsing case ids and lane
+filenames.
+
+Files: created `libraries/libharness/src/trace-identity.js`.
+
+Exports:
+
+```js
+/** Task ids must not contain "--" or start/end with "-": the "--"
+ *  delimiter and the terminal "-r<digits>" suffix then parse unambiguously. */
+export function isValidTaskId(id) // boolean
+/** `<taskId>-r<runIndex>`; throws when isValidTaskId(taskId) is false
+ *  or runIndex is not a non-negative integer. */
+export function buildCaseId(taskId, runIndex)
+/** `trace--<caseId>.raw.ndjson` */
+export function rawTraceFilename(caseId)
+/** `trace--<caseId>--<participant>.<role>.ndjson` */
+export function laneFilename(caseId, participant, role)
+/** Moved verbatim from trace-multi.js (same regex, same fallback). */
+export function parseIdentity(file)
+/** Moved verbatim from trace-github.js (same segment-delimiter rule). */
+export function participantInNames(names, participant)
+/** Decision 10 key rule for one name: true when key equals the exact
+ *  basename, the parsed case segment, or the parsed participant segment. */
+export function nameMatchesKey(name, key)
+```
+
+`nameMatchesKey` derives case/participant via `parseIdentity` on the
+basename and reuses the `participantInNames` single-name check; no second
+grammar.
+
+Verification: `bun test libraries/libharness/test/trace-identity.test.js`
+(step 7).
+
+## Step 2 — Create the shared split module
+
+One split implementation serves both the CLI and the benchmark runner.
+
+Files: created `libraries/libharness/src/trace-split.js`.
+
+```js
+/**
+ * Split a combined `{source, seq, event}` NDJSON trace into per-source
+ * lane files named by laneFilename(caseId, source, role).
+ * Classification: sources in STRUCTURAL_ROLES ("agent", "supervisor",
+ * "facilitator", "judge") take their own name as role; any other valid
+ * source name classifies as role "agent" with the source as participant.
+ * Skips empty/malformed/non-envelope lines and orchestrator events;
+ * drops sources failing /^[a-z][a-z0-9-]*$/. Lane files carry unwrapped
+ * event JSON, one per line.
+ * Async streaming: runtime.fs.createReadStream + node:readline in,
+ * runtime.fs.createWriteStream out (lazily opened per source).
+ * @returns {Promise<string[]>} absolute paths written
+ */
+export async function splitTrace(runtime, inputPath, { caseId, outputDir })
+```
+
+The bucket-parsing and classification logic moves from
+`commands/trace.js` (`parseBuckets`, `STRUCTURAL_ROLES`,
+`VALID_SOURCE_NAME`); `judge` joins the structural-role set (decision 3 —
+no current producer feeds judge-source envelopes through split, so kata
+split output is unchanged).
+
+Verification: `bun test libraries/libharness/test/trace-split.test.js`
+(step 7).
+
+## Step 3 — Rewire the CLI split and download commands
+
+`split` keeps CLI concerns only; `download` narrows its auto-convert.
+
+Files: modified `libraries/libharness/src/commands/trace.js`.
+
+- `runSplitCommand`: keep input/`--mode` validation (`--mode` stays
+  required-but-inert per design), `--case` default `"default"`,
+  `--output-dir` default `dirname(file)`, `mkdirSync`; then
+  `await splitTrace(runtime, file, { caseId, outputDir })`. Delete the
+  local `parseBuckets`, `STRUCTURAL_ROLES`, and `VALID_SOURCE_NAME`.
+- `runDownloadCommand`: produce `structured.json` only when the extracted
+  artifact carries exactly one `.ndjson` member
+  (`files.filter((f) => f.endsWith(".ndjson")).length === 1`); the
+  multi-member case writes no `structured.json` (decision 12).
+- `runFindCommand`: positional renames to `key`
+  (`ctx.args.key`), matching step 6's CLI definition.
+
+Verification: `bun test libraries/libharness/test/trace-split.test.js
+libraries/libharness/test/trace-resolve-files.test.js`.
+
+## Step 4 — Re-point trace-multi at the identity module
+
+Files: modified `libraries/libharness/src/trace-multi.js`.
+
+- Delete the local `parseIdentity`; import it from `./trace-identity.js`
+  (used by `compareTwo`). No re-export from this module.
+
+Verification: `bun test libraries/libharness/test/trace-multi.test.js`.
+
+## Step 5 — Discovery: pattern, recursive listing, keyed find
+
+Files: modified `libraries/libharness/src/trace-github.js`,
+`libraries/libharness/src/index.js`.
+
+- Delete the local `participantInNames`; import `participantInNames` and
+  `nameMatchesKey` from `./trace-identity.js`. `index.js` re-points its
+  `participantInNames` export to `./trace-identity.js`; no alias stays in
+  `trace-github.js` (design § Clean break).
+- `listRuns`: default `pattern` becomes `"kata|agent|eval|benchmark"`
+  (decision 11); update the JSDoc default note.
+- `downloadTrace`: list extracted members recursively — `await
+  fs.readdir(dir, { recursive: true, withFileTypes: true })`, keep regular
+  files only, return paths relative to `dir`, still excluding `*.zip`
+  (decision 9). Basename-level name matching stays with callers via the
+  identity module.
+- `findByKey(runId, key, opts)`: matrix branch unchanged (artifact name
+  `trace--<key>` via `participantInNames`). Dispatch branch: download each
+  `trace--*` artifact, collect every member with
+  `nameMatchesKey(basename(member), key)` across all artifacts; exactly
+  one match returns `{runId, participant: key, host: "dispatch", artifact,
+  path}`; zero matches keeps the existing not-found error; several matches
+  throw an error listing the matching member names so the caller narrows
+  the key (decision 10 — deliberately replaces silent first-match).
+- `runMatchesParticipant`: unchanged rule, now via the imported
+  `participantInNames`.
+
+Verification: `bun test libraries/libharness/test/trace-github.test.js`.
+
+## Step 6 — gemba-trace CLI definition and goldens
+
+Files: modified `products/gemba/bin/gemba-trace.js`,
+`products/gemba/test/golden/gemba-trace/help.stdout.txt`.
+
+- `runs`: description default-pattern text →
+  `(default pattern: kata|agent|eval|benchmark)`.
+- `find`: `args: ["run-id", "key"]`, `argsUsage: "<run-id> <key>"`,
+  description generalized to keyed lane lookup (exact filename, case, or
+  participant; ambiguous keys error with candidates).
+- `download`: description notes `structured.json` is produced only for
+  single-`.ndjson`-member artifacts.
+- Refresh the help golden to match (`cases.json` runner regenerates or
+  hand-edit lines 6–8 and the examples block if `find` example needs the
+  key wording).
+
+Verification: `cd products/gemba && bun test test/golden.test.js`.
+
+## Step 7 — Tests for the shared core
+
+Files: created `libraries/libharness/test/trace-identity.test.js`;
+modified `libraries/libharness/test/trace-split.test.js`,
+`libraries/libharness/test/trace-multi.test.js`,
+`libraries/libharness/test/trace-github.test.js`.
+
+- `trace-identity.test.js`: build→parse round-trip across ≥2 task ids ×
+  ≥2 run indexes (spec criterion 4 — grid uniqueness of
+  `buildCaseId`); `isValidTaskId` rejects `a--b`, `-a`, `a-`, accepts
+  `a-b`; `buildCaseId` throws on invalid ids; `parseIdentity` cases moved
+  from `trace-multi.test.js`; `participantInNames` cases moved from
+  `trace-github.test.js`; `nameMatchesKey` for basename/case/participant
+  keys and non-matches.
+- `trace-split.test.js`: retarget the split assertions at `splitTrace`
+  (async runtime seeded via `createMockFs`; fall back to
+  `test/real-runtime.js` + `mkdtemp` if the mock read stream does not
+  compose with readline); add judge-source envelopes classifying to
+  `trace--<case>--judge.judge.ndjson` (spec criterion 2's benchmark
+  shape); keep `runSplitCommand`-level tests for `--mode` validation and
+  `--case`/`--output-dir` defaults.
+- `trace-github.test.js`: new default-pattern expectations (an
+  `eval-kata`- or `benchmark`-named run matches); `findByKey` dispatch
+  cases — case-segment key, exact-basename key, ambiguity error listing
+  candidates; recursive member listing (a member under
+  `runs/task/0/`).
+- `trace-multi.test.js`: `parseIdentity` moves out; keep `compareTwo`
+  identity-threading coverage against the imported function.
+
+Verification: `bun test libraries/libharness`.

--- a/specs/2270-benchmark-trace-parity/plan-a-02.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-02.md
@@ -25,6 +25,9 @@ In `WorkdirManager.start(task, runIndex)`:
   `supervisorTracePath = join(runDir, laneFilename(caseId, "supervisor",
   "supervisor"))`,
   `judgeTracePath = join(runDir, laneFilename(caseId, "judge", "judge"))`.
+  (The workdir names its fixed lanes; source-to-role *classification*
+  stays solely in the split module — these are different rules, not a
+  duplicate.)
 - Materialize the raw and agent/supervisor lane files empty at allocation
   (`await fs.writeFile(p, "")` for raw, agent, supervisor — not judge), so
   every path that reaches the judge, including a pre-session agent
@@ -58,8 +61,8 @@ if (!isValidTaskId(id)) {
 The rule itself lives in the identity module; this file only invokes the
 predicate.
 
-Verification: `bun test
-libraries/libharness/test/benchmark-task-family.integration.test.js`.
+Verification: loader-level rejection test added in step 8
+(`benchmark-task-family.integration.test.js`).
 
 ## Step 3 — Raw-trace summary module
 
@@ -84,41 +87,49 @@ export async function summarizeRawTrace(runtime, rawTracePath)
 Implementation: `runtime.fs.readFile` once, split lines, `sumTraceCost`
 for `{totalCostUsd, bySource}`, then one walk of the parsed lines for
 turns/submission. The `extractText` last-text-block helper moves here from
-the private splitter.
+the private splitter. An empty (materialized-stub) raw file yields zeros
+and an empty submission.
 
-Verification: unit test in step 8 asserts cost/turns/submission from a
-seeded envelope stream.
+Verification: `bun test
+libraries/libharness/test/benchmark-raw-summary.test.js` (step 8).
 
-## Step 4 — Runner: preserve the raw trace, shared split, summary
+## Step 4 — Runner: preserve the raw trace, shared pipeline
+
+Split and summary run on the runner's shared path so the test seam
+exercises the real pipeline.
 
 Files: modified `libraries/libharness/src/benchmark/runner.js`.
 
-In `#runAgent`:
-
-- Stream the supervisor session to `workdir.rawTracePath` (replaces the
-  `.combined.ndjson` temp path).
-- After the session settles:
+- `#runAgent` (default path): stream the supervisor session to
+  `workdir.rawTracePath` (replaces the `.combined.ndjson` temp path) and
+  return only `{agentError}`. Delete the whole-file `readFile` +
+  `sumTraceCost` block, the `fs.unlink`, and the `splitAndSummarize`
+  import; drop the now-unused direct `sumTraceCost` import.
+- `#runAgentSafe`: after either the hook or the default path settles
+  (including the catch branch), run the shared pipeline once:
   `await splitTrace(this.runtime, workdir.rawTracePath, { caseId:
   workdir.caseId, outputDir: workdir.runDir })` (import from
-  `../trace-split.js`), then
-  `const summary = await summarizeRawTrace(this.runtime,
-  workdir.rawTracePath)`.
-- Return `{turns, submission, costUsd, costBreakdown, agentError}` from
-  the summary. Delete the whole-file `readFile` + `sumTraceCost` block,
-  the `fs.unlink`, and the `splitAndSummarize` import; drop the now-unused
-  direct `sumTraceCost` import.
-
-In record assembly (`#executeCell`):
-
-- Trace-path fields become run-output-relative and presence-gated
-  (decision 7): for each of `rawTracePath`, `agentTracePath`,
-  `supervisorTracePath`, `judgeTracePath`, include
-  `relative(this.output, absPath)` only when the file exists
-  (`fs.access` check via a small helper). Raw and agent/supervisor lanes
-  are materialized at allocation, so they are present on every executed
-  cell; the judge lane appears only on judged cells.
-- `#buildPreflightFailureRecord`: delete the three trace-path fields —
-  preflight-failure records carry none.
+  `../trace-split.js`), then `const summary = await
+  summarizeRawTrace(this.runtime, workdir.rawTracePath)`; return
+  `{...summary, agentError}`. Cost, turns, and submission are always
+  derived from the raw file — the fabricated-return shape disappears.
+- **Seam contract change**: `opts.runAgent` narrows to "run the session,
+  stream `{source, seq, event}` envelopes to `workdir.rawTracePath`,
+  return `{agentError?}`". Update the constructor JSDoc
+  (`runner.js:79-83`), which still documents "write a valid NDJSON trace
+  to `workdir.agentTracePath`".
+- Record assembly (`#executeCell`): trace-path fields become
+  run-output-relative and presence-gated (decision 7): for each of
+  `rawTracePath`, `agentTracePath`, `supervisorTracePath`,
+  `judgeTracePath`, include `relative(this.output, absPath)` only when
+  the file exists (`fs.access` check via a small helper). Raw and
+  agent/supervisor lanes are materialized at allocation, so they are
+  present on every executed cell; the judge lane appears only on judged
+  cells.
+- `#buildPreflightFailureRecord`: delete the three trace-path fields,
+  with a comment stating that preflight-failure records carry no trace
+  paths even though the materialized stubs exist on disk (decision 7 —
+  the record references only traces a session produced).
 - Update the `#runAgent` docblock (no more `agent.ndjson` /
   `supervisor.ndjson` wording).
 
@@ -169,12 +180,17 @@ products` returns nothing.
 Files: modified
 `libraries/libharness/test/benchmark-workdir-start.integration.test.js`,
 `libraries/libharness/test/benchmark-workdir.integration.test.js`,
+`libraries/libharness/test/benchmark-task-family.integration.test.js`,
 `libraries/libharness/test/benchmark-e2e.integration.test.js`,
+`libraries/libharness/test/mock-runner.js`,
 `libraries/libharness/test/benchmark-runner-concurrency.test.js`,
 `libraries/libharness/test/benchmark-runner-score.test.js`,
 `libraries/libharness/test/benchmark-shard.test.js`,
 `libraries/libharness/test/benchmark-result.test.js`,
+`libraries/libharness/test/benchmark-report.test.js`,
+`libraries/libharness/test/benchmark-report-score.test.js`,
 `libraries/libharness/test/benchmark-judge.test.js`,
+`libraries/libharness/test/redaction-pipeline-producer.test.js`,
 `libraries/libharness/test/report-helpers.js`; created
 `libraries/libharness/test/benchmark-raw-summary.test.js`.
 
@@ -182,33 +198,45 @@ Files: modified
   `runs/<taskId>/<idx>/`; raw + agent/supervisor lanes exist empty after
   `start()`; judge lane path allocated but not materialized; handle
   carries `caseId`/`rawTracePath`; no `__` slug directory for any id.
+- Task-family test: a `tasks/bad--id/` directory makes `loadTaskFamily`
+  throw the invalid-task-id error (loader invokes the predicate).
 - `benchmark-raw-summary.test.js`: cost (multi-source result events),
   turns (orchestrator summary), submission (last agent assistant text),
-  and tolerance of malformed/blank lines.
+  zeros on an empty file, tolerance of malformed/blank lines.
+- **Seam rework**: `mockRunAgent` in the e2e (and any hook in
+  `mock-runner.js` / runner unit tests) switches to the new contract —
+  write `{source, seq, event}` envelopes to `workdir.rawTracePath`
+  (agent assistant + result events with `total_cost_usd`, orchestrator
+  summary event with turns) and return `{agentError?}`; the real
+  split/summary derives cost, turns, and submission. Add a shared
+  envelope-writing helper to `mock-runner.js` so the fixtures live once.
 - E2E: per-cell tree keeps `trace--<case>.raw.ndjson` plus both lanes
-  after the run — no deletion (spec criterion 1); record `costUsd` +
-  `costBreakdown` equal `sumTraceCost` over the preserved raw file (spec
-  criterion 3); records' trace paths are run-output-relative and every
-  referenced file exists under the output dir (spec criterion 8); the
-  existing "consumable by gemba-trace overview" test reads the new lane
-  path.
-- Runner unit tests (`concurrency`/`score`/`shard`): update fabricated
-  records/paths to the new shape; preflight-failure expectations drop
-  trace paths.
-- `benchmark-result.test.js` and `report-helpers.js`: convention-named,
-  run-output-relative fixture paths (e.g.
-  `runs/x/0/trace--x-r0--agent.agent.ndjson`), `rawTracePath` added;
-  preflight branch rejects trace-path fields.
+  after the run — no deletion, lanes non-empty (spec criterion 1);
+  criterion 3 assertion compares the record's agent+supervisor spend to
+  the raw file: `costBreakdown.agent`/`costBreakdown.supervisor` equal
+  `sumTraceCost(raw).bySource` and their sum equals
+  `sumTraceCost(raw).totalCostUsd` (record `costUsd` additionally folds
+  in judge cost, so it is *not* compared to the raw file); records' trace
+  paths are run-output-relative and every referenced file exists under
+  the output dir (spec criterion 8); the existing "consumable by
+  gemba-trace overview" test reads the new lane path.
+- Runner unit tests (`concurrency`/`score`/`shard`): hooks adopt the new
+  seam contract (envelope fixtures where cost/turns matter); preflight
+  expectations drop trace paths.
+- `benchmark-result.test.js`, `report-helpers.js`,
+  `benchmark-report.test.js`, `benchmark-report-score.test.js`:
+  convention-named, run-output-relative fixture paths (e.g.
+  `runs/x/0/trace--x-r0--agent.agent.ndjson`), `rawTracePath` added to
+  happy records; preflight fixtures drop trace-path fields (the report
+  suites fabricate records inline and would otherwise be schema-skipped).
 - `benchmark-judge.test.js`: assert the judge lane file at the convention
   path contains only redacted content — drive `runJudge` with a fake query
   emitting a sentinel env value and assert the written file carries the
   redaction placeholder (spec criterion 9, judge lane).
-- Raw-file redaction (spec criterion 9, kept raw trace): assert in the
-  supervisor-output/redaction-pipeline coverage that the bytes persisted
-  to a `trace--<case>.raw.ndjson` path are the redacted stream — extend
-  `libraries/libharness/test/redaction-pipeline-producer.test.js` with a
-  file-content assertion at the convention-named path (the persisted file
-  is the same `fileStream` the existing criterion-1 test observes).
+- `redaction-pipeline-producer.test.js` (spec criterion 9, kept raw
+  trace): extend with a file-content assertion at a convention-named
+  `trace--<case>.raw.ndjson` path — the persisted file is the same
+  redacted `fileStream` the existing criterion-1 test observes.
 
 Verification: `bun test libraries/libharness` green, plus the criterion-11
 sweep from [plan-a.md](plan-a.md) § Verification.

--- a/specs/2270-benchmark-trace-parity/plan-a-02.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-02.md
@@ -182,7 +182,6 @@ Files: modified
 `libraries/libharness/test/benchmark-workdir.integration.test.js`,
 `libraries/libharness/test/benchmark-task-family.integration.test.js`,
 `libraries/libharness/test/benchmark-e2e.integration.test.js`,
-`libraries/libharness/test/mock-runner.js`,
 `libraries/libharness/test/benchmark-runner-concurrency.test.js`,
 `libraries/libharness/test/benchmark-runner-score.test.js`,
 `libraries/libharness/test/benchmark-shard.test.js`,
@@ -192,7 +191,8 @@ Files: modified
 `libraries/libharness/test/benchmark-judge.test.js`,
 `libraries/libharness/test/redaction-pipeline-producer.test.js`,
 `libraries/libharness/test/report-helpers.js`; created
-`libraries/libharness/test/benchmark-raw-summary.test.js`.
+`libraries/libharness/test/benchmark-raw-summary.test.js`,
+`libraries/libharness/test/benchmark-trace-helpers.js`.
 
 - Workdir tests: paths follow the convention under
   `runs/<taskId>/<idx>/`; raw + agent/supervisor lanes exist empty after
@@ -203,23 +203,30 @@ Files: modified
 - `benchmark-raw-summary.test.js`: cost (multi-source result events),
   turns (orchestrator summary), submission (last agent assistant text),
   zeros on an empty file, tolerance of malformed/blank lines.
-- **Seam rework**: `mockRunAgent` in the e2e (and any hook in
-  `mock-runner.js` / runner unit tests) switches to the new contract —
-  write `{source, seq, event}` envelopes to `workdir.rawTracePath`
-  (agent assistant + result events with `total_cost_usd`, orchestrator
-  summary event with turns) and return `{agentError?}`; the real
-  split/summary derives cost, turns, and submission. Add a shared
-  envelope-writing helper to `mock-runner.js` so the fixtures live once.
+- **Seam rework**: every `runAgent` hook — `mockRunAgent` in the e2e and
+  the hooks in the `concurrency`/`score`/`shard` runner tests — switches
+  to the new contract: write `{source, seq, event}` envelopes to
+  `workdir.rawTracePath` (agent assistant + result events with
+  `total_cost_usd`, orchestrator summary event with turns) and return
+  `{agentError?}`; the real split/summary derives cost, turns, and
+  submission. The shared envelope-writing helper lives in the new
+  `benchmark-trace-helpers.js` (`mock-runner.js` is an AgentRunner mock
+  for orchestration tests — out of scope for benchmark fixtures).
 - E2E: per-cell tree keeps `trace--<case>.raw.ndjson` plus both lanes
   after the run — no deletion, lanes non-empty (spec criterion 1);
-  criterion 3 assertion compares the record's agent+supervisor spend to
-  the raw file: `costBreakdown.agent`/`costBreakdown.supervisor` equal
-  `sumTraceCost(raw).bySource` and their sum equals
-  `sumTraceCost(raw).totalCostUsd` (record `costUsd` additionally folds
-  in judge cost, so it is *not* compared to the raw file); records' trace
-  paths are run-output-relative and every referenced file exists under
-  the output dir (spec criterion 8); the existing "consumable by
-  gemba-trace overview" test reads the new lane path.
+  criterion 3 asserts CLI parity as the spec's verification column
+  states: invoke the `cost` verb handler (`runCostCommand`, in-process
+  with a captured-stdout runtime) over the preserved raw file and assert
+  its `bySource.agent`/`bySource.supervisor` equal the record's
+  `costBreakdown` and their sum its `totalCostUsd` (record `costUsd`
+  additionally folds in judge cost, so it is *not* compared to the raw
+  file); records' trace paths are run-output-relative and every
+  referenced file exists under the output dir (spec criterion 8).
+  Existing assertions that treat record paths as absolute — `dirname` on
+  `agentTracePath` and direct `readFile` of it — must join the path
+  against the output dir first, and the shared `before` hook must keep
+  the output dir in scope. The existing "consumable by gemba-trace
+  overview" test reads the new lane path.
 - Runner unit tests (`concurrency`/`score`/`shard`): hooks adopt the new
   seam contract (envelope fixtures where cost/turns matter); preflight
   expectations drop trace paths.

--- a/specs/2270-benchmark-trace-parity/plan-a-02.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-02.md
@@ -1,0 +1,214 @@
+# Plan 2270-a — Part 02: Benchmark runtime pipeline
+
+The benchmark runner adopts the shared modules from part 01: convention
+paths, preserved raw traces, one-pass summary, relative record paths, and
+the private splitter's deletion. Design refs: [design-a.md](design-a.md)
+§§ Components, Key Decisions 1 and 6–7, Contracts § File naming and
+§ Records and judge template.
+
+Depends on part 01 (imports `trace-identity.js` and `trace-split.js`).
+
+## Step 1 — Workdir: convention paths, lane materialization
+
+Files: modified `libraries/libharness/src/benchmark/workdir.js`.
+
+In `WorkdirManager.start(task, runIndex)`:
+
+- Delete the `task.id.replace("/", "__")` slug mapping (dead — task ids
+  are single directory names); `runDir = join(this.runOutputDir, "runs",
+  task.id, String(runIndex))`.
+- `const caseId = buildCaseId(task.id, runIndex)` (import from
+  `../trace-identity.js`).
+- Allocate convention paths in `runDir`:
+  `rawTracePath = join(runDir, rawTraceFilename(caseId))`,
+  `agentTracePath = join(runDir, laneFilename(caseId, "agent", "agent"))`,
+  `supervisorTracePath = join(runDir, laneFilename(caseId, "supervisor",
+  "supervisor"))`,
+  `judgeTracePath = join(runDir, laneFilename(caseId, "judge", "judge"))`.
+- Materialize the raw and agent/supervisor lane files empty at allocation
+  (`await fs.writeFile(p, "")` for raw, agent, supervisor — not judge), so
+  every path that reaches the judge, including a pre-session agent
+  failure, finds them on disk (decision 7).
+- Return `caseId` and `rawTracePath` on the handle; extend the `Workdir`
+  typedef with both. Paths on the handle stay absolute (runtime
+  consumers).
+
+Deleted: bare `agent.ndjson`/`supervisor.ndjson`/`judge.ndjson`
+allocation lines and the slug mapping.
+
+Verification: `bun test
+libraries/libharness/test/benchmark-workdir-start.integration.test.js
+libraries/libharness/test/benchmark-workdir.integration.test.js`
+(updated in step 8).
+
+## Step 2 — Task-family: validate ids at load
+
+Files: modified `libraries/libharness/src/benchmark/task-family.js`.
+
+In `loadTask` (or `discoverTasks` before pushing), reject invalid ids:
+
+```js
+if (!isValidTaskId(id)) {
+  throw new Error(
+    `invalid task id '${id}': task directory names must not contain "--" or start/end with "-"`,
+  );
+}
+```
+
+The rule itself lives in the identity module; this file only invokes the
+predicate.
+
+Verification: `bun test
+libraries/libharness/test/benchmark-task-family.integration.test.js`.
+
+## Step 3 — Raw-trace summary module
+
+One post-session read of the preserved raw file replaces
+split-and-summarize coupling (decision 6).
+
+Files: created `libraries/libharness/src/benchmark/raw-summary.js`.
+
+```js
+/**
+ * One read of the preserved raw combined trace:
+ *   cost      — sumTraceCost over the lines (the one cost path),
+ *   turns     — last orchestrator-source `summary` event's `turns`,
+ *   submission— last agent-source assistant text block.
+ * @returns {Promise<{costUsd: number,
+ *   costBreakdown: {agent: number, supervisor: number},
+ *   turns: number, submission: string}>}
+ */
+export async function summarizeRawTrace(runtime, rawTracePath)
+```
+
+Implementation: `runtime.fs.readFile` once, split lines, `sumTraceCost`
+for `{totalCostUsd, bySource}`, then one walk of the parsed lines for
+turns/submission. The `extractText` last-text-block helper moves here from
+the private splitter.
+
+Verification: unit test in step 8 asserts cost/turns/submission from a
+seeded envelope stream.
+
+## Step 4 — Runner: preserve the raw trace, shared split, summary
+
+Files: modified `libraries/libharness/src/benchmark/runner.js`.
+
+In `#runAgent`:
+
+- Stream the supervisor session to `workdir.rawTracePath` (replaces the
+  `.combined.ndjson` temp path).
+- After the session settles:
+  `await splitTrace(this.runtime, workdir.rawTracePath, { caseId:
+  workdir.caseId, outputDir: workdir.runDir })` (import from
+  `../trace-split.js`), then
+  `const summary = await summarizeRawTrace(this.runtime,
+  workdir.rawTracePath)`.
+- Return `{turns, submission, costUsd, costBreakdown, agentError}` from
+  the summary. Delete the whole-file `readFile` + `sumTraceCost` block,
+  the `fs.unlink`, and the `splitAndSummarize` import; drop the now-unused
+  direct `sumTraceCost` import.
+
+In record assembly (`#executeCell`):
+
+- Trace-path fields become run-output-relative and presence-gated
+  (decision 7): for each of `rawTracePath`, `agentTracePath`,
+  `supervisorTracePath`, `judgeTracePath`, include
+  `relative(this.output, absPath)` only when the file exists
+  (`fs.access` check via a small helper). Raw and agent/supervisor lanes
+  are materialized at allocation, so they are present on every executed
+  cell; the judge lane appears only on judged cells.
+- `#buildPreflightFailureRecord`: delete the three trace-path fields —
+  preflight-failure records carry none.
+- Update the `#runAgent` docblock (no more `agent.ndjson` /
+  `supervisor.ndjson` wording).
+
+Verification: `bun test
+libraries/libharness/test/benchmark-e2e.integration.test.js` (updated in
+step 8).
+
+## Step 5 — Result schema: relative, presence-gated paths
+
+Files: modified `libraries/libharness/src/benchmark/result.js`.
+
+- `HAPPY_RECORD`: add `rawTracePath: z.string()`; keep `agentTracePath`
+  and `supervisorTracePath` required strings; `judgeTracePath` becomes
+  `z.string().optional()`. Comment states paths are relative to the run
+  output directory.
+- `PREFLIGHT_RECORD`: replace the three required trace-path fields with
+  `z.undefined().optional()` for all four path fields (records carry
+  none); replace the "populated even on preflight failure" comment with
+  the decision-7 rationale.
+
+Verification: `bun test libraries/libharness/test/benchmark-result.test.js`.
+
+## Step 6 — Judge adapter and template docs
+
+Files: modified `libraries/libharness/src/benchmark/judge.js`.
+
+- No behavioural change: the judge already writes to
+  `workdir.judgeTracePath` and templates `{{AGENT_TRACE_PATH}}` from
+  `workdir.agentTracePath` — both now convention-named absolute paths,
+  materialized before any session runs.
+- Update the module docblock's `agent.ndjson` / `judge.ndjson` mentions to
+  the convention names.
+
+Verification: `bun test libraries/libharness/test/benchmark-judge.test.js`.
+
+## Step 7 — Delete the private splitter
+
+Files: deleted `libraries/libharness/src/benchmark/trace-split.js`.
+
+`splitAndSummarize` and its interface go with it; step 4 removed the last
+import.
+
+Verification: `rg -n "splitAndSummarize|benchmark/trace-split" libraries
+products` returns nothing.
+
+## Step 8 — Benchmark tests and fixtures
+
+Files: modified
+`libraries/libharness/test/benchmark-workdir-start.integration.test.js`,
+`libraries/libharness/test/benchmark-workdir.integration.test.js`,
+`libraries/libharness/test/benchmark-e2e.integration.test.js`,
+`libraries/libharness/test/benchmark-runner-concurrency.test.js`,
+`libraries/libharness/test/benchmark-runner-score.test.js`,
+`libraries/libharness/test/benchmark-shard.test.js`,
+`libraries/libharness/test/benchmark-result.test.js`,
+`libraries/libharness/test/benchmark-judge.test.js`,
+`libraries/libharness/test/report-helpers.js`; created
+`libraries/libharness/test/benchmark-raw-summary.test.js`.
+
+- Workdir tests: paths follow the convention under
+  `runs/<taskId>/<idx>/`; raw + agent/supervisor lanes exist empty after
+  `start()`; judge lane path allocated but not materialized; handle
+  carries `caseId`/`rawTracePath`; no `__` slug directory for any id.
+- `benchmark-raw-summary.test.js`: cost (multi-source result events),
+  turns (orchestrator summary), submission (last agent assistant text),
+  and tolerance of malformed/blank lines.
+- E2E: per-cell tree keeps `trace--<case>.raw.ndjson` plus both lanes
+  after the run — no deletion (spec criterion 1); record `costUsd` +
+  `costBreakdown` equal `sumTraceCost` over the preserved raw file (spec
+  criterion 3); records' trace paths are run-output-relative and every
+  referenced file exists under the output dir (spec criterion 8); the
+  existing "consumable by gemba-trace overview" test reads the new lane
+  path.
+- Runner unit tests (`concurrency`/`score`/`shard`): update fabricated
+  records/paths to the new shape; preflight-failure expectations drop
+  trace paths.
+- `benchmark-result.test.js` and `report-helpers.js`: convention-named,
+  run-output-relative fixture paths (e.g.
+  `runs/x/0/trace--x-r0--agent.agent.ndjson`), `rawTracePath` added;
+  preflight branch rejects trace-path fields.
+- `benchmark-judge.test.js`: assert the judge lane file at the convention
+  path contains only redacted content — drive `runJudge` with a fake query
+  emitting a sentinel env value and assert the written file carries the
+  redaction placeholder (spec criterion 9, judge lane).
+- Raw-file redaction (spec criterion 9, kept raw trace): assert in the
+  supervisor-output/redaction-pipeline coverage that the bytes persisted
+  to a `trace--<case>.raw.ndjson` path are the redacted stream — extend
+  `libraries/libharness/test/redaction-pipeline-producer.test.js` with a
+  file-content assertion at the convention-named path (the persisted file
+  is the same `fileStream` the existing criterion-1 test observes).
+
+Verification: `bun test libraries/libharness` green, plus the criterion-11
+sweep from [plan-a.md](plan-a.md) § Verification.

--- a/specs/2270-benchmark-trace-parity/plan-a-03.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-03.md
@@ -1,9 +1,10 @@
 # Plan 2270-a — Part 03: Action and reusable workflow
 
 The benchmark action mints `trace--*` artifacts and exposes the trace
-contract; the reusable workflow forwards it. Design refs:
+contract; the reusable workflow forwards it; an action-contract test
+verifies spec criterion 10 on the PR. Design refs:
 [design-a.md](design-a.md) § Contracts § Benchmark action surface, Key
-Decision 8. No library code; may run in parallel with parts 01–02.
+Decision 8. No library code; independent of parts 01–02.
 
 ## Step 1 — Benchmark action: trace input, output, upload
 
@@ -47,9 +48,18 @@ ${{ inputs.trace }}`, `FAMILY: ${{ inputs.family }}`):
   fi
   ```
 
-- Compute the trace artifact name next to the existing results name:
-  `trace-artifact-name=trace--${ARTIFACT_NAME}` unsharded,
-  `trace--${ARTIFACT_NAME}-shard-${SHARD_INDEX}` when `SHARD_TOTAL != 1`.
+- Compute the trace artifact name next to the existing results name and
+  keep it in a shell variable for the manifest:
+
+  ```bash
+  if [ "$SHARD_TOTAL" != "1" ]; then
+    TRACE_ARTIFACT="trace--${ARTIFACT_NAME}-shard-${SHARD_INDEX}"
+  else
+    TRACE_ARTIFACT="trace--${ARTIFACT_NAME}"
+  fi
+  echo "trace-artifact-name=${TRACE_ARTIFACT}" >> "$GITHUB_OUTPUT"
+  ```
+
 - Emit `trace-dir=$(realpath "$OUTPUT_DIR")/runs` when `TRACE_ENABLED` is
   `true`, else `trace-dir=`.
 - When `TRACE_ENABLED` is `true`, write the artifact's root anchor
@@ -60,7 +70,7 @@ ${{ inputs.trace }}`, `FAMILY: ${{ inputs.family }}`):
   {
     echo "family=$FAMILY"
     echo "shard=${SHARD_INDEX}/${SHARD_TOTAL}"
-    echo "artifact=trace-artifact-name value"
+    echo "artifact=${TRACE_ARTIFACT}"
   } > "$OUTPUT_DIR/trace-manifest.txt"
   ```
 
@@ -84,9 +94,7 @@ inside its `cwd/` cannot enter the evidence. The manifest misses the
 artifact keeps its existing `benchmark-shard-<i>` scheme (pre-existing,
 out of scope).
 
-Verification: `bun run check` (workflow lint via repo checks); a
-dry-review that the upload set at depth `runs/*/*/` matches the part-02
-workdir layout.
+Verification: the action-contract test in step 3.
 
 ## Step 2 — Reusable workflow forwards the contract
 
@@ -98,11 +106,49 @@ Files: modified
   step. No other change — each shard mints its own collision-safe
   artifact, so eval workflows get trace artifacts with no caller-side
   steps.
+- Sequencing note (also in [plan-a.md](plan-a.md) § Risks): the shard step
+  pins the published `forwardimpact/benchmark@v1.0.8`, so the forwarded
+  input is inert until that pin advances to the release carrying this
+  change — a post-release step for the release engineer.
 
-Verification: `bun run check`; the shard step's `with:` block carries
-`trace`.
+Verification: the shard step's `with:` block carries `trace`; `bun run
+check` (markdown/format surfaces only — the repo has no workflow linter,
+which is why step 3 exists).
 
-## Step 3 — Action READMEs state the contract
+## Step 3 — Action-contract test (spec criterion 10)
+
+A test executes the action's shell contract so `trace-dir` and the upload
+set verify on the PR, not just post-release.
+
+Files: created `products/gemba/test/benchmark-action-contract.test.js`;
+modified `products/gemba/package.json` (add `yaml` to `devDependencies`).
+
+The test parses `products/gemba/actions/benchmark/action.yml` with `yaml`
+and:
+
+- asserts the `trace-dir` output wires to
+  `steps.resolve-paths.outputs.trace-dir`, and the `Upload traces` step's
+  `if:` gates on `always()`, run mode, and `inputs.trace`, with the
+  exact-depth `runs/*/*/trace--*.ndjson` + `trace-manifest.txt` path set;
+- extracts the `Resolve paths` step's `run` script and executes it with
+  `bash` in a temp dir (env: `OUTPUT_DIR`, `SHARD_INDEX`, `SHARD_TOTAL`,
+  `ARTIFACT_NAME`, `TRACE_ENABLED`, `FAMILY`, `GITHUB_OUTPUT` → temp
+  file), asserting: `trace-dir` equals `<output>/runs` (absolute) when
+  enabled and empty when disabled; `trace-artifact-name` is
+  `trace--<name>` unsharded and `trace--<name>-shard-<i>` sharded; an
+  `artifact-name` containing `--` exits non-zero; the manifest lands at
+  `<output>/trace-manifest.txt` with the family/shard/artifact lines;
+- seeds `<output>/runs/x/0/trace--x-r0--agent.agent.ndjson` plus a decoy
+  `<output>/runs/x/0/cwd/trace--planted.raw.ndjson`, then asserts the
+  upload glob (via `fs.globSync` with the same pattern) matches the
+  convention file beneath the emitted `trace-dir` and not the decoy —
+  the criterion-10 "read the output and list convention-named files
+  beneath it" assertion.
+
+Verification: `cd products/gemba && bun test
+test/benchmark-action-contract.test.js`.
+
+## Step 4 — Action READMEs state the contract
 
 Files: modified `products/gemba/actions/benchmark/README.md`,
 `products/gemba/actions/harness/README.md`.

--- a/specs/2270-benchmark-trace-parity/plan-a-03.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-03.md
@@ -1,0 +1,121 @@
+# Plan 2270-a — Part 03: Action and reusable workflow
+
+The benchmark action mints `trace--*` artifacts and exposes the trace
+contract; the reusable workflow forwards it. Design refs:
+[design-a.md](design-a.md) § Contracts § Benchmark action surface, Key
+Decision 8. No library code; may run in parallel with parts 01–02.
+
+## Step 1 — Benchmark action: trace input, output, upload
+
+Files: modified `products/gemba/actions/benchmark/action.yml`.
+
+Inputs — add:
+
+```yaml
+trace:
+  description: |
+    Upload every trace file as a trace--* workflow artifact and expose the
+    trace-dir output (run mode). Capture is unconditional in the runner —
+    cost derivation and the judge depend on the traces existing — so
+    disabling this skips only the artifact upload and empties the outputs.
+    Deliberate asymmetry with the harness action's same-named input, which
+    disables capture.
+  required: false
+  default: "true"
+```
+
+Outputs — add:
+
+```yaml
+trace-dir:
+  description: |
+    Absolute path of <output>/runs; every trace file of the run sits
+    beneath it at <taskId>/<runIndex>/trace--*. Empty when trace is
+    disabled.
+  value: ${{ steps.resolve-paths.outputs.trace-dir }}
+```
+
+`Resolve paths` step — extend (env gains `TRACE_ENABLED:
+${{ inputs.trace }}`, `FAMILY: ${{ inputs.family }}`):
+
+- Fail fast on delimiter breakage before anything else:
+
+  ```bash
+  if [[ "$ARTIFACT_NAME" == *--* ]]; then
+    echo "::error::artifact-name must not contain '--' (trace-name delimiter)"
+    exit 1
+  fi
+  ```
+
+- Compute the trace artifact name next to the existing results name:
+  `trace-artifact-name=trace--${ARTIFACT_NAME}` unsharded,
+  `trace--${ARTIFACT_NAME}-shard-${SHARD_INDEX}` when `SHARD_TOTAL != 1`.
+- Emit `trace-dir=$(realpath "$OUTPUT_DIR")/runs` when `TRACE_ENABLED` is
+  `true`, else `trace-dir=`.
+- When `TRACE_ENABLED` is `true`, write the artifact's root anchor
+  **before the run** so a timed-out shard's upload still roots at
+  `<output>` (decision 8):
+
+  ```bash
+  {
+    echo "family=$FAMILY"
+    echo "shard=${SHARD_INDEX}/${SHARD_TOTAL}"
+    echo "artifact=trace-artifact-name value"
+  } > "$OUTPUT_DIR/trace-manifest.txt"
+  ```
+
+New step after `Upload shard results`:
+
+```yaml
+- name: Upload traces
+  if: always() && inputs.mode == 'run' && inputs.trace == 'true'
+  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+  with:
+    name: ${{ steps.resolve-paths.outputs.trace-artifact-name }}
+    path: |
+      ${{ inputs.output }}/runs/*/*/trace--*.ndjson
+      ${{ inputs.output }}/trace-manifest.txt
+    if-no-files-found: warn
+```
+
+The exact-depth glob is deliberate — never `**`, so files an agent plants
+inside its `cwd/` cannot enter the evidence. The manifest misses the
+`trace--` filename prefix, so member-name matching ignores it. The results
+artifact keeps its existing `benchmark-shard-<i>` scheme (pre-existing,
+out of scope).
+
+Verification: `bun run check` (workflow lint via repo checks); a
+dry-review that the upload set at depth `runs/*/*/` matches the part-02
+workdir layout.
+
+## Step 2 — Reusable workflow forwards the contract
+
+Files: modified
+`products/gemba/actions/benchmark/.github/workflows/benchmark.yml`.
+
+- Add `workflow_call` input `trace` (type `string`, default `"true"`) and
+  forward `trace: ${{ inputs.trace }}` in the shard job's benchmark action
+  step. No other change — each shard mints its own collision-safe
+  artifact, so eval workflows get trace artifacts with no caller-side
+  steps.
+
+Verification: `bun run check`; the shard step's `with:` block carries
+`trace`.
+
+## Step 3 — Action READMEs state the contract
+
+Files: modified `products/gemba/actions/benchmark/README.md`,
+`products/gemba/actions/harness/README.md`.
+
+- Benchmark README: document the `trace` input (upload/outputs gate only;
+  capture unconditional), the `trace-dir` output, the per-shard
+  `trace--<artifact-name>[-shard-<i>]` artifact naming, the extracted
+  member shape `runs/<taskId>/<runIndex>/trace--*` matching the record's
+  relative paths, the `--`-in-`artifact-name` fail-fast, and the
+  download-then-analyze flow (`gemba-trace runs` / `find` / `download`).
+- Harness README: one short note on the same-named `trace` input
+  asymmetry — harness `trace` disables capture; benchmark `trace` only
+  gates upload/outputs — mirroring the note added to the benchmark README.
+
+Verification: `bun run check` (markdown lint); both READMEs state the
+asymmetry.

--- a/specs/2270-benchmark-trace-parity/plan-a-04.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-04.md
@@ -2,9 +2,14 @@
 
 Every surface that documents benchmark output states the eval trace
 contract: what a run preserves, the artifact shape, and the
-download-then-analyze flow (spec requirement 12). Runs after parts 01–03
-(documents their contracts). External-audience rules apply: fully
-qualified URLs, `npm`/`npx` only, no monorepo-relative paths.
+download-then-analyze flow (spec requirement 12). This part also carries
+the documentation consequence of decision 12: `download` stops minting
+`structured.json` on every multi-member bundle (kata dispatch, harness
+matrix, eval shards), so every documented `structured.json` flow is
+rewritten to drive the verbs off the downloaded `.ndjson` members, which
+`loadTrace` accepts natively. Runs after parts 01–03 (documents their
+contracts). External-audience rules apply: fully qualified URLs,
+`npm`/`npx` only, no monorepo-relative paths.
 
 ## Step 1 — gemba-benchmark skill
 
@@ -12,10 +17,10 @@ Files: modified `.claude/skills/gemba-benchmark/SKILL.md`.
 
 - `{{AGENT_TRACE_PATH}}` row: `agent.ndjson` → "the cell's
   `trace--<case>--agent.agent.ndjson` lane".
-- Trace section (extend the existing "Each run produces … NDJSON traces"
-  paragraph): per cell under `runs/<taskId>/<runIndex>/`, a run preserves
-  `trace--<case>.raw.ndjson` (combined, enveloped), agent and supervisor
-  lanes, and a judge lane on judged cells, where `<case>` is
+- Extend the existing "Each run produces … NDJSON traces" paragraph with
+  the trace contract: per cell under `runs/<taskId>/<runIndex>/`, a run
+  preserves `trace--<case>.raw.ndjson` (combined, enveloped), agent and
+  supervisor lanes, and a judge lane on judged cells, where `<case>` is
   `<taskId>-r<runIndex>`; the action uploads them as `trace--*` workflow
   artifacts (kept on failed/timed-out cells); analyze with `gemba-trace`
   with no benchmark-specific flags.
@@ -26,12 +31,18 @@ Verification: `bun run context` (jidoka instruction checks) green.
 
 Files: modified `.claude/skills/gemba-trace/SKILL.md`.
 
-- `runs` default-pattern mention → `kata|agent|eval|benchmark`; note eval
-  runs list by default.
-- Download-traces bullet: `find <run-id> <key>` resolves a lane by exact
-  filename, case, or participant; an ambiguous key errors with the
-  candidates; eval flow is the same `runs` → `download` shape as kata
-  runs.
+- Command reference: add the default `runs` pattern
+  (`kata|agent|eval|benchmark` — eval runs list by default) next to the
+  existing `runs [pattern]` line, and add `find <run-id> <key>` (resolves
+  a lane by exact filename, case, or participant; an ambiguous key errors
+  with the candidates). These are additions — the skill currently
+  documents neither.
+- Rewrite the `download` reference line (line 36) and the Typical
+  Workflow (lines ~121–127): `download` extracts the artifact's `.ndjson`
+  members (nested per cell for eval artifacts) and the analysis verbs
+  take those files directly; `structured.json` appears only when the
+  artifact carries a single `.ndjson` member. The current
+  `download → structured.json` walkthrough is replaced, not annotated.
 
 Verification: `bun run context` green.
 
@@ -45,7 +56,7 @@ Files: modified
 - Output-layout prose ("absolute paths to both NDJSON traces"): records
   carry run-output-relative paths; add the per-cell file table from
   design § File naming (raw, agent lane, supervisor lane, judge lane) and
-  a short "Traces as artifacts" subsection: the action's `trace` input,
+  a new "Traces as artifacts" subsection: the action's `trace` input,
   `trace-dir` output, `trace--*` artifact per shard, and the
   download-then-analyze flow.
 
@@ -56,6 +67,11 @@ Verification: `bun run check` (markdown) green.
 Files: modified
 `websites/fit/docs/libraries/prove-changes/run-eval/index.md`.
 
+- Rewrite the "Read the results" block (lines ~155–166): its
+  `download` → `overview/timeline/tool structured.json` flow dies with
+  decision 12 (the documented artifact carries three `.ndjson` members —
+  raw plus two lanes), so the examples point the verbs at the downloaded
+  lane files (`--file trace--default--agent.agent.ndjson`, etc.).
 - Add a benchmark-driven-eval subsection: a workflow calling the reusable
   benchmark workflow mints `trace--*` artifacts on every shard with no
   caller-side steps; state what each cell preserves and point the
@@ -70,16 +86,21 @@ Verification: `bun run check` green.
 Files: modified
 `websites/fit/docs/libraries/prove-changes/trace-analysis/index.md`.
 
-- Eval traces paragraph: benchmark cells emit the same
+- Rework the `download` walkthrough and every worked example that pipes
+  `/tmp/trace-<run-id>/structured.json` (the command examples span lines
+  ~25–213): `download` yields the artifact's `.ndjson` members and every
+  verb consumes them as-is; `structured.json` is produced only when the
+  artifact carries exactly one `.ndjson` member. This is a rewrite of the
+  guide's primary flow, not a one-line note — after part 01 the file the
+  examples reference is no longer produced for dispatch or eval bundles.
+- Add an eval-traces paragraph: benchmark cells emit the same
   `trace--<case>--<participant>.<role>.ndjson` convention with case
   `<taskId>-r<runIndex>`; the judge lane is `--judge.judge.ndjson`; raw
   and judge files are enveloped streams, split lanes unwrapped — every
   file-consuming verb takes them as-is.
-- `download` auto-convert note (line ~28): `structured.json` is produced
-  only when the artifact carries exactly one `.ndjson` member;
-  multi-member bundles (kata dispatch, eval shards) skip it.
-- `find` example/description: key may be a participant, case, or exact
-  filename; ambiguous keys error with candidates.
+- Document `find <run-id> <key>` where the guide covers discovery: key
+  may be a participant, case, or exact filename; ambiguous keys error
+  with candidates (addition — the guide does not cover `find` today).
 
 Verification: `bun run check` green; criterion-11 sweep from
 [plan-a.md](plan-a.md) still clean (docs carry no bare per-cell

--- a/specs/2270-benchmark-trace-parity/plan-a-04.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-04.md
@@ -31,6 +31,11 @@ Verification: `bun run context` (jidoka instruction checks) green.
 
 Files: modified `.claude/skills/gemba-trace/SKILL.md`.
 
+- Intro paragraph (lines ~12–15): "turns raw trace artifacts into
+  structured JSON and provides a query interface" describes the flow
+  decision 12 disables on common bundles — rewrite it around reading
+  NDJSON traces directly (structured JSON only for single-member
+  artifacts).
 - Command reference: add the default `runs` pattern
   (`kata|agent|eval|benchmark` — eval runs list by default) next to the
   existing `runs [pattern]` line, and add `find <run-id> <key>` (resolves
@@ -105,3 +110,16 @@ Files: modified
 Verification: `bun run check` green; criterion-11 sweep from
 [plan-a.md](plan-a.md) still clean (docs carry no bare per-cell
 filenames).
+
+## Step 6 — Internal runbook touch-up
+
+Files: modified
+`.claude/skills/kata-product-issue/references/trace-discovery.md`.
+
+- The claim "participant filtering, which the `gemba-trace` CLI does not
+  provide directly" (lines ~36–37) becomes false once `find <run-id>
+  <key>` ships — update the note to point at `find` with the ambiguity
+  error, keeping the `grep` recipe as the multi-match fallback. Internal
+  reference, so relative links are fine.
+
+Verification: `bun run context` green.

--- a/specs/2270-benchmark-trace-parity/plan-a-04.md
+++ b/specs/2270-benchmark-trace-parity/plan-a-04.md
@@ -1,0 +1,86 @@
+# Plan 2270-a — Part 04: Documentation
+
+Every surface that documents benchmark output states the eval trace
+contract: what a run preserves, the artifact shape, and the
+download-then-analyze flow (spec requirement 12). Runs after parts 01–03
+(documents their contracts). External-audience rules apply: fully
+qualified URLs, `npm`/`npx` only, no monorepo-relative paths.
+
+## Step 1 — gemba-benchmark skill
+
+Files: modified `.claude/skills/gemba-benchmark/SKILL.md`.
+
+- `{{AGENT_TRACE_PATH}}` row: `agent.ndjson` → "the cell's
+  `trace--<case>--agent.agent.ndjson` lane".
+- Trace section (extend the existing "Each run produces … NDJSON traces"
+  paragraph): per cell under `runs/<taskId>/<runIndex>/`, a run preserves
+  `trace--<case>.raw.ndjson` (combined, enveloped), agent and supervisor
+  lanes, and a judge lane on judged cells, where `<case>` is
+  `<taskId>-r<runIndex>`; the action uploads them as `trace--*` workflow
+  artifacts (kept on failed/timed-out cells); analyze with `gemba-trace`
+  with no benchmark-specific flags.
+
+Verification: `bun run context` (jidoka instruction checks) green.
+
+## Step 2 — gemba-trace skill
+
+Files: modified `.claude/skills/gemba-trace/SKILL.md`.
+
+- `runs` default-pattern mention → `kata|agent|eval|benchmark`; note eval
+  runs list by default.
+- Download-traces bullet: `find <run-id> <key>` resolves a lane by exact
+  filename, case, or participant; an ambiguous key errors with the
+  candidates; eval flow is the same `runs` → `download` shape as kata
+  runs.
+
+Verification: `bun run context` green.
+
+## Step 3 — Prove Agent Changes: run-benchmark guide
+
+Files: modified
+`websites/fit/docs/libraries/prove-changes/run-benchmark/index.md`.
+
+- `{{AGENT_TRACE_PATH}}` table row (line ~223): "Absolute path to
+  `agent.ndjson`" → the convention-named agent lane.
+- Output-layout prose ("absolute paths to both NDJSON traces"): records
+  carry run-output-relative paths; add the per-cell file table from
+  design § File naming (raw, agent lane, supervisor lane, judge lane) and
+  a short "Traces as artifacts" subsection: the action's `trace` input,
+  `trace-dir` output, `trace--*` artifact per shard, and the
+  download-then-analyze flow.
+
+Verification: `bun run check` (markdown) green.
+
+## Step 4 — Prove Agent Changes: run-eval guide
+
+Files: modified
+`websites/fit/docs/libraries/prove-changes/run-eval/index.md`.
+
+- Add a benchmark-driven-eval subsection: a workflow calling the reusable
+  benchmark workflow mints `trace--*` artifacts on every shard with no
+  caller-side steps; state what each cell preserves and point the
+  analysis flow at the trace-analysis guide. The existing harness-driven
+  single-eval example (manual split + upload) stays — it already follows
+  the shared convention.
+
+Verification: `bun run check` green.
+
+## Step 5 — Prove Agent Changes: trace-analysis guide
+
+Files: modified
+`websites/fit/docs/libraries/prove-changes/trace-analysis/index.md`.
+
+- Eval traces paragraph: benchmark cells emit the same
+  `trace--<case>--<participant>.<role>.ndjson` convention with case
+  `<taskId>-r<runIndex>`; the judge lane is `--judge.judge.ndjson`; raw
+  and judge files are enveloped streams, split lanes unwrapped — every
+  file-consuming verb takes them as-is.
+- `download` auto-convert note (line ~28): `structured.json` is produced
+  only when the artifact carries exactly one `.ndjson` member;
+  multi-member bundles (kata dispatch, eval shards) skip it.
+- `find` example/description: key may be a participant, case, or exact
+  filename; ambiguous keys error with candidates.
+
+Verification: `bun run check` green; criterion-11 sweep from
+[plan-a.md](plan-a.md) still clean (docs carry no bare per-cell
+filenames).

--- a/specs/2270-benchmark-trace-parity/plan-a.md
+++ b/specs/2270-benchmark-trace-parity/plan-a.md
@@ -48,11 +48,14 @@ the action-contract test).
 - `bun run check` green (format, lint, jsdoc, invariants, context).
 - Spec criterion 11 sweep returns nothing outside `specs/`:
   `rg --hidden --pcre2 '(?<![.\w-])(agent|supervisor|judge)\.ndjson'`
-- Spec criteria on the PR: 1–3 via the part-02 e2e assertions (criterion 3
-  compares the record's agent+supervisor breakdown, not `costUsd`, which
-  folds in judge cost), 4 via the part-01 identity round-trip, 8–9 via the
-  part-02 record/redaction tests, 10 via the part-03 action-contract
-  test, 11 via the sweep above, 12 via part 04. Criteria 5–7 verify
+- Spec criteria on the PR: 1 and 3 via the part-02 e2e assertions
+  (criterion 3 drives the `cost` verb handler in-process over the
+  preserved raw file and compares the record's agent+supervisor
+  breakdown — not `costUsd`, which folds in judge cost); 2 via the
+  part-01 split units plus the part-02 step-7 deletion sweep; 4 via the
+  part-01 identity round-trip; 8–9 via the part-02 record/redaction
+  tests; 10 via the part-03 action-contract test; 11 via the sweep
+  above; 12 via parts 03 (action README) and 04. Criteria 5–7 verify
   post-release (published action + pin/Dependabot bumps), not on this PR
   — noted for the release engineer.
 

--- a/specs/2270-benchmark-trace-parity/plan-a.md
+++ b/specs/2270-benchmark-trace-parity/plan-a.md
@@ -9,8 +9,9 @@ Build the two shared modules first — the identity grammar
 re-point every existing consumer (CLI split, trace-multi, trace-github,
 public export) at them, since every later step consumes their contracts.
 Then rebuild the benchmark runtime pipeline on those modules: convention
-paths and lane materialization in the workdir, raw-trace preservation and
-the one-pass summary in the runner, run-output-relative record fields, and
+paths and lane materialization in the workdir, raw-trace preservation with
+split and summary hoisted to the runner's shared path (so the test seam
+exercises the real pipeline), run-output-relative record fields, and
 deletion of the private splitter. The action and reusable workflow changes
 and the documentation updates touch no library code, so they follow as
 contract-level work. The whole change lands as one PR: the naming
@@ -23,22 +24,23 @@ convention spans runner, action, tests, and docs, and spec requirement 11
 | --- | --- | --- |
 | [plan-a-01](plan-a-01.md) | Shared trace core: identity module, shared split module, CLI rewiring, discovery changes, `gemba-trace` help + goldens | — |
 | [plan-a-02](plan-a-02.md) | Benchmark runtime: workdir, task-family, raw-summary, runner, result schema, judge docs, private-splitter deletion, tests | 01 |
-| [plan-a-03](plan-a-03.md) | Benchmark composite action, reusable workflow, both action READMEs | — |
+| [plan-a-03](plan-a-03.md) | Benchmark composite action, reusable workflow, action-contract test, both action READMEs | — |
 | [plan-a-04](plan-a-04.md) | Documentation: `gemba-benchmark`/`gemba-trace` skills, Prove Agent Changes guides | 01, 02, 03 (documents their contracts) |
 
 ## Execution
 
 Route all parts to an engineering agent (`staff-engineer` via
-`kata-implement`); part 04 is documentation but documents contracts landed
-in 01–03, so keeping one implementer avoids a handoff. Sequence: 01 → 02
-sequentially (02 imports 01's modules); 03 may run in parallel with 01/02
-(it touches only YAML and READMEs); 04 runs last. All on one branch, one
-PR.
+`kata-implement`), sequenced 01 → 02 → 03 → 04 on one branch, one PR.
+Deliberate deviation for the approver: part 04 is documentation, which
+kata-plan defaults to `technical-writer`, but it documents contracts the
+same PR lands (record paths, artifact naming, `download` narrowing), so
+one implementer avoids a mid-PR handoff.
 
 Libraries used: libharness (trace-identity, trace-split, trace-github,
 trace-multi, commands/trace, benchmark/\*, sumTraceCost), libmock
 (createMockFs, createTestRuntime), libcli (definition surface only), zod
-(existing result schema).
+(existing result schema), yaml (new devDependency of `products/gemba` for
+the action-contract test).
 
 ## Verification (whole PR)
 
@@ -46,10 +48,13 @@ trace-multi, commands/trace, benchmark/\*, sumTraceCost), libmock
 - `bun run check` green (format, lint, jsdoc, invariants, context).
 - Spec criterion 11 sweep returns nothing outside `specs/`:
   `rg --hidden --pcre2 '(?<![.\w-])(agent|supervisor|judge)\.ndjson'`
-- Spec criteria 5–7 verify post-release (published action + Dependabot
-  SHA-bump in eval workflows), not on this PR — noted for the release
-  engineer; criteria 1–4 and 8–12 verify on the PR via the tests named in
-  parts 01–04.
+- Spec criteria on the PR: 1–3 via the part-02 e2e assertions (criterion 3
+  compares the record's agent+supervisor breakdown, not `costUsd`, which
+  folds in judge cost), 4 via the part-01 identity round-trip, 8–9 via the
+  part-02 record/redaction tests, 10 via the part-03 action-contract
+  test, 11 via the sweep above, 12 via part 04. Criteria 5–7 verify
+  post-release (published action + pin/Dependabot bumps), not on this PR
+  — noted for the release engineer.
 
 ## Risks
 
@@ -58,22 +63,30 @@ trace-multi, commands/trace, benchmark/\*, sumTraceCost), libmock
   resolution. v4 roots the archive at the matched files' least common
   ancestor, so the pre-run `<output>/trace-manifest.txt` anchor is
   load-bearing — it cannot be folded into the run step or written under
-  `runs/`. There is no PR-level test of the extraction shape; the
-  post-release criterion-5 dispatch is the first real check.
-- **`createMockFs` async-stream fidelity.** The shared split module streams
-  via `runtime.fs.createReadStream` + readline; the existing CLI split
-  tests drive `fsSync.readFileSync`. If the mock's read stream does not
-  compose with `node:readline` `createInterface`, tests for the shared
-  module need the real-fs test runtime (`test/real-runtime.js` +
-  `mkdtemp`), which several benchmark integration tests already use.
+  `runs/`. The action-contract test covers the glob and manifest, but not
+  v4's archiving; the post-release criterion-5 dispatch is the first real
+  check of the extraction shape.
+- **Published-pin sequencing.** The reusable workflow's shard step invokes
+  the published `forwardimpact/benchmark@v1.0.8` action, which does not
+  declare the new `trace` input — forwarding it is inert (with a workflow
+  warning) until that internal pin advances to the release carrying this
+  change. That pin bump is a post-release step for the release engineer,
+  distinct from the eval workflows' Dependabot SHA-bump.
 - **`findByKey` behaviour change on kata dispatch runs.** Decision 10
   replaces silent first-match with an ambiguity error on the shared
-  surface. Any existing automation that relied on first-match on dispatch
-  bundles (e.g. runbooks passing a bare participant present in several
-  cases) will start erroring with a candidate list; this is the designed
-  accuracy fix, but the error message must list the matching member names
-  or the flow is a dead end.
+  surface. Automation that relied on first-match (e.g. a bare participant
+  present in several cases) starts erroring; the error must list the
+  matching member names or the flow is a dead end.
 - **`structured.json` narrowing is a cross-surface output change.** Kata
-  dispatch bundles (multi-member) stop minting `structured.json` on
-  `download`. Anything parsing that file from a multi-member bundle breaks
-  loudly; the trace-analysis guide update in part 04 is the notice.
+  dispatch bundles, harness matrix bundles (raw + lanes), and eval shards
+  are all multi-member, so `download` stops minting `structured.json` on
+  every common bundle. Part 04 therefore rewrites every documented
+  `structured.json` flow (gemba-trace skill, trace-analysis and run-eval
+  guides) to drive the verbs off the downloaded `.ndjson` members, which
+  `loadTrace` accepts natively.
+- **`runAgent` seam contract change.** Part 02 narrows the internal test
+  seam to "stream envelopes to `rawTracePath`, return `{agentError}`" so
+  hook-driven tests exercise the real split/summary path. Every
+  hook-using test fabricating `costUsd`/`turns`/`submission` must switch
+  to envelope fixtures; the seam is documented internal-only, so no
+  external consumer breaks.

--- a/specs/2270-benchmark-trace-parity/plan-a.md
+++ b/specs/2270-benchmark-trace-parity/plan-a.md
@@ -1,0 +1,79 @@
+# Plan 2270-a — Benchmark Trace Parity
+
+Implements [design-a.md](design-a.md) for [spec.md](spec.md).
+
+## Approach
+
+Build the two shared modules first — the identity grammar
+(`trace-identity.js`) and the split implementation (`trace-split.js`) — and
+re-point every existing consumer (CLI split, trace-multi, trace-github,
+public export) at them, since every later step consumes their contracts.
+Then rebuild the benchmark runtime pipeline on those modules: convention
+paths and lane materialization in the workdir, raw-trace preservation and
+the one-pass summary in the runner, run-output-relative record fields, and
+deletion of the private splitter. The action and reusable workflow changes
+and the documentation updates touch no library code, so they follow as
+contract-level work. The whole change lands as one PR: the naming
+convention spans runner, action, tests, and docs, and spec requirement 11
+(clean break, no aliases) forbids landing the halves separately.
+
+## Parts
+
+| Part | Scope | Depends on |
+| --- | --- | --- |
+| [plan-a-01](plan-a-01.md) | Shared trace core: identity module, shared split module, CLI rewiring, discovery changes, `gemba-trace` help + goldens | — |
+| [plan-a-02](plan-a-02.md) | Benchmark runtime: workdir, task-family, raw-summary, runner, result schema, judge docs, private-splitter deletion, tests | 01 |
+| [plan-a-03](plan-a-03.md) | Benchmark composite action, reusable workflow, both action READMEs | — |
+| [plan-a-04](plan-a-04.md) | Documentation: `gemba-benchmark`/`gemba-trace` skills, Prove Agent Changes guides | 01, 02, 03 (documents their contracts) |
+
+## Execution
+
+Route all parts to an engineering agent (`staff-engineer` via
+`kata-implement`); part 04 is documentation but documents contracts landed
+in 01–03, so keeping one implementer avoids a handoff. Sequence: 01 → 02
+sequentially (02 imports 01's modules); 03 may run in parallel with 01/02
+(it touches only YAML and READMEs); 04 runs last. All on one branch, one
+PR.
+
+Libraries used: libharness (trace-identity, trace-split, trace-github,
+trace-multi, commands/trace, benchmark/\*, sumTraceCost), libmock
+(createMockFs, createTestRuntime), libcli (definition surface only), zod
+(existing result schema).
+
+## Verification (whole PR)
+
+- `bun test libraries/libharness` and `cd products/gemba && bun test` green.
+- `bun run check` green (format, lint, jsdoc, invariants, context).
+- Spec criterion 11 sweep returns nothing outside `specs/`:
+  `rg --hidden --pcre2 '(?<![.\w-])(agent|supervisor|judge)\.ndjson'`
+- Spec criteria 5–7 verify post-release (published action + Dependabot
+  SHA-bump in eval workflows), not on this PR — noted for the release
+  engineer; criteria 1–4 and 8–12 verify on the PR via the tests named in
+  parts 01–04.
+
+## Risks
+
+- **`upload-artifact` v4 archive rooting.** The trace artifact's member
+  paths must extract as `runs/<taskId>/<idx>/trace--*` for record-relative
+  resolution. v4 roots the archive at the matched files' least common
+  ancestor, so the pre-run `<output>/trace-manifest.txt` anchor is
+  load-bearing — it cannot be folded into the run step or written under
+  `runs/`. There is no PR-level test of the extraction shape; the
+  post-release criterion-5 dispatch is the first real check.
+- **`createMockFs` async-stream fidelity.** The shared split module streams
+  via `runtime.fs.createReadStream` + readline; the existing CLI split
+  tests drive `fsSync.readFileSync`. If the mock's read stream does not
+  compose with `node:readline` `createInterface`, tests for the shared
+  module need the real-fs test runtime (`test/real-runtime.js` +
+  `mkdtemp`), which several benchmark integration tests already use.
+- **`findByKey` behaviour change on kata dispatch runs.** Decision 10
+  replaces silent first-match with an ambiguity error on the shared
+  surface. Any existing automation that relied on first-match on dispatch
+  bundles (e.g. runbooks passing a bare participant present in several
+  cases) will start erroring with a candidate list; this is the designed
+  accuracy fix, but the error message must list the matching member names
+  or the flow is a dead end.
+- **`structured.json` narrowing is a cross-surface output change.** Kata
+  dispatch bundles (multi-member) stop minting `structured.json` on
+  `download`. Anything parsing that file from a multi-member bundle breaks
+  loudly; the trace-analysis guide update in part 04 is the notice.


### PR DESCRIPTION
## Summary

- Implementation plan for [spec 2270](../blob/main/specs/2270-benchmark-trace-parity/spec.md) per the approved [design-a](../blob/main/specs/2270-benchmark-trace-parity/design-a.md) (merged in #1994): `plan-a.md` (approach, execution, risks, whole-PR verification) plus four parts.
- **plan-a-01 — shared trace core**: new `trace-identity.js` (case ids, lane filenames, validity predicate; `parseIdentity`/`participantInNames` move in) and shared `trace-split.js` (judge joins the structural roles); CLI split/download/find rewiring with the `structured.json` narrowing extracted into a testable helper; discovery gains the `eval|benchmark` default pattern, recursive member listing, and keyed `find` with an ambiguity error; help goldens refresh.
- **plan-a-02 — benchmark runtime**: convention paths + lane materialization in the workdir, task-id validation at family load, preserved raw trace (unlink removed), new `raw-summary.js`, split/summary hoisted to the runner's shared path with a narrowed `runAgent` test seam, run-output-relative presence-gated record paths, private splitter deleted, full test/fixture updates including redaction coverage of both newly preserved files.
- **plan-a-03 — action + workflow**: `trace` input, `trace-dir` output, pre-run manifest anchor, `always()` trace upload with shard-safe naming and delimiter fail-fast; reusable workflow forwards `trace`; new action-contract test executes the resolve-paths script for spec criterion 10 on the PR; both action READMEs state the trace-input asymmetry.
- **plan-a-04 — docs**: both skills and the three Prove Agent Changes guides state the eval trace contract; every documented `download → structured.json` flow is rewritten for the multi-member narrowing.
- Spec criteria 5–7 verify post-release (published action + pin/Dependabot bumps); the internal `forwardimpact/benchmark@v1.0.8` pin in the reusable workflow must also advance post-release before the forwarded `trace` input takes effect — both noted for the release engineer.

### Panel record

- Full panel (3 technical `staff-engineer` + 3 devex `devex-engineer`) reviewed `8e716ba`: 0 blockers; consensus highs/mediums (basename matching at member call sites, criterion-3 cost assertion, `structured.json` doc scope, `runAgent` seam bypass, criterion-10 test gap, libmock recursive-readdir seam, report-test file lists, published-pin sequencing) all addressed in `ed23090`.
- Scoped 1+1 re-read of the revised sections at `ed23090`: 0 blocker/high; 3 mediums (skill intro, twelve `structured.json` help examples, criterion-3 CLI-level parity) and lows folded in at `5b28932` (head).
- Dismissed lows with recorded rationale: identity module keeps `parseIdentity` and `participantInNames` as distinct shapes (artifact names carry no extension); workdir naming fixed lanes is not the split module's classification rule; STATUS design-row lag is superseded by the plan-approved row.
- Approval: `wiki/STATUS.md` row `2270 plan approved` landed on the wiki (`70a06f54`); human ship-it signal invoked this merge.

## Test plan

- [x] `bun run check` — plan is markdown-only; lint/format/context gates run in PR CI
- [x] `bun run test` — no code changes on this branch; suite runs in PR CI