### PR TITLE
docs(claude): require ASD-STE100 Simplified Technical English

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # Forward Impact Engineering
 
+## Critical: Writing Style
+
+**All output and artifacts must follow ASD-STE100 Simplified Technical
+English.** Use the active voice and one idea per sentence. Avoid AI tells:
+em-dash asides, antithesis pairs, rhetorical questions, and stacked noun
+chains.
+
 ## Goal
 
 > "The aim of leadership should be to improve the performance of [engineers] and
@@ -135,12 +142,6 @@ rg '<do_confirm_checklist'  # Exit gates — do from memory, then confirm
 
 When `.claude/**` writes are blocked, use `echo … | bunx gemba-selfedit <path>`
 — gated to `.claude/settings.json` Edit() rules + non-`main` branch.
-
-## Writing Style
-
-All prose, from marketing copy to commit messages, is simple and direct.
-Avoid the tells of AI-generated text: em-dash asides, antithesis pairs,
-rhetorical questions, and stacked noun chains. One idea per sentence.
 
 ## Memory and Coordination
 


### PR DESCRIPTION
## Summary

- Add a critical instruction at the top of the root `CLAUDE.md`: all output and
  artifacts must follow ASD-STE100 Simplified Technical English.
- Fold the former `## Writing Style` section into the new block. The AI-tell
  guidance is kept, so the policy keeps one home and the root layer stays inside
  its 192-line / 896-word Jidoka budget.

## Test plan

- [x] `just check-instructions` (jidoka instructions)
- [x] `bun run format:md` and `bun run lint:md`
- [x] `bun run invariants`
- [x] `bun run context`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPyWL5ciMuaiW41LsHSEkb)_