### PR TITLE
design(2280): gemba-prefixed actions and the gemba-skills pack

### DIFF
--- a/specs/2280-gemba-action-prefix-skills-pack/design-a.md
+++ b/specs/2280-gemba-action-prefix-skills-pack/design-a.md
@@ -21,9 +21,10 @@ graph LR
     PA -->|"subtree split, non-force"| SIB["Siblings<br/>forwardimpact/gemba-benchmark<br/>gemba-bootstrap · gemba-harness · gemba-wiki"]
     S --> PS
     PS -->|"fit-pack stage + tag"| PACK["forwardimpact/gemba-skills"]
-    SIB -->|"SHA-pinned uses:"| CON["Consumers<br/>monorepo workflows · kata-agent internals<br/>generated installation workflows"]
+    SIB -->|"SHA-pinned uses:"| CON["Monorepo workflows<br/>kata-agent internals"]
+    SIB -->|"generated uses:"| GEN["Generated installation workflows"]
     PACK -->|"apm install"| INST["Kata installations"]
-    KS -->|"generates"| CON
+    KS -->|"generates"| GEN
     KS -->|"prerequisite"| INST
 ```
 
@@ -31,26 +32,28 @@ graph LR
 
 | Component | Where | Change |
 | --------- | ----- | ------ |
-| Action homes | `products/gemba/actions/` | Four directories rename to `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, `gemba-wiki`. Each home stays a byte-faithful whole-root mirror of its sibling, README and self-references included. |
+| Action homes | `products/gemba/actions/` | Four directories rename to `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, `gemba-wiki`. The self- and cross-references inside the four homes (READMEs, action metadata, the benchmark reusable workflow) repoint to the `gemba-*` names, and each home stays the byte-faithful mirror of its sibling repo root. |
 | Action publish workflow | `publish-actions.yml` | The four matrix entries pair each renamed prefix with its renamed repo. The `paths:` filter follows. Kata and Jidoka entries are untouched. |
 | Sibling action repos | GitHub org | Operator renames the four repos in place. Redirects, tags, and commit SHAs survive, so existing pins resolve throughout. |
-| Split lineage | Seed runbook | The prefix rename changes the split lineage, so each renamed sibling gets one sanctioned re-seed force push, then publishes stay non-force (the spec 2140 runbook pattern). |
-| Skill-pack publish workflow | `publish-skills.yml` | The fit leg stages prefix `fit` alone. A new leg publishes `gemba-skills`: prefix `gemba`, version file `products/gemba/package.json`, agents off, README and apm text describing the platform. |
-| Pack sibling | `forwardimpact/gemba-skills` | Operator creates it empty. The first publish run seeds it with a plain push and tags it at the Gemba package version. |
-| Workflow consumers | `.github/workflows/`, `products/kata/actions/`, benchmark reusable workflow | Every `uses:` line repoints to the renamed sibling at the same commit SHA. The benchmark action's reusable workflow repoints its self-reference. |
+| Split lineage | A new runbook part in this spec's plan | The prefix rename changes the split lineage, so each renamed sibling gets one sanctioned re-seed force push, then publishes stay non-force. The plan carries its own runbook part; the spec 2140 runbook is the immutable precedent, not the home. |
+| Skill-pack publish workflow | `publish-skills.yml` | The fit leg stages prefix `fit` alone, and the fit-skills README notes where the gemba skills moved. A new leg publishes `gemba-skills`: prefix `gemba`, version file `products/gemba/package.json` (also added to the workflow's `paths:` trigger), agents off, README and apm text describing the platform. |
+| Pack sibling | `forwardimpact/gemba-skills` | Operator creates it with an initial commit, so the pack action's plain `git push` has a branch to land on. The first publish run stages the pack and tags it at the Gemba package version. |
+| Reference consumers | `.github/workflows/`, `products/kata/actions/`, `products/jidoka/actions/` | Every `uses:` line repoints to the renamed sibling: SHA pins keep their SHA, tag pins keep their tag. The Jidoka action's metadata and README prose references follow. |
 | kata-setup skill | `.claude/skills/kata-setup/` | Prerequisites add `apm install forwardimpact/gemba-skills`. The dispatch template, ref-resolution instructions, and placeholder tokens use the `gemba-*` names. |
 | monorepo-setup skill | `.claude/skills/monorepo-setup/` | The pack install line adds `forwardimpact/gemba-skills`. |
 | Product docs and skills | Gemba overview page, `gemba` skill, `gemba-benchmark` skill, benchmark CI guide | Action tables, `uses:` examples, and Getting Started name the `gemba-*` actions and the pack install. |
 | CLI documentation parity | benchmark CLI definition + golden help output | The `documentation` entry's link text follows the renamed action, keeping the skill-to-CLI parity rule intact. |
 | Enum and contributor docs | `.github/CLAUDE.md`, CLAUDE.md, KATA.md | The action table in `.github/CLAUDE.md` is the `sibling-composite-actions` enum source. It renames first; the fences reseed from it. The Distribution Model adds `gemba-skills` and remaps Gemba to it. |
-| Repo-local paths | session hook, justfile, binaries publish workflow | Installer invocations follow the bootstrap home rename. The installer file name stays `fit-install.sh`. |
+| Repo-local paths | session hook, justfile, binaries publish workflow, split-and-push docstring, `.github/CLAUDE.md` | Installer invocations and path prose follow the home renames, including the split-and-push example prefix and the `.github/CLAUDE.md` bootstrap path. The installer file name stays `fit-install.sh`. |
 
 ## Interfaces
 
 - **Action publish matrix rows** (shape per row, four rows):
   `prefix: products/gemba/actions/gemba-<name>` → `repo: gemba-<name>`.
 - **Pack leg** (one new matrix entry): `prefix: gemba`, `repo: gemba-skills`,
-  `version-file: products/gemba/package.json`, `sync-agents: "false"`.
+  `version-file: products/gemba/package.json`, `sync-agents: "false"`. The
+  workflow's `paths:` trigger gains `products/gemba/package.json`, so a Gemba
+  version bump alone republishes and retags the pack.
 - **kata-setup placeholders:** `{{KATA_AGENT_REF}}` stays.
   `{{FIT_BOOTSTRAP_REF}}`, `{{FIT_HARNESS_REF}}`, `{{FIT_WIKI_REF}}` become
   `{{GEMBA_BOOTSTRAP_REF}}`, `{{GEMBA_HARNESS_REF}}`, `{{GEMBA_WIKI_REF}}`.
@@ -66,13 +69,13 @@ graph LR
 | Pack contents | Skills only, agents off | Sync agents into the pack. No gemba agent profiles exist; kata-skills stays the agents carrier. |
 | Placeholder tokens | `{{GEMBA_*_REF}}` | Keep `{{FIT_*_REF}}`. The token names lie about the repos they resolve. |
 | Enum propagation | Edit the md-table source, reseed the fences with the invariant tooling | Hand-edit each fence. The enumeration-drift invariant owns the fences; hand edits drift. |
-| Old-name guard | Absence sweep excluding immutable records | Repo-wide rewrite including `specs/**` and changelogs. That rewrites history records. |
+| Old-name guard | Absence sweeps with hidden-file semantics (`--hidden`, `.git` excluded), immutable records excluded | Repo-wide rewrite including `specs/**` and changelogs. That rewrites history records. A sweep without `--hidden` misses `.github/**` and `.claude/**`, the largest consumer surfaces. |
 
 ## Rollout sequence
 
 1. **Operator, before merge.** Rename the four sibling repos on GitHub. Create
-   `forwardimpact/gemba-skills` empty. Verify the publishing App's
-   installation covers all five repos.
+   `forwardimpact/gemba-skills` with an initial commit. Verify the publishing
+   App's installation covers all five repos.
 2. **Merge.** The combined monorepo change lands on `main`: homes renamed,
    matrices repointed, skills and docs updated, fences reseeded.
 3. **Operator, after merge.** Re-seed each renamed action prefix once with the
@@ -80,14 +83,18 @@ graph LR
    Pre-rename tags keep the old commits reachable, so existing SHA pins
    resolve before, during, and after.
 4. **Steady state.** Push-triggered publishes run non-force. The first
-   `publish-skills.yml` run seeds `gemba-skills` and tags it. The next release
-   cut moves each renamed sibling's `v1` and version tags onto the new
-   lineage. Dependabot then carries new-lineage SHAs to consumers.
+   `publish-skills.yml` run stages `gemba-skills` and tags it. The next
+   release cut lays new version tags on the new lineage and moves only `v1`;
+   the existing version tags stay on the old lineage as its anchors.
+   Dependabot then carries new-lineage SHAs to consumers.
 
-Between steps 2 and 3, a `main` push can trigger action publishes that fail as
-non-fast-forward on the renamed legs. The failure is visible, scoped to those
-legs (`fail-fast: false`), and harmless: consumers keep resolving the pinned
-old-lineage SHAs. Step 3 clears it.
+Two transient failure windows exist, both visible, scoped to the renamed legs
+(`fail-fast: false`), and harmless because consumers keep resolving their
+pinned old-lineage refs. Between steps 1 and 2, a `main` push that touches the
+old action paths mints App tokens for repo names that no longer exist, so
+those legs fail at the mint. Between steps 2 and 3, the split of each renamed
+prefix produces a new lineage, so those legs fail as non-fast-forward until
+the re-seed lands. Step 3 clears both.
 
 ## Clean break
 

--- a/specs/2280-gemba-action-prefix-skills-pack/design-a.md
+++ b/specs/2280-gemba-action-prefix-skills-pack/design-a.md
@@ -1,0 +1,103 @@
+# Design 2280-a: Gemba-Prefixed Distribution
+
+Spec 2280 renames the four Gemba actions to `gemba-*`, publishes the platform
+skills as a `gemba-skills` sibling pack, and updates kata-setup to teach both.
+This design fixes the components, interfaces, and rollout. It changes no
+runtime behavior. Every action and skill keeps its contents; only names,
+publish targets, and references move.
+
+## Component map
+
+```mermaid
+graph LR
+    subgraph monorepo
+        H["Action homes<br/>products/gemba/actions/gemba-*"]
+        S["Skills<br/>gemba, gemba-*"]
+        PA["publish-actions.yml"]
+        PS["publish-skills.yml"]
+        KS["kata-setup skill"]
+    end
+    H --> PA
+    PA -->|"subtree split, non-force"| SIB["Siblings<br/>forwardimpact/gemba-benchmark<br/>gemba-bootstrap · gemba-harness · gemba-wiki"]
+    S --> PS
+    PS -->|"fit-pack stage + tag"| PACK["forwardimpact/gemba-skills"]
+    SIB -->|"SHA-pinned uses:"| CON["Consumers<br/>monorepo workflows · kata-agent internals<br/>generated installation workflows"]
+    PACK -->|"apm install"| INST["Kata installations"]
+    KS -->|"generates"| CON
+    KS -->|"prerequisite"| INST
+```
+
+## Components
+
+| Component | Where | Change |
+| --------- | ----- | ------ |
+| Action homes | `products/gemba/actions/` | Four directories rename to `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, `gemba-wiki`. Each home stays a byte-faithful whole-root mirror of its sibling, README and self-references included. |
+| Action publish workflow | `publish-actions.yml` | The four matrix entries pair each renamed prefix with its renamed repo. The `paths:` filter follows. Kata and Jidoka entries are untouched. |
+| Sibling action repos | GitHub org | Operator renames the four repos in place. Redirects, tags, and commit SHAs survive, so existing pins resolve throughout. |
+| Split lineage | Seed runbook | The prefix rename changes the split lineage, so each renamed sibling gets one sanctioned re-seed force push, then publishes stay non-force (the spec 2140 runbook pattern). |
+| Skill-pack publish workflow | `publish-skills.yml` | The fit leg stages prefix `fit` alone. A new leg publishes `gemba-skills`: prefix `gemba`, version file `products/gemba/package.json`, agents off, README and apm text describing the platform. |
+| Pack sibling | `forwardimpact/gemba-skills` | Operator creates it empty. The first publish run seeds it with a plain push and tags it at the Gemba package version. |
+| Workflow consumers | `.github/workflows/`, `products/kata/actions/`, benchmark reusable workflow | Every `uses:` line repoints to the renamed sibling at the same commit SHA. The benchmark action's reusable workflow repoints its self-reference. |
+| kata-setup skill | `.claude/skills/kata-setup/` | Prerequisites add `apm install forwardimpact/gemba-skills`. The dispatch template, ref-resolution instructions, and placeholder tokens use the `gemba-*` names. |
+| monorepo-setup skill | `.claude/skills/monorepo-setup/` | The pack install line adds `forwardimpact/gemba-skills`. |
+| Product docs and skills | Gemba overview page, `gemba` skill, `gemba-benchmark` skill, benchmark CI guide | Action tables, `uses:` examples, and Getting Started name the `gemba-*` actions and the pack install. |
+| CLI documentation parity | benchmark CLI definition + golden help output | The `documentation` entry's link text follows the renamed action, keeping the skill-to-CLI parity rule intact. |
+| Enum and contributor docs | `.github/CLAUDE.md`, CLAUDE.md, KATA.md | The action table in `.github/CLAUDE.md` is the `sibling-composite-actions` enum source. It renames first; the fences reseed from it. The Distribution Model adds `gemba-skills` and remaps Gemba to it. |
+| Repo-local paths | session hook, justfile, binaries publish workflow | Installer invocations follow the bootstrap home rename. The installer file name stays `fit-install.sh`. |
+
+## Interfaces
+
+- **Action publish matrix rows** (shape per row, four rows):
+  `prefix: products/gemba/actions/gemba-<name>` → `repo: gemba-<name>`.
+- **Pack leg** (one new matrix entry): `prefix: gemba`, `repo: gemba-skills`,
+  `version-file: products/gemba/package.json`, `sync-agents: "false"`.
+- **kata-setup placeholders:** `{{KATA_AGENT_REF}}` stays.
+  `{{FIT_BOOTSTRAP_REF}}`, `{{FIT_HARNESS_REF}}`, `{{FIT_WIKI_REF}}` become
+  `{{GEMBA_BOOTSTRAP_REF}}`, `{{GEMBA_HARNESS_REF}}`, `{{GEMBA_WIKI_REF}}`.
+- **Install command:** `apm install forwardimpact/gemba-skills`.
+
+## Key decisions
+
+| Decision | Choice | Rejected alternative and why |
+| -------- | ------ | ---------------------------- |
+| Sibling transition | Rename the repos in place | Create new repos and archive the old ones. That severs every existing SHA pin and tag, splits history across two repos, and doubles the org list. |
+| Lineage after the prefix move | One sanctioned re-seed per renamed sibling | Keep the old prefix paths to preserve lineage. That breaks the home-mirrors-sibling rule (MONOREPO.md) and leaves the action homes unrenamed, which the spec requires. |
+| Pack version source | The Gemba product package version | Keep Gear's version. It stamps platform skills with another product's version; jidoka-skills already versions by its product package. |
+| Pack contents | Skills only, agents off | Sync agents into the pack. No gemba agent profiles exist; kata-skills stays the agents carrier. |
+| Placeholder tokens | `{{GEMBA_*_REF}}` | Keep `{{FIT_*_REF}}`. The token names lie about the repos they resolve. |
+| Enum propagation | Edit the md-table source, reseed the fences with the invariant tooling | Hand-edit each fence. The enumeration-drift invariant owns the fences; hand edits drift. |
+| Old-name guard | Absence sweep excluding immutable records | Repo-wide rewrite including `specs/**` and changelogs. That rewrites history records. |
+
+## Rollout sequence
+
+1. **Operator, before merge.** Rename the four sibling repos on GitHub. Create
+   `forwardimpact/gemba-skills` empty. Verify the publishing App's
+   installation covers all five repos.
+2. **Merge.** The combined monorepo change lands on `main`: homes renamed,
+   matrices repointed, skills and docs updated, fences reseeded.
+3. **Operator, after merge.** Re-seed each renamed action prefix once with the
+   same pinned split binary and a force push to the renamed sibling's `main`.
+   Pre-rename tags keep the old commits reachable, so existing SHA pins
+   resolve before, during, and after.
+4. **Steady state.** Push-triggered publishes run non-force. The first
+   `publish-skills.yml` run seeds `gemba-skills` and tags it. The next release
+   cut moves each renamed sibling's `v1` and version tags onto the new
+   lineage. Dependabot then carries new-lineage SHAs to consumers.
+
+Between steps 2 and 3, a `main` push can trigger action publishes that fail as
+non-fast-forward on the renamed legs. The failure is visible, scoped to those
+legs (`fail-fast: false`), and harmless: consumers keep resolving the pinned
+old-lineage SHAs. Step 3 clears it.
+
+## Clean break
+
+This design removes:
+
+- The four bare-name entries and path filters in the action publish matrix.
+- The `fit gemba` two-prefix pack leg and its repeated-prefix bootstrap note.
+- The `{{FIT_*_REF}}` placeholder tokens.
+- The "Gemba — `fit-skills`" mapping and every authored
+  `forwardimpact/{benchmark,bootstrap,harness,wiki}` reference.
+
+The sibling repos are renamed, not duplicated. The redirects that keep old
+pins resolving are GitHub-native. This design adds no shim it must maintain.

--- a/specs/2280-gemba-action-prefix-skills-pack/spec.md
+++ b/specs/2280-gemba-action-prefix-skills-pack/spec.md
@@ -1,0 +1,167 @@
+# Spec 2280: Gemba-Prefixed Actions and the gemba-skills Pack
+
+**Classification:** product-aligned. The change lands on the Gemba product
+surface (`products/gemba/actions/`), on its published skill distribution, and
+on the documentation of those surfaces.
+
+**Persona and job:** Teams Using Agents → Stand Up and Operate an Agent Team
+(Gemba's Big Hire in JTBD.md).
+
+## Problem
+
+Gemba ships one runtime loop on two surfaces (spec 2250). The command surface
+carries the product name: `gemba-harness`, `gemba-trace`, `gemba-wiki`,
+`gemba-xmr`, `gemba-benchmark`, `gemba-selfedit`. The action surface does not.
+The skill surface ships inside another product's pack. The setup skill still
+teaches names from two naming generations ago. A team that hires the platform
+must decode all three inconsistencies before the first workflow runs.
+
+### The platform actions do not carry the product name
+
+The monorepo publishes seven composite actions to sibling repos. The Kata and
+Jidoka actions carry their product prefix. The four Gemba actions do not.
+
+| Product | Action homes under `products/<product>/actions/` | Sibling repos |
+| ------- | ------------------------------------------------ | ------------- |
+| Kata | `kata-agent`, `kata-interview` | `forwardimpact/kata-agent`, `forwardimpact/kata-interview` |
+| Jidoka | `jidoka` | `forwardimpact/jidoka` |
+| Gemba | `benchmark`, `bootstrap`, `harness`, `wiki` | `forwardimpact/benchmark`, `forwardimpact/bootstrap`, `forwardimpact/harness`, `forwardimpact/wiki` |
+
+The bare names cost consumers three ways:
+
+- A consumer cannot attribute `uses: forwardimpact/harness` to a product. The
+  name `forwardimpact/wiki` reads as the organization's wiki, not as a memory
+  action.
+- The action name does not mirror the CLI it fronts. The `harness` action runs
+  `gemba-harness`. The `wiki` action runs `gemba-wiki`. The pairing is
+  invisible in a workflow file.
+- The Gemba overview page must explain that four generically named repos form
+  one platform surface.
+
+Two prior decisions produced this state, and both premises are now gone. Spec
+2140 debranded the `fit-*` action repos to bare names. It kept `kata-agent`
+because a bare `agent` is too generic. It dropped CLI-to-action name parity
+because the CLIs were `fit-*` and no product owned the actions. Spec 2250 then
+created the Gemba product and moved the action homes under it. It excluded
+sibling renames because the product name was still a deferred decision. The
+name is now resolved. By spec 2140's own retention test, all four bare names
+fail: each is generic, and a named product owns each one.
+
+### The platform skills ship inside the fit-skills pack
+
+- The skill-pack publish workflow stages two prefixes (`fit gemba`) into
+  `forwardimpact/fit-skills` and stamps the result with Gear's package version.
+- Kata and Jidoka own product packs (`kata-skills`, `jidoka-skills`, each
+  versioned by its product package). Gemba does not. Root CLAUDE.md maps
+  "Gemba — `fit-skills`".
+- A team that wants the six platform skills (`gemba` plus five `gemba-*`
+  capability skills) must install every `fit-*` skill (seventeen today) aimed
+  at a different persona, Platform Builders.
+- A Kata installation gets no platform skills at all. The kata-setup
+  prerequisite installs `forwardimpact/kata-skills` only. Downstream agents
+  run the `gemba-wiki`, `gemba-trace`, and `gemba-xmr` CLIs with no installed
+  skill that teaches them.
+
+### The setup skill teaches superseded names
+
+The kata-setup dispatch template pins the platform actions through
+placeholders named `{{FIT_BOOTSTRAP_REF}}`, `{{FIT_HARNESS_REF}}`, and
+`{{FIT_WIKI_REF}}`. Those tokens carry the `fit-` names that spec 2140
+retired. One generated file shows three naming generations at once: `fit-`
+placeholder tokens, bare sibling repos on the `uses:` lines, and `gemba-*` CLI
+names in the `clis:` input.
+
+### Who is affected
+
+| Who | How |
+| --- | --- |
+| Teams Using Agents | The job's trigger is "the team must reverse-engineer it from CI plumbing". Unattributable action names and a skill pack hidden inside another product are that plumbing. |
+| Kata installations | Setup omits the platform skills and generates workflows that teach retired names. |
+| Internal contributors | Docs, enum fences, and the org repo list mix three naming generations. |
+
+## Proposal
+
+Bring the platform's published distribution under the product's name.
+
+1. **Rename the four platform actions to `gemba-*`.** The monorepo homes
+   become `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, and
+   `gemba-wiki`. The sibling repos take the same names. GitHub repo renames
+   preserve redirects, tags, and commit SHAs, so existing downstream pins keep
+   resolving (the mechanism spec 2140 shipped).
+2. **Publish a `forwardimpact/gemba-skills` pack.** It carries the `gemba`
+   product skill and the `gemba-*` capability skills, versioned by the Gemba
+   product package, installed with `apm install forwardimpact/gemba-skills`.
+   The fit-skills pack returns to `fit-*` skills only.
+3. **Update the kata-setup skill.** Generated templates and ref resolution
+   name the `gemba-*` actions. Placeholder tokens follow. The prerequisites
+   install `forwardimpact/gemba-skills` beside `forwardimpact/kata-skills`, so
+   Kata agents get the platform skills with the platform.
+
+**Compatibility stance:** clean break. Every authored reference moves in one
+change. No shims, no alias repos, no dual publishing. External consumers keep
+resolving only through GitHub's built-in rename redirects. Old-path removal is
+a success criterion.
+
+## Scope
+
+### Included
+
+| Surface | Change |
+| ------- | ------ |
+| Action homes under the Gemba product | The four directories rename to `gemba-*`. Contents stay byte-faithful whole-root mirrors. |
+| Published sibling repos | GitHub renames the four repos to `gemba-*` (operator action; redirects retained). |
+| Action publish workflow | Matrix prefixes, sibling repo names, and path filters follow the renames. |
+| Monorepo workflow consumers | Every SHA-pinned `uses:` line repoints to the renamed sibling at the same SHA. |
+| Sibling-internal references | The kata-agent and kata-interview actions, the Jidoka action's docs, and the benchmark action's reusable workflow repoint their `uses:` lines and self-references. |
+| Skill-pack publish workflow | The fit leg stages `fit` only. A new leg publishes `gemba-skills` (prefix `gemba`, versioned by the Gemba package). |
+| New sibling repo `forwardimpact/gemba-skills` | Created empty; the publishing App's installation covers it (operator action). |
+| kata-setup skill | Prerequisites add the gemba-skills install. Templates, ref-resolution instructions, and placeholder tokens use the `gemba-*` names. |
+| monorepo-setup skill | The pack install line adds `forwardimpact/gemba-skills`. |
+| Gemba skills and product docs | The `gemba` product skill, the `gemba-benchmark` skill, the Gemba overview page, and the benchmark CI-workflow guide name the renamed actions and the pack install. |
+| CLI documentation parity | The benchmark CLI's `documentation` entry and its golden help output follow the skill's renamed link text. |
+| Enum and contributor docs | The action table in `.github/CLAUDE.md` (the `sibling-composite-actions` enum source), the reseeded fences in CLAUDE.md and KATA.md, the Distribution Model pack list, and the Gemba pack mapping update together. |
+| Repo-local path references | The session hook, the justfile installer recipe, and the binaries publish workflow follow the bootstrap directory rename. |
+
+### Excluded
+
+| Item | Why |
+| ---- | --- |
+| CLI names, npm packages, launchers | Already `gemba-*`. Unchanged. |
+| The `fit-install.sh` file name | It is a released asset that external docs and pinned curl commands consume. Renaming it is a separate decision (spec 2250 deferred it). Only its directory moves. |
+| `kata-agent`, `kata-interview`, `jidoka` action names | Already product-prefixed. Only their internal `uses:` lines change. |
+| Local `.github/actions/*` CI glue | Unpublished. Outside the sibling naming standard. |
+| Benchmark family fixtures (`benchmarks/*`) | Eval fixtures with their own naming. Adding or renaming families is eval work, not distribution naming. |
+| Outpost pack template | It declares `fit-skills` and uses no gemba skill. The pack split does not affect it. |
+| Historical records | Prior `specs/**` documents and changelog entries that name old actions are immutable records. |
+| Pack mechanics | `fit-pack` staging and the APM layout are reused unchanged. |
+
+## Success criteria
+
+| # | Claim | Verification |
+| - | ----- | ------------ |
+| 1 | The four action homes carry the product prefix. | `ls products/gemba/actions/` lists exactly `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, `gemba-wiki`. |
+| 2 | The action publish matrix targets only `gemba-*` sibling repos for the platform actions. | `.github/workflows/publish-actions.yml` maps each `products/gemba/actions/gemba-*` prefix to the matching `gemba-*` repo. |
+| 3 | No authored reference to the bare sibling names remains. | `rg -n 'forwardimpact/(benchmark|bootstrap|harness|wiki)\b' --glob '!specs/**' --glob '!**/CHANGELOG.md'` returns nothing. |
+| 4 | The gemba skills ship as their own pack. | `.github/workflows/publish-skills.yml` carries a `gemba-skills` leg with prefix `gemba` versioned by `products/gemba/package.json`, and the fit leg's prefix is `fit` alone. |
+| 5 | kata-setup teaches the platform names. | `rg -n 'FIT_(BOOTSTRAP|HARNESS|WIKI)_REF' .claude/skills/kata-setup/` returns nothing; the skill's prerequisites and templates name `forwardimpact/gemba-skills` and `forwardimpact/gemba-*` actions. |
+| 6 | The enum fences list the renamed actions. | The `sibling-composite-actions` fences list `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, `gemba-wiki`, `jidoka`, `kata-agent`, `kata-interview`. |
+| 7 | The product docs name the pack and the renamed actions. | The Gemba overview's actions table and Getting Started name `forwardimpact/gemba-*` and `apm install forwardimpact/gemba-skills`; root CLAUDE.md maps Gemba to `gemba-skills` and lists the pack among the synced siblings. |
+| 8 | Repository checks and tests stay green. | `bun run check` and `bun run test` pass. |
+| 9 | The renamed siblings and the new pack publish green. | After the operator renames the four repos and creates `gemba-skills` with App access, the next `main` publish runs of `publish-actions.yml` and `publish-skills.yml` succeed on every renamed leg. |
+
+## Relationship to other specs
+
+- **Spec 2140 (subtree-split actions).** It established monorepo-canonical
+  action sources and the rename-with-redirects mechanism. It also set the
+  retention test this spec applies: a bare name survives only when it is not
+  generic. This spec reuses the mechanism and reverses the bare names by that
+  same test.
+- **Spec 2250 (agent-platform product).** It created Gemba and deferred the
+  sibling renames pending the name decision. This spec completes the naming it
+  deferred.
+- **Spec 2260 (Jidoka product reframe).** Precedent: a product action
+  published under the product's name and a pack versioned by the product
+  package.
+- **Spec 2160 (bootstrap apm install).** The bootstrap action provisions the
+  packs a consumer declares. The gemba-skills pack reaches downstream
+  installations through that same path once declared.

--- a/specs/2280-gemba-action-prefix-skills-pack/spec.md
+++ b/specs/2280-gemba-action-prefix-skills-pack/spec.md
@@ -1,8 +1,7 @@
 # Spec 2280: Gemba-Prefixed Actions and the gemba-skills Pack
 
-**Classification:** product-aligned. The change lands on the Gemba product
-surface (`products/gemba/actions/`), on its published skill distribution, and
-on the documentation of those surfaces.
+**Classification:** product-aligned — the change lands on the Gemba product
+surface, its published skill distribution, and the documentation of both.
 
 **Persona and job:** Teams Using Agents → Stand Up and Operate an Agent Team
 (Gemba's Big Hire in JTBD.md).
@@ -38,25 +37,29 @@ The bare names cost consumers three ways:
 - The Gemba overview page must explain that four generically named repos form
   one platform surface.
 
-Two prior decisions produced this state, and both premises are now gone. Spec
-2140 debranded the `fit-*` action repos to bare names. It kept `kata-agent`
-because a bare `agent` is too generic. It dropped CLI-to-action name parity
-because the CLIs were `fit-*` and no product owned the actions. Spec 2250 then
-created the Gemba product and moved the action homes under it. It excluded
-sibling renames because the product name was still a deferred decision. The
-name is now resolved. By spec 2140's own retention test, all four bare names
-fail: each is generic, and a named product owns each one.
+Two recorded decisions produced this state. Spec 2140 debranded the `fit-*`
+action repos to bare names, kept `kata-agent` because a bare `agent` is too
+generic, and dropped CLI-to-action name parity "since the `forwardimpact/`
+owner already namespaces a published action". Spec 2250 created the Gemba
+product, moved the action homes under it, and excluded sibling renames so
+downstream `uses:` pins stayed untouched. It also deferred the product's
+name. The premises behind both decisions have since moved. The organization
+now publishes actions for three products, so owner namespacing identifies the
+publisher but not the product. The CLIs these actions front are now
+`gemba-*`, so restored parity carries product attribution instead of a brand
+prefix. GitHub rename redirects keep the downstream pins resolving, which
+removes the cost that motivated 2250's exclusion. The name 2250 deferred is
+resolved: the product is Gemba.
 
 ### The platform skills ship inside the fit-skills pack
 
 - The skill-pack publish workflow stages two prefixes (`fit gemba`) into
   `forwardimpact/fit-skills` and stamps the result with Gear's package version.
-- Kata and Jidoka own product packs (`kata-skills`, `jidoka-skills`, each
-  versioned by its product package). Gemba does not. Root CLAUDE.md maps
-  "Gemba — `fit-skills`".
+- Kata and Jidoka own product packs (`kata-skills`, `jidoka-skills`). Gemba
+  does not. Root CLAUDE.md maps "Gemba — `fit-skills`".
 - A team that wants the six platform skills (`gemba` plus five `gemba-*`
   capability skills) must install every `fit-*` skill (seventeen today) aimed
-  at a different persona, Platform Builders.
+  at other personas.
 - A Kata installation gets no platform skills at all. The kata-setup
   prerequisite installs `forwardimpact/kata-skills` only. Downstream agents
   run the `gemba-wiki`, `gemba-trace`, and `gemba-xmr` CLIs with no installed
@@ -77,6 +80,7 @@ names in the `clis:` input.
 | --- | --- |
 | Teams Using Agents | The job's trigger is "the team must reverse-engineer it from CI plumbing". Unattributable action names and a skill pack hidden inside another product are that plumbing. |
 | Kata installations | Setup omits the platform skills and generates workflows that teach retired names. |
+| Existing fit-skills installations | The pack's next sync drops the six gemba skills. A team that adopted fit-skills for them must install gemba-skills. |
 | Internal contributors | Docs, enum fences, and the org repo list mix three naming generations. |
 
 ## Proposal
@@ -98,9 +102,12 @@ Bring the platform's published distribution under the product's name.
    Kata agents get the platform skills with the platform.
 
 **Compatibility stance:** clean break. Every authored reference moves in one
-change. No shims, no alias repos, no dual publishing. External consumers keep
-resolving only through GitHub's built-in rename redirects. Old-path removal is
-a success criterion.
+change. No shims, no alias repos, no dual publishing. For the action renames,
+external consumers keep resolving only through GitHub's built-in rename
+redirects. The pack split has no redirect analogue: the next fit-skills sync
+drops the gemba skills, and the fit-skills README notes where they moved (the
+jidoka-skills rename note is the precedent). Old-path removal is a success
+criterion.
 
 ## Scope
 
@@ -108,26 +115,26 @@ a success criterion.
 
 | Surface | Change |
 | ------- | ------ |
-| Action homes under the Gemba product | The four directories rename to `gemba-*`. Contents stay byte-faithful whole-root mirrors. |
+| Action homes under the Gemba product | The four directories rename to `gemba-*`. Each home stays the byte-faithful mirror of its sibling repo root. |
 | Published sibling repos | GitHub renames the four repos to `gemba-*` (operator action; redirects retained). |
 | Action publish workflow | Matrix prefixes, sibling repo names, and path filters follow the renames. |
 | Monorepo workflow consumers | Every SHA-pinned `uses:` line repoints to the renamed sibling at the same SHA. |
-| Sibling-internal references | The kata-agent and kata-interview actions, the Jidoka action's docs, and the benchmark action's reusable workflow repoint their `uses:` lines and self-references. |
-| Skill-pack publish workflow | The fit leg stages `fit` only. A new leg publishes `gemba-skills` (prefix `gemba`, versioned by the Gemba package). |
+| Sibling-internal references | The four renamed actions' own README and metadata self- and cross-references, the kata-agent and kata-interview actions, the Jidoka action's metadata and README, and the benchmark action's reusable workflow all repoint to the `gemba-*` names. |
+| Skill-pack publish workflow | The fit leg stages `fit` only, and the fit-skills README notes where the gemba skills moved. A new leg publishes `gemba-skills` (prefix `gemba`, versioned by the Gemba package); a Gemba version bump alone republishes the pack. |
 | New sibling repo `forwardimpact/gemba-skills` | Created empty; the publishing App's installation covers it (operator action). |
 | kata-setup skill | Prerequisites add the gemba-skills install. Templates, ref-resolution instructions, and placeholder tokens use the `gemba-*` names. |
 | monorepo-setup skill | The pack install line adds `forwardimpact/gemba-skills`. |
 | Gemba skills and product docs | The `gemba` product skill, the `gemba-benchmark` skill, the Gemba overview page, and the benchmark CI-workflow guide name the renamed actions and the pack install. |
 | CLI documentation parity | The benchmark CLI's `documentation` entry and its golden help output follow the skill's renamed link text. |
 | Enum and contributor docs | The action table in `.github/CLAUDE.md` (the `sibling-composite-actions` enum source), the reseeded fences in CLAUDE.md and KATA.md, the Distribution Model pack list, and the Gemba pack mapping update together. |
-| Repo-local path references | The session hook, the justfile installer recipe, and the binaries publish workflow follow the bootstrap directory rename. |
+| Repo-local path references | The session hook, the justfile installer recipe, the binaries publish workflow, the split-and-push docstring example, and the `.github/CLAUDE.md` bootstrap path follow the directory renames. |
 
 ### Excluded
 
 | Item | Why |
 | ---- | --- |
 | CLI names, npm packages, launchers | Already `gemba-*`. Unchanged. |
-| The `fit-install.sh` file name | It is a released asset that external docs and pinned curl commands consume. Renaming it is a separate decision (spec 2250 deferred it). Only its directory moves. |
+| The `fit-install.sh` file name | It is a released asset that external docs and pinned curl commands consume. Renaming it is a separate decision. Only its directory moves. |
 | `kata-agent`, `kata-interview`, `jidoka` action names | Already product-prefixed. Only their internal `uses:` lines change. |
 | Local `.github/actions/*` CI glue | Unpublished. Outside the sibling naming standard. |
 | Benchmark family fixtures (`benchmarks/*`) | Eval fixtures with their own naming. Adding or renaming families is eval work, not distribution naming. |
@@ -137,28 +144,30 @@ a success criterion.
 
 ## Success criteria
 
-| # | Claim | Verification |
-| - | ----- | ------------ |
-| 1 | The four action homes carry the product prefix. | `ls products/gemba/actions/` lists exactly `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, `gemba-wiki`. |
-| 2 | The action publish matrix targets only `gemba-*` sibling repos for the platform actions. | `.github/workflows/publish-actions.yml` maps each `products/gemba/actions/gemba-*` prefix to the matching `gemba-*` repo. |
-| 3 | No authored reference to the bare sibling names remains. | `rg -n 'forwardimpact/(benchmark|bootstrap|harness|wiki)\b' --glob '!specs/**' --glob '!**/CHANGELOG.md'` returns nothing. |
-| 4 | The gemba skills ship as their own pack. | `.github/workflows/publish-skills.yml` carries a `gemba-skills` leg with prefix `gemba` versioned by `products/gemba/package.json`, and the fit leg's prefix is `fit` alone. |
-| 5 | kata-setup teaches the platform names. | `rg -n 'FIT_(BOOTSTRAP|HARNESS|WIKI)_REF' .claude/skills/kata-setup/` returns nothing; the skill's prerequisites and templates name `forwardimpact/gemba-skills` and `forwardimpact/gemba-*` actions. |
-| 6 | The enum fences list the renamed actions. | The `sibling-composite-actions` fences list `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, `gemba-wiki`, `jidoka`, `kata-agent`, `kata-interview`. |
-| 7 | The product docs name the pack and the renamed actions. | The Gemba overview's actions table and Getting Started name `forwardimpact/gemba-*` and `apm install forwardimpact/gemba-skills`; root CLAUDE.md maps Gemba to `gemba-skills` and lists the pack among the synced siblings. |
-| 8 | Repository checks and tests stay green. | `bun run check` and `bun run test` pass. |
-| 9 | The renamed siblings and the new pack publish green. | After the operator renames the four repos and creates `gemba-skills` with App access, the next `main` publish runs of `publish-actions.yml` and `publish-skills.yml` succeed on every renamed leg. |
+| #  | Claim | Verification |
+| -- | ----- | ------------ |
+| 1  | The four action homes carry the product prefix. | `ls products/gemba/actions/` lists exactly `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, `gemba-wiki`. |
+| 2  | The action publish matrix targets only `gemba-*` sibling repos for the platform actions. | `.github/workflows/publish-actions.yml` maps each `products/gemba/actions/gemba-*` prefix to the matching `gemba-*` repo. |
+| 3  | No authored reference to the bare sibling names remains. | `rg -n --hidden -g '!.git/**' -g '!specs/**' -g '!**/CHANGELOG.md' 'forwardimpact/(benchmark|bootstrap|harness|wiki)\b'` returns nothing. |
+| 4  | No authored reference to the old home paths remains. | `rg -n --hidden -g '!.git/**' -g '!specs/**' 'products/gemba/actions/(benchmark|bootstrap|harness|wiki)\b'` returns nothing. |
+| 5  | The gemba skills ship as their own pack. | `.github/workflows/publish-skills.yml` carries a `gemba-skills` leg with prefix `gemba` versioned by `products/gemba/package.json`, and the fit leg's prefix is `fit` alone. |
+| 6  | kata-setup teaches the platform names. | `rg -n --hidden 'FIT_(BOOTSTRAP|HARNESS|WIKI)_REF' .claude/skills/kata-setup/` returns nothing; the skill's prerequisites and templates name `forwardimpact/gemba-skills` and `forwardimpact/gemba-*` actions. |
+| 7  | The enum fences list the renamed actions. | The `sibling-composite-actions` fences list `gemba-benchmark`, `gemba-bootstrap`, `gemba-harness`, `gemba-wiki`, `jidoka`, `kata-agent`, `kata-interview`. |
+| 8  | The product docs name the pack and the renamed actions. | The Gemba overview page's actions table and its own Getting Started section name `forwardimpact/gemba-*` and `apm install forwardimpact/gemba-skills`; root CLAUDE.md maps Gemba to `gemba-skills` and lists the pack among the synced siblings. |
+| 9  | Repository checks and tests stay green. | `bun run check` and `bun run test` pass. |
+| 10 | The renamed siblings and the new pack publish green. | The operator renames the four repos and creates `gemba-skills` (App access included) before the merge; after the merge and the one-time re-seed, the next `main` runs of `publish-actions.yml` and `publish-skills.yml` succeed on every renamed leg. |
 
 ## Relationship to other specs
 
 - **Spec 2140 (subtree-split actions).** It established monorepo-canonical
-  action sources and the rename-with-redirects mechanism. It also set the
-  retention test this spec applies: a bare name survives only when it is not
-  generic. This spec reuses the mechanism and reverses the bare names by that
-  same test.
-- **Spec 2250 (agent-platform product).** It created Gemba and deferred the
-  sibling renames pending the name decision. This spec completes the naming it
-  deferred.
+  action sources, the rename-with-redirects mechanism, and the seed runbook
+  pattern this change reuses. It recorded the parity drop this spec reverses.
+  The reversal premise is product attribution, not a revised genericness
+  verdict.
+- **Spec 2250 (agent-platform product).** It created Gemba and excluded the
+  sibling renames so downstream pins stayed untouched. Rename redirects
+  preserve those pins, and the name it deferred is resolved, so this spec
+  completes the naming.
 - **Spec 2260 (Jidoka product reframe).** Precedent: a product action
   published under the product's name and a pack versioned by the product
   package.


### PR DESCRIPTION
Lockstep spec + design for spec **2280**. One PR carries both artifacts per the lockstep co-execution protocol; no separate spec PR exists.

## What

Bring Gemba's published distribution under the product's name:

1. **Rename the four platform actions to `gemba-*`** — homes under `products/gemba/actions/` and the sibling repos (`benchmark`→`gemba-benchmark`, `bootstrap`→`gemba-bootstrap`, `harness`→`gemba-harness`, `wiki`→`gemba-wiki`). GitHub repo renames keep redirects, tags, and SHAs, so existing pins resolve throughout.
2. **Publish `forwardimpact/gemba-skills`** — the `gemba` product skill plus the five `gemba-*` capability skills, versioned by the Gemba package. fit-skills returns to `fit-*` only.
3. **Update kata-setup** — `gemba-*` action refs and placeholders, plus a gemba-skills prerequisite so Kata installations get the platform skills.

Compatibility stance: clean break in every authored reference; external continuity through GitHub rename redirects only.

## Artifacts

- `specs/2280-gemba-action-prefix-skills-pack/spec.md` (WHAT/WHY)
- `specs/2280-gemba-action-prefix-skills-pack/design-a.md` (WHICH/WHERE, 110 lines)

## Review panel disposition

Clean panel per the kata-review caller protocol, 12 reviewers in one batch (spec: 3 product-manager + 3 staff-engineer; design: 3 staff-engineer + 3 devex-engineer). Zero blockers. All consensus blocker/high/medium findings addressed in the follow-up commit: hidden-file semantics on both absence sweeps (`--hidden`, `.git` excluded), faithful 2140/2250 citations (recorded reasons quoted, misattributed "retention test" and "2250 deferred it" claims removed), kata-skills versioning claim corrected, the four actions' own self-references added to scope, Jidoka action docs added to the design's component map, `products/gemba/package.json` added to the pack leg's `paths:` trigger, gemba-skills repo initialized with a first commit, v1-only tag move (old version tags stay as old-lineage anchors), and both rollout failure windows documented. Verified singletons addressed in the same pass.

## Operator runbook (from design § Rollout)

1. Before merge: rename the four sibling repos, create `forwardimpact/gemba-skills` with an initial commit, verify App installation coverage on all five.
2. After merge: one sanctioned re-seed force push per renamed action sibling, then publishes stay non-force.

## Approval and STATUS

The trusted human invoked `/ship-it` on this branch in the interactive session on 2026-08-14. That in-session message is the design-class approval signal; under lockstep it covers the bundled spec (`design approved` subsumes `spec approved`). The human-directed squash-merge of this PR is the same signal expressed on the PR.

`wiki/STATUS.md` reconciliation is still needed: this session's git proxy does not authorize `forwardimpact/monorepo.wiki`, so the row could not be pushed from here. On the next wiki-authorized run, set the row to `2280	design	approved` (claimed at `spec draft` → `design draft` → approved per the lockstep lifecycle), and release the stale `staff-engineer | spec-2280` claim row if present.