### PR TITLE
design(2290): repository settings file for kata skills

### DIFF
--- a/specs/2290-kata-settings-file/design-a.md
+++ b/specs/2290-kata-settings-file/design-a.md
@@ -41,9 +41,9 @@ by the read mechanic's degradation rules alone.
 | --------- | ----- | ---- |
 | Settings file | `.kata/settings.json` at the consumer repository root | One flat JSON object. Holds only selectors: identifiers from the owning tables, integers, or string lists. Optional. |
 | Shared settings reference | New shared agent reference, shipped with the pack beside the other agent references | The single home for the read mechanic (§ Read mechanic). It points at the merge-gate skill for the gate-side rules; it does not restate them. |
-| Trust options table and gate rules | `kata-release-merge` (its trust step is already the canonical trust home per the approval-signals reference) | Defines the `trustSource` rows and the companion parameters. The trust checklist item, the trust step, and the comment-gate step resolve the trusted set through the selected row. New checklist items carry the default-branch read, the fail-closed rule, and the `.kata/`-diff rule. |
+| Trust options table and gate rules | `kata-release-merge`, in a settings reference its trust step points at (the skill is the canonical trust home per the approval-signals reference) | Defines the `trustSource` rows and the companion parameters. The trust checklist item, the trust step, and the comment-gate step resolve the trusted set through the selected row. New checklist items carry the default-branch read, the fail-closed rule, and the `.kata/`-diff rule. |
 | Trust pointer conversions | `kata-release-merge` references (comment gate, re-ping owner table, comment templates) and the approval-signals agent reference | Each restated trust-count literal becomes a pointer to the trust table. Templates name the configured trust source. The dispatch-side trust check inherits the configured source through the approval-signals pointer. |
-| Rigor options tables | `kata-review` caller protocol (already owns panel composition) | Defines the `reviewPanel` profile rows and the `reviewBlockingSeverity` vocabulary. The panel-rationale reference explains profile intent instead of restating fixed sizes. |
+| Rigor options tables | `kata-review`, in a dedicated settings reference the caller protocol points at | Defines the `reviewPanel` profile rows and the `reviewBlockingSeverity` vocabulary. The `reviewPanel` block's body is the profile table itself. The panel-rationale reference explains profile intent instead of restating fixed sizes. |
 | Floor pointers | `kata-review` severity-vocabulary caller obligation; both floor restatements (exit checklist and panel step) in `kata-spec`, `kata-design`, `kata-plan`, `kata-implement` | Each points at the caller protocol's configured floor. |
 | Settings invariant | `.jidoka/invariants/` rule module in this repository | Holds the machine-readable key vocabulary, validates the settings file when present, and checks each options table against the vocabulary. The table-agreement check reuses the enumeration-drift pattern. |
 | Setup and orientation | `kata-setup` output note; one KATA.md paragraph | Name the optional file and point at the owning tables. Neither restates a vocabulary. |
@@ -77,6 +77,47 @@ Panel profile rows (owned by the caller protocol; sizes per panel):
 The consensus threshold stays ≥⌈N/2⌉ for any panel size. The severity floor
 means: address every confirmed consensus finding at the floor severity or
 above. `medium` reproduces today's blocker/high/medium rule.
+
+## Options-block format
+
+Every key lives in one `<setting>` block, the same semantic-tag play as
+`<job>` and the checklist tags. `rg '<setting '` enumerates every knob
+repo-wide.
+
+```markdown
+<setting key="trustSource" default="top-contributors">
+
+| Option | Meaning |
+| --- | --- |
+| `top-contributors` (default) | Trust the top `trustContributorCount` humans by contributor ranking. |
+| `allowlist` | Trust exactly the logins in `trustAllowlist`. Empty list: no human. |
+
+</setting>
+
+<setting key="trustContributorCount" default="7">
+
+Integer, minimum 1. Applies under `trustSource: top-contributors`; ignored
+otherwise. Counts humans only; the CI app identity stays trusted.
+
+</setting>
+```
+
+- The opening tag carries exactly `key` and `default`, on one line within 74
+  characters (worst phase-1 tag: 55).
+- A selector block's body is one table with the option identifiers in column
+  one and exactly one cell suffixed `(default)`. Extra columns are free: the
+  `reviewPanel` block's body is the profile table in § Key vocabulary.
+- A parameter block's body is prose: type, constraints, and applicability in
+  one sentence. The body never restates the default literal; the attribute
+  is that class's one home.
+- The shared settings reference documents this grammar once, beside the
+  read mechanic.
+- The settings invariant anchors on the tags (outside fenced code) and
+  asserts: one-line opening tag, paired closing tag, exactly one block per
+  machine-vocabulary key in both directions, option column equal to the
+  machine vocabulary, exactly one `(default)` mark, and the mark equal to
+  the `default` attribute. Types and ranges live in the machine vocabulary,
+  not the tag.
 
 ## Read mechanic
 
@@ -114,6 +155,9 @@ them:
 | Invalid explicit configuration at the gate | Fail closed | Degrade to defaults. An unreadable allowlist that silently widens trust back to the contributor ranking is a trust escalation, the reverse of the file's intent. |
 | Enforcement | Invariant holds the machine vocabulary and checks the tables against it | A standalone JSON Schema shipped in the pack. Nothing runs it in a consumer repo; the invariant reuses the repository's existing stop-the-line channel. |
 | Gate read source | Default branch | Working tree. A PR that edits `.kata/settings.json` could weaken the trust gate that judges the same PR. |
+| Tag attributes | `key` and `default` only | Adding `type` and `applies` attributes. The worst phase-1 tag then measures 73 and 103 characters against the one-line-within-74 tag rule; the machine vocabulary already owns types, and applicability is reader documentation, not machine surface. |
+| Selector default marking | `default` attribute plus one mandatory `(default)` row suffix, reconciled by the invariant | Attribute only (rendered views strip unknown tags, so the table loses its default) or row only (no anchored machine surface). Checked duplication is the house's source-plus-consumer pattern. |
+| Block placement | A references file of the owning skill, pointed at by the procedure step | SKILL.md and caller-protocol placement. The trust home's line carve-out is documented as bounded, the caller protocol has six words of headroom under the reference word cap, and the L6 charter owns lookup data. |
 
 ## Clean break
 

--- a/specs/2290-kata-settings-file/design-a.md
+++ b/specs/2290-kata-settings-file/design-a.md
@@ -1,0 +1,115 @@
+# Design 2290-a: Kata Settings File
+
+Spec 2290 introduces `.kata/settings.json`, a repository-owned selector over
+policy options the skills define. This design fixes the components, the key
+vocabulary, the read mechanic, and the enforcement. It adds no runtime code.
+The agent reads the file because the skill text says to. Every default
+reproduces current behavior, so an installation without the file is untouched.
+
+## Component map
+
+```mermaid
+graph LR
+    subgraph consumer["Consumer repository"]
+        SF[".kata/settings.json<br/>(optional)"]
+    end
+    subgraph pack["kata-skills pack"]
+        XR["x-settings.md<br/>agent reference<br/>(read mechanic)"]
+        RM["kata-release-merge<br/>trust options table"]
+        CP["kata-review<br/>caller-protocol<br/>rigor options tables"]
+        PH["kata-spec · kata-design<br/>kata-plan · kata-implement<br/>floor pointers"]
+    end
+    INV["Settings invariant<br/>.jidoka/invariants/"]
+    SF -->|"read via x-settings.md"| RM
+    SF -->|"read via x-settings.md"| CP
+    PH -->|"floor pointer"| CP
+    RM -.->|"canonical trust list"| GATES["comment-gate · reping<br/>kata-dispatch trust check"]
+    SF --> INV
+    RM --> INV
+    CP --> INV
+```
+
+## Components
+
+| Component | Where | Role |
+| --------- | ----- | ---- |
+| Settings file | `.kata/settings.json` at the consumer repository root | One flat JSON object. Holds only selectors: identifiers from the owning tables, integers, or string lists. Optional; absence selects every default. |
+| Settings mechanic reference | New shared agent reference (`x-settings.md`), shipped with the pack beside the other agent references | The single home for the read mechanic: file location, absent-file and absent-key semantics, unparseable-file semantics, the defaults-equal-current-behavior principle, and the rule that a key no table defines has no effect and is surfaced as a finding. |
+| Trust options table | `kata-release-merge` (its trust step is already the canonical trust home per the approval-signals reference) | Defines `trustSource` rows and the `trustContributorCount` / `trustAllowlist` parameters. The gate resolves the trusted set through the selected row. |
+| Rigor options tables | `kata-review` `references/caller-protocol.md` (already owns panel composition) | Defines `reviewPanel` profile rows and the `reviewBlockingSeverity` vocabulary. |
+| Phase-skill floor pointers | `kata-spec`, `kata-design`, `kata-plan`, `kata-implement` | Each replaces its restated blocker/high/medium sentence with a pointer to the caller protocol's configured floor. |
+| Settings invariant | `.jidoka/invariants/` rule module in this repository | Parses the settings file when present, rejects unknown keys and out-of-vocabulary values, and checks each options table against the machine-readable vocabulary the rule holds. |
+| Setup and orientation | `kata-setup` output note; one KATA.md paragraph | Name the optional file and point at the owning tables. Neither restates a vocabulary. |
+
+## Key vocabulary (the interface)
+
+| Key | Type | Vocabulary | Default |
+| --- | ---- | ---------- | ------- |
+| `trustSource` | identifier | `top-contributors`, `allowlist` | `top-contributors` |
+| `trustContributorCount` | integer ≥ 1 | — | `7` |
+| `trustAllowlist` | string list | tracker logins | `[]` |
+| `reviewPanel` | identifier | `light`, `standard`, `thorough` | `standard` |
+| `reviewBlockingSeverity` | identifier | `blocker`, `high`, `medium`, `low` | `medium` |
+
+Each key is independently meaningful. `trustContributorCount` applies only
+under `top-contributors`; `trustAllowlist` applies only under `allowlist`; an
+inapplicable key is ignored. The owning table documents this per row.
+
+Panel profile rows (owned by the caller protocol; sizes per panel):
+
+| Profile | Spec panels | Design/plan panels | Implementation panels |
+| ------- | ----------- | ------------------ | --------------------- |
+| `light` | product 1 + technical 1 | technical 1 + devex 1 | technical 1 + devex 1 |
+| `standard` (default) | product 3 + technical 3 | technical 3 + devex 3 | technical 5 + devex 3 |
+| `thorough` | product 5 + technical 5 | technical 5 + devex 5 | technical 5 + devex 5 |
+
+The consensus threshold stays ≥⌈N/2⌉ for any panel size. The severity floor
+means: address every confirmed consensus finding at the floor severity or
+above. `medium` reproduces today's blocker/high/medium rule.
+
+## Read mechanic
+
+- Skills read `.kata/settings.json` from the repository root at invocation.
+- An absent file, an absent key, or an unparseable file selects the marked
+  defaults. An unparseable file is additionally surfaced as a finding.
+- **Gate exception.** `kata-release-merge` reads the file from the default
+  branch (the committed state on the trunk), never from a PR head or a
+  worktree that contains PR content. All other skills read the working tree.
+- A diff that touches `.kata/` is trust-sensitive at the gate: it merges only
+  on the strictest human signal, the same treatment agent-instruction paths
+  receive on the experiment path.
+
+## Key decisions
+
+| Decision | Choice | Rejected alternative and why |
+| -------- | ------ | ---------------------------- |
+| Loader | The agent reads the file per skill text | A harness or library loader. It couples published skills to one runtime, breaks standalone IDE use, and adds a moving part every consumer must run. |
+| File shape | Flat keys, scalar or string-list values | Grouped objects with named references (trust groups, per-gate overrides). Model-side joins and polymorphic shapes degrade instruction-following, and no code resolver exists to absorb them. |
+| Panel configuration | Named profiles | Per-caller numeric keys. Free numerics create untested combinations and let one typo run a 9-reviewer panel; a profile row is one lookup with reviewed contents. |
+| Vocabulary home | The owning skill's options table | Semantics in the JSON file or a schema document. Two homes drift; the table is the layer agents already load. |
+| Failure posture | Defaults equal current behavior | Fail-loud on any read problem. A hard failure turns a missing optional file into an outage; degrading to the known-safe posture keeps every existing installation working unchanged. |
+| Enforcement | Invariant holds the machine vocabulary and checks the tables against it | A standalone JSON Schema shipped in the pack. Nothing runs it in a consumer repo; the invariant reuses the repository's existing stop-the-line channel, the same pattern the enumeration-drift rules use for fence agreement. |
+| Gate read source | Default branch | Working tree. A PR that edits `.kata/settings.json` could weaken the trust gate that judges the same PR. |
+
+## Clean break
+
+This design removes:
+
+- The fixed top-seven literal in the merge gate's trust step. It survives only
+  as the marked default row of the trust table.
+- The fixed panel sizes in the caller protocol. They survive only as the
+  `standard` profile row.
+- The restated blocker/high/medium floor sentences in the four phase skills.
+  Each becomes a pointer to the configured floor.
+
+No environment variable, no fallback mechanism, and no second read path
+exists. The pack ships one mechanic in one reference.
+
+## Consumer-side validation
+
+Consumer repositories run no invariant from this repository. Their protection
+is layered: defaults absorb every read failure, the mechanic reference tells
+the agent to ignore and surface unknown keys, and the gate pins `.kata/`
+changes behind the strictest human signal. The invariant here protects the
+canonical pack: it stops a vocabulary and its owning table from drifting
+apart before a sync ships the drift to every installation.

--- a/specs/2290-kata-settings-file/design-a.md
+++ b/specs/2290-kata-settings-file/design-a.md
@@ -3,8 +3,8 @@
 Spec 2290 introduces `.kata/settings.json`, a repository-owned selector over
 policy options the skills define. This design fixes the components, the key
 vocabulary, the read mechanic, and the enforcement. It adds no runtime code.
-The agent reads the file because the skill text says to. Every default
-reproduces current behavior, so an installation without the file is untouched.
+The agent reads the file because the skill text says to, and an installation
+without the file is untouched.
 
 ## Component map
 
@@ -14,31 +14,38 @@ graph LR
         SF[".kata/settings.json<br/>(optional)"]
     end
     subgraph pack["kata-skills pack"]
-        XR["x-settings.md<br/>agent reference<br/>(read mechanic)"]
-        RM["kata-release-merge<br/>trust options table"]
-        CP["kata-review<br/>caller-protocol<br/>rigor options tables"]
-        PH["kata-spec · kata-design<br/>kata-plan · kata-implement<br/>floor pointers"]
+        XR["Shared settings reference<br/>(read mechanic)"]
+        RM["kata-release-merge<br/>trust table + gate rules"]
+        CP["kata-review caller protocol<br/>rigor tables"]
+        PH["kata-spec · kata-design<br/>kata-plan · kata-implement<br/>kata-review floor pointers"]
+        AS["approval-signals reference<br/>trust pointer"]
     end
-    INV["Settings invariant<br/>.jidoka/invariants/"]
-    SF -->|"read via x-settings.md"| RM
-    SF -->|"read via x-settings.md"| CP
+    subgraph ci["This repository's CI"]
+        INV["Settings invariant<br/>(machine vocabulary)"]
+    end
+    SF -->|"read per the mechanic"| RM
+    SF -->|"read per the mechanic"| CP
     PH -->|"floor pointer"| CP
-    RM -.->|"canonical trust list"| GATES["comment-gate · reping<br/>kata-dispatch trust check"]
-    SF --> INV
+    AS -.->|"pointer (dispatch trust check inherits)"| RM
     RM --> INV
     CP --> INV
 ```
+
+The invariant validates the settings file only inside this repository, where
+one may exist for the monorepo's own installation. Consumer files are governed
+by the read mechanic's degradation rules alone.
 
 ## Components
 
 | Component | Where | Role |
 | --------- | ----- | ---- |
-| Settings file | `.kata/settings.json` at the consumer repository root | One flat JSON object. Holds only selectors: identifiers from the owning tables, integers, or string lists. Optional; absence selects every default. |
-| Settings mechanic reference | New shared agent reference (`x-settings.md`), shipped with the pack beside the other agent references | The single home for the read mechanic: file location, absent-file and absent-key semantics, unparseable-file semantics, the defaults-equal-current-behavior principle, and the rule that a key no table defines has no effect and is surfaced as a finding. |
-| Trust options table | `kata-release-merge` (its trust step is already the canonical trust home per the approval-signals reference) | Defines `trustSource` rows and the `trustContributorCount` / `trustAllowlist` parameters. The gate resolves the trusted set through the selected row. |
-| Rigor options tables | `kata-review` `references/caller-protocol.md` (already owns panel composition) | Defines `reviewPanel` profile rows and the `reviewBlockingSeverity` vocabulary. |
-| Phase-skill floor pointers | `kata-spec`, `kata-design`, `kata-plan`, `kata-implement` | Each replaces its restated blocker/high/medium sentence with a pointer to the caller protocol's configured floor. |
-| Settings invariant | `.jidoka/invariants/` rule module in this repository | Parses the settings file when present, rejects unknown keys and out-of-vocabulary values, and checks each options table against the machine-readable vocabulary the rule holds. |
+| Settings file | `.kata/settings.json` at the consumer repository root | One flat JSON object. Holds only selectors: identifiers from the owning tables, integers, or string lists. Optional. |
+| Shared settings reference | New shared agent reference, shipped with the pack beside the other agent references | The single home for the read mechanic (§ Read mechanic). It points at the merge-gate skill for the gate-side rules; it does not restate them. |
+| Trust options table and gate rules | `kata-release-merge` (its trust step is already the canonical trust home per the approval-signals reference) | Defines the `trustSource` rows and the companion parameters. The trust checklist item, the trust step, and the comment-gate step resolve the trusted set through the selected row. New checklist items carry the default-branch read, the fail-closed rule, and the `.kata/`-diff rule. |
+| Trust pointer conversions | `kata-release-merge` references (comment gate, re-ping owner table, comment templates) and the approval-signals agent reference | Each restated trust-count literal becomes a pointer to the trust table. Templates name the configured trust source. The dispatch-side trust check inherits the configured source through the approval-signals pointer. |
+| Rigor options tables | `kata-review` caller protocol (already owns panel composition) | Defines the `reviewPanel` profile rows and the `reviewBlockingSeverity` vocabulary. The panel-rationale reference explains profile intent instead of restating fixed sizes. |
+| Floor pointers | `kata-review` severity-vocabulary caller obligation; both floor restatements (exit checklist and panel step) in `kata-spec`, `kata-design`, `kata-plan`, `kata-implement` | Each points at the caller protocol's configured floor. |
+| Settings invariant | `.jidoka/invariants/` rule module in this repository | Holds the machine-readable key vocabulary, validates the settings file when present, and checks each options table against the vocabulary. The table-agreement check reuses the enumeration-drift pattern. |
 | Setup and orientation | `kata-setup` output note; one KATA.md paragraph | Name the optional file and point at the owning tables. Neither restates a vocabulary. |
 
 ## Key vocabulary (the interface)
@@ -51,9 +58,13 @@ graph LR
 | `reviewPanel` | identifier | `light`, `standard`, `thorough` | `standard` |
 | `reviewBlockingSeverity` | identifier | `blocker`, `high`, `medium`, `low` | `medium` |
 
-Each key is independently meaningful. `trustContributorCount` applies only
-under `top-contributors`; `trustAllowlist` applies only under `allowlist`; an
-inapplicable key is ignored. The owning table documents this per row.
+One key never changes another key's meaning. The two trust parameters each
+apply under one `trustSource` row (`trustContributorCount` under
+`top-contributors`, `trustAllowlist` under `allowlist`); an inapplicable key
+is ignored, and the owning table says so per row. Two fixed points sit outside
+the vocabulary: the CI app identity stays trusted by definition under every
+`trustSource`, and `allowlist` with an empty `trustAllowlist` therefore
+trusts no human. The owning table documents that fail-closed edge.
 
 Panel profile rows (owned by the caller protocol; sizes per panel):
 
@@ -69,15 +80,27 @@ above. `medium` reproduces today's blocker/high/medium rule.
 
 ## Read mechanic
 
-- Skills read `.kata/settings.json` from the repository root at invocation.
-- An absent file, an absent key, or an unparseable file selects the marked
-  defaults. An unparseable file is additionally surfaced as a finding.
-- **Gate exception.** `kata-release-merge` reads the file from the default
-  branch (the committed state on the trunk), never from a PR head or a
-  worktree that contains PR content. All other skills read the working tree.
-- A diff that touches `.kata/` is trust-sensitive at the gate: it merges only
-  on the strictest human signal, the same treatment agent-instruction paths
-  receive on the experiment path.
+The shared reference owns these rules. Skills read `.kata/settings.json` from
+the repository root at invocation.
+
+- **Absent file or absent key.** Select the marked default.
+- **Unreadable configuration.** A file that fails to parse, or a known key
+  with an out-of-vocabulary or out-of-range value, splits by consumer class.
+  A non-gate skill selects the marked default and reports the problem on its
+  coordination surface (a PR comment when the run owns one, the session
+  output otherwise). The merge gate fails closed: trust-gated merges block
+  with the named reason `settings unreadable`, owned by a trusted human.
+- **Unknown key.** No effect. Reported like an unreadable value.
+
+The gate-side rules live in the merge-gate skill, and the reference points at
+them:
+
+- The gate reads the file from the default branch (the committed trunk
+  state), never from a PR head or a worktree that contains PR content.
+- A diff that touches `.kata/` merges only on a trusted human's explicit
+  signal on that change, pinned to the approved head, per the existing
+  approval-signal classes. No agent-originated approval qualifies, whatever
+  the PR's type or phase.
 
 ## Key decisions
 
@@ -87,29 +110,25 @@ above. `medium` reproduces today's blocker/high/medium rule.
 | File shape | Flat keys, scalar or string-list values | Grouped objects with named references (trust groups, per-gate overrides). Model-side joins and polymorphic shapes degrade instruction-following, and no code resolver exists to absorb them. |
 | Panel configuration | Named profiles | Per-caller numeric keys. Free numerics create untested combinations and let one typo run a 9-reviewer panel; a profile row is one lookup with reviewed contents. |
 | Vocabulary home | The owning skill's options table | Semantics in the JSON file or a schema document. Two homes drift; the table is the layer agents already load. |
-| Failure posture | Defaults equal current behavior | Fail-loud on any read problem. A hard failure turns a missing optional file into an outage; degrading to the known-safe posture keeps every existing installation working unchanged. |
-| Enforcement | Invariant holds the machine vocabulary and checks the tables against it | A standalone JSON Schema shipped in the pack. Nothing runs it in a consumer repo; the invariant reuses the repository's existing stop-the-line channel, the same pattern the enumeration-drift rules use for fence agreement. |
+| Absent configuration | Defaults equal current behavior | Fail-loud on a missing optional file. That turns absence into an outage; every existing installation must keep working unchanged. |
+| Invalid explicit configuration at the gate | Fail closed | Degrade to defaults. An unreadable allowlist that silently widens trust back to the contributor ranking is a trust escalation, the reverse of the file's intent. |
+| Enforcement | Invariant holds the machine vocabulary and checks the tables against it | A standalone JSON Schema shipped in the pack. Nothing runs it in a consumer repo; the invariant reuses the repository's existing stop-the-line channel. |
 | Gate read source | Default branch | Working tree. A PR that edits `.kata/settings.json` could weaken the trust gate that judges the same PR. |
 
 ## Clean break
 
-This design removes:
+This design removes every fixed policy literal outside the owning tables:
 
-- The fixed top-seven literal in the merge gate's trust step. It survives only
-  as the marked default row of the trust table.
-- The fixed panel sizes in the caller protocol. They survive only as the
-  `standard` profile row.
-- The restated blocker/high/medium floor sentences in the four phase skills.
-  Each becomes a pointer to the configured floor.
+- **Trust.** The top-seven literals in the merge-gate skill (trust checklist
+  item, trust step, comment-gate step) and in its references (comment gate,
+  re-ping owner table, the two comment templates), plus the approval-signals
+  trust sentence. Each survives only as the trust table's marked default row
+  or a pointer to it.
+- **Rigor.** The fixed panel sizes in the caller protocol and the size
+  literals in the panel-rationale reference, both subsumed by the profile
+  table. The blocker/high/medium floor restatements: two in each of the four
+  phase skills and one in the review skill's caller obligation, each replaced
+  by a pointer to the configured floor.
 
 No environment variable, no fallback mechanism, and no second read path
 exists. The pack ships one mechanic in one reference.
-
-## Consumer-side validation
-
-Consumer repositories run no invariant from this repository. Their protection
-is layered: defaults absorb every read failure, the mechanic reference tells
-the agent to ignore and surface unknown keys, and the gate pins `.kata/`
-changes behind the strictest human signal. The invariant here protects the
-canonical pack: it stops a vocabulary and its owning table from drifting
-apart before a sync ships the drift to every installation.

--- a/specs/2290-kata-settings-file/spec.md
+++ b/specs/2290-kata-settings-file/spec.md
@@ -1,0 +1,121 @@
+# Spec 2290: Repository Settings File for Kata Skills
+
+**Classification:** product-aligned — the change lands on Kata's published
+skill distribution and the documentation of that surface.
+
+**Persona and job:** Teams Using Agents → Run a Continuously Improving Agent
+Team (Kata's Big Hire in JTBD.md). The Little Hire is the sharper fit: onboard
+a Kata installation that runs the Plan-Do-Study-Act loop without per-team
+prompt engineering.
+
+## Problem
+
+Kata skills hard-code installation policy in instruction text. Every
+installation inherits one fixed governance posture, whatever its size, risk
+tolerance, or token budget. Two policies carry the most cross-installation
+variance:
+
+- **Trust.** The merge gate trusts the CI app identity plus the top seven
+  human contributors by the tracker's contributor ranking. The count and the
+  source are fixed in the skill. The comment gate and the re-ping rule key off
+  the same fixed list.
+- **Review rigor.** The review caller protocol fixes each panel at three
+  reviewers (five for the implementation technical panel). Every phase skill
+  blocks on the fixed blocker/high/medium severity floor.
+
+Installations differ on both:
+
+| Installation | Wants | Gets today |
+| ------------ | ----- | ---------- |
+| Solo maintainer | An explicit allowlist of one trusted login | A contributor ranking that can elevate drive-by committers into the trust set |
+| Small team on metered tokens | One reviewer per panel, blockers only | Twelve sub-agent reviewers per lockstep run, medium floor |
+| Regulated organization | Five reviewers per panel, every finding addressed | Three per panel, low findings optional |
+
+The only override channel today is prose. The release-cut skill defers to
+CONTRIBUTING.md, which "may override the skill defaults". Prose overrides are
+unstructured: nothing validates them, agents must interpret them, and
+equivalent values drift apart. This monorepo shows the drift: the
+audit-rotation revisit threshold is four runs in the security-audit skill, six
+in the documentation skill, and "a few" in the devex-audit skill. Three values
+express one concept.
+
+The remaining escape is to edit the skill text locally. The skill packs sync
+unchanged from upstream, so a local edit is overwritten on the next sync or
+blocks the sync entirely. The JTBD entry names the anxiety this feeds:
+autonomy might amplify bad patterns faster than humans can intervene. A team
+that cannot tune the trust gate or the review rigor to its own risk tolerance
+either forks the pack or fires the product.
+
+## Proposal
+
+A repository-owned settings file, `.kata/settings.json`, selects among policy
+options that the skills themselves define.
+
+1. **Options tables in the owning skill.** Each configurable policy appears in
+   exactly one skill surface as a table of named options. Each row carries an
+   identifier, its meaning, and one marked default.
+2. **The settings file selects.** The file is one flat JSON object. Each key
+   holds an identifier from the owning table, an integer, or a list of
+   strings. No nesting, no key whose meaning depends on another object.
+3. **The agent is the loader.** The skill text instructs the read. No runtime
+   library, harness hook, or environment variable participates. A shared agent
+   reference defines the read mechanic once: file location, absent-file and
+   absent-key semantics, unparseable-file semantics.
+4. **Defaults equal current behavior.** Every marked default reproduces the
+   value the skills enforce today. A missing file, a missing key, an
+   unreadable file, and an agent that never reads the file all produce
+   today's behavior. Misconfiguration degrades to the known-safe posture.
+5. **Phase-1 vocabulary: trust and review rigor.** Trust source
+   (contributor ranking or explicit allowlist), trusted-contributor count, and
+   allowlist. Review panel profile and blocking severity floor.
+6. **Security boundary.** The merge gate reads the settings from the default
+   branch, never from a PR head. A diff that touches `.kata/` gates at the
+   strictest level, the same treatment agent-instruction paths receive.
+7. **Validation.** A repository invariant stops the line when the settings
+   file carries an unknown key or an out-of-vocabulary value, and when a
+   skill's options table disagrees with the machine-readable vocabulary.
+
+**Compatibility stance:** clean break. The hard-coded policy sentences become
+the marked default rows of the options tables. No dual mechanism remains. An
+absent file selecting the defaults is specified behavior, not a compatibility
+shim. Old-path removal (the fixed literals outside the tables) is a success
+criterion.
+
+## Scope
+
+### Included
+
+| Surface | Change |
+| ------- | ------ |
+| `kata-release-merge` skill | Trust policy becomes an options table (source, count, allowlist). The gate resolves trust through the selected option, reads settings from the default branch, and classifies `.kata/` diffs as trust-sensitive. |
+| Comment-gate and re-ping references | Verified to consume the gate's canonical trust list through pointers, with no restated values. |
+| `kata-review` caller protocol | Panel composition becomes a profile table (light / standard / thorough). The blocking severity floor becomes a keyed option. |
+| `kata-spec`, `kata-design`, `kata-plan`, `kata-implement` | Severity-floor sentences point at the caller protocol's configured floor instead of restating blocker/high/medium. |
+| New shared agent reference | Single home for the settings read mechanic: location, absence semantics, unparseable-file semantics, defaults-equal-current-behavior principle. Ships with the pack like the other agent references. |
+| Repository invariant | Validates the settings file and the table-to-vocabulary agreement. |
+| `kata-setup` skill | Names the optional settings file and its owning tables in the setup output. |
+| KATA.md | One orientation paragraph: the file exists, what it governs, where the vocabularies live. |
+
+### Excluded
+
+| Item | Why |
+| ---- | --- |
+| Approval and human-involvement levels per phase gate | A governance-model change with its own trust implications. It needs its own spec once this mechanism is proven. |
+| Cadence, retention, naming, tooling, and template knobs | Future vocabulary growth on the same mechanism. Each key must earn its options table. |
+| Workflow-generation values (crons, roster, models, timeouts) | GitHub evaluates them in workflow YAML. `kata-setup` owns them. |
+| Runtime loader code (libraries, harness, env vars) | The mechanism is skill-text only. Skills must work standalone in any harness. |
+| Per-caller numeric panel overrides | The profile table covers phase 1. Free numerics multiply untested combinations. |
+
+## Success criteria
+
+| # | Claim | Verification |
+| - | ----- | ------------ |
+| 1 | Trust policy is selectable. | The merge-gate skill defines a trust options table with `top-contributors` (default) and `allowlist` rows, keyed by `trustSource`, `trustContributorCount`, and `trustAllowlist`. |
+| 2 | Review rigor is selectable. | The caller protocol defines panel profiles `light`, `standard` (default), and `thorough` keyed by `reviewPanel`, and a severity floor keyed by `reviewBlockingSeverity` with default `medium`. |
+| 3 | Defaults reproduce current behavior. | Each options table marks exactly one default row, and the default rows carry seven contributors, the 3/3/5+3 panel sizes, and the medium floor. |
+| 4 | The read mechanic has one home. | `rg -l 'settings\.json' .claude/agents .claude/skills` shows the mechanic's rules in the shared reference only; consuming skills each carry a one-line pointer. |
+| 5 | The gate reads settings from the default branch. | The merge-gate skill carries the default-branch read rule and the `.kata/` trust-sensitive classification as checklist items. |
+| 6 | The invariant stops the line. | `bun run invariants` fails on a fixture with an unknown key, a fixture with an out-of-vocabulary value, and a table that disagrees with the vocabulary. |
+| 7 | No fixed policy literal survives outside a table. | `rg -n 'top.?7|top seven' .claude/skills .claude/agents` matches only options-table default rows and their rationale references. |
+| 8 | Published skills stay generic. | `bun run invariants` (skill-genericity rules) passes on every edited skill. |
+| 9 | Repository checks stay green. | `bun run check` and `bun run test` pass. |

--- a/specs/2290-kata-settings-file/spec.md
+++ b/specs/2290-kata-settings-file/spec.md
@@ -1,7 +1,11 @@
 # Spec 2290: Repository Settings File for Kata Skills
 
-**Classification:** product-aligned — the change lands on Kata's published
-skill distribution and the documentation of that surface.
+**Classification:** internal. Every changed surface lands under `.claude/`
+(skills and agent references), `KATA.md`, and `.jidoka/invariants/`. Nothing
+lands under `products/` or `services/`, so the shared rubric's decision test
+classifies the change internal (spec 2210 applied the same test to the same
+surfaces). The motivation is still the product's consumers: the settings file
+is the interface a Kata installation configures.
 
 **Persona and job:** Teams Using Agents → Run a Continuously Improving Agent
 Team (Kata's Big Hire in JTBD.md). The Little Hire is the sharper fit: onboard
@@ -17,11 +21,12 @@ variance:
 
 - **Trust.** The merge gate trusts the CI app identity plus the top seven
   human contributors by the tracker's contributor ranking. The count and the
-  source are fixed in the skill. The comment gate and the re-ping rule key off
-  the same fixed list.
+  source are fixed in the skill. The comment gate, the re-ping rule, the
+  gate's comment templates, and the approval-signals reference restate the
+  same fixed count.
 - **Review rigor.** The review caller protocol fixes each panel at three
-  reviewers (five for the implementation technical panel). Every phase skill
-  blocks on the fixed blocker/high/medium severity floor.
+  reviewers (five for the implementation technical panel). The review skill
+  and every phase skill restate the fixed blocker/high/medium severity floor.
 
 Installations differ on both:
 
@@ -53,33 +58,48 @@ options that the skills themselves define.
 
 1. **Options tables in the owning skill.** Each configurable policy appears in
    exactly one skill surface as a table of named options. Each row carries an
-   identifier, its meaning, and one marked default.
+   identifier, its meaning, and one marked default. Other surfaces point at
+   the owning table and restate no values.
 2. **The settings file selects.** The file is one flat JSON object. Each key
    holds an identifier from the owning table, an integer, or a list of
    strings. No nesting, no key whose meaning depends on another object.
 3. **The agent is the loader.** The skill text instructs the read. No runtime
-   library, harness hook, or environment variable participates. A shared agent
-   reference defines the read mechanic once: file location, absent-file and
-   absent-key semantics, unparseable-file semantics.
+   library, harness hook, or environment variable participates. One shared
+   home defines the read mechanic once: file location, absence semantics, and
+   misconfiguration semantics.
 4. **Defaults equal current behavior.** Every marked default reproduces the
-   value the skills enforce today. A missing file, a missing key, an
-   unreadable file, and an agent that never reads the file all produce
-   today's behavior. Misconfiguration degrades to the known-safe posture.
-5. **Phase-1 vocabulary: trust and review rigor.** Trust source
-   (contributor ranking or explicit allowlist), trusted-contributor count, and
-   allowlist. Review panel profile and blocking severity floor.
-6. **Security boundary.** The merge gate reads the settings from the default
-   branch, never from a PR head. A diff that touches `.kata/` gates at the
-   strictest level, the same treatment agent-instruction paths receive.
-7. **Validation.** A repository invariant stops the line when the settings
-   file carries an unknown key or an out-of-vocabulary value, and when a
-   skill's options table disagrees with the machine-readable vocabulary.
+   value the skills enforce today. An absent file, an absent key, and an agent
+   that never reads the file all produce today's behavior.
+5. **Explicit misconfiguration fails safe.** A present file that does not
+   parse, or a known key with a value outside its vocabulary, degrades by
+   consumer class. Non-gate skills select the marked default and report the
+   problem on their coordination surface. The merge gate fails closed: it
+   blocks trust-gated merges with a named block reason until the file is
+   fixed. An unreadable explicit trust configuration must never widen the
+   trusted set back to the default ranking. An unknown key has no effect and
+   is reported the same way.
+6. **Phase-1 vocabulary: trust and review rigor.** Trust source (contributor
+   ranking or explicit allowlist), trusted-contributor count, and allowlist.
+   Review panel profile and blocking severity floor.
+7. **Security boundary.** The merge gate reads the settings from the default
+   branch, never from a PR head. A diff that touches `.kata/` is a
+   trust-policy change: whatever the PR's type or phase, it merges only on a
+   trusted human's explicit signal on that change, pinned to the approved
+   head, per the existing approval-signal classes. No agent-originated
+   approval qualifies. This extends the human-only rule that already covers
+   spec and design approvals.
+8. **Validation.** A repository invariant holds the machine-readable copy of
+   the key vocabulary. It stops the line when the settings file carries an
+   unknown key or an out-of-vocabulary value, and when a skill's options table
+   disagrees with that vocabulary. The invariant is this repository's CI
+   gate; consumer installations rely on the degradation rules in item 5.
 
-**Compatibility stance:** clean break. The hard-coded policy sentences become
-the marked default rows of the options tables. No dual mechanism remains. An
-absent file selecting the defaults is specified behavior, not a compatibility
-shim. Old-path removal (the fixed literals outside the tables) is a success
-criterion.
+**Compatibility stance:** clean break. The hard-coded trust, panel-size, and
+severity-floor literals become the marked default rows of the options tables.
+Every other surface that restates them becomes a pointer. No dual mechanism
+remains. An absent file selecting the defaults is specified behavior, not a
+compatibility shim. Old-path removal (the fixed literals outside the tables)
+is a success criterion.
 
 ## Scope
 
@@ -87,12 +107,14 @@ criterion.
 
 | Surface | Change |
 | ------- | ------ |
-| `kata-release-merge` skill | Trust policy becomes an options table (source, count, allowlist). The gate resolves trust through the selected option, reads settings from the default branch, and classifies `.kata/` diffs as trust-sensitive. |
-| Comment-gate and re-ping references | Verified to consume the gate's canonical trust list through pointers, with no restated values. |
-| `kata-review` caller protocol | Panel composition becomes a profile table (light / standard / thorough). The blocking severity floor becomes a keyed option. |
-| `kata-spec`, `kata-design`, `kata-plan`, `kata-implement` | Severity-floor sentences point at the caller protocol's configured floor instead of restating blocker/high/medium. |
-| New shared agent reference | Single home for the settings read mechanic: location, absence semantics, unparseable-file semantics, defaults-equal-current-behavior principle. Ships with the pack like the other agent references. |
-| Repository invariant | Validates the settings file and the table-to-vocabulary agreement. |
+| `kata-release-merge` skill | Trust policy becomes an options table (source, count, allowlist). The gate resolves the trusted set through the selected option, reads settings from the default branch, fails closed on unreadable trust configuration, and gates `.kata/` diffs on an explicit human signal. |
+| `kata-release-merge` references (comment gate, re-ping rule, templates) | Restated trust-count literals become pointers to the trust table. Comment templates name the configured trust source instead of a fixed count. |
+| Approval-signals agent reference | Its trust-gate sentence points at the merge gate's configured trust source instead of restating a fixed count. The dispatch-side trust check inherits the configured source through the same pointer. |
+| `kata-review` caller protocol | Panel composition becomes a profile table (light / standard / thorough). The blocking severity floor becomes a keyed option. The panel-rationale reference explains the profiles instead of restating fixed sizes. |
+| `kata-review` skill | The severity vocabulary's caller obligation points at the configured floor instead of restating blocker/high/medium. |
+| `kata-spec`, `kata-design`, `kata-plan`, `kata-implement` | Both severity-floor restatements in each skill (exit checklist and panel step) point at the caller protocol's configured floor. |
+| Shared settings reference | Single home for the read mechanic: file location, absence and misconfiguration semantics, the defaults-equal-current-behavior principle, and a pointer to the gate-side rules. Ships with the pack like the other agent references. |
+| Repository invariant | Holds the machine-readable key vocabulary, validates `.kata/settings.json` when present, and checks each options table against the vocabulary. |
 | `kata-setup` skill | Names the optional settings file and its owning tables in the setup output. |
 | KATA.md | One orientation paragraph: the file exists, what it governs, where the vocabularies live. |
 
@@ -108,14 +130,16 @@ criterion.
 
 ## Success criteria
 
-| # | Claim | Verification |
-| - | ----- | ------------ |
-| 1 | Trust policy is selectable. | The merge-gate skill defines a trust options table with `top-contributors` (default) and `allowlist` rows, keyed by `trustSource`, `trustContributorCount`, and `trustAllowlist`. |
-| 2 | Review rigor is selectable. | The caller protocol defines panel profiles `light`, `standard` (default), and `thorough` keyed by `reviewPanel`, and a severity floor keyed by `reviewBlockingSeverity` with default `medium`. |
-| 3 | Defaults reproduce current behavior. | Each options table marks exactly one default row, and the default rows carry seven contributors, the 3/3/5+3 panel sizes, and the medium floor. |
-| 4 | The read mechanic has one home. | `rg -l 'settings\.json' .claude/agents .claude/skills` shows the mechanic's rules in the shared reference only; consuming skills each carry a one-line pointer. |
-| 5 | The gate reads settings from the default branch. | The merge-gate skill carries the default-branch read rule and the `.kata/` trust-sensitive classification as checklist items. |
-| 6 | The invariant stops the line. | `bun run invariants` fails on a fixture with an unknown key, a fixture with an out-of-vocabulary value, and a table that disagrees with the vocabulary. |
-| 7 | No fixed policy literal survives outside a table. | `rg -n 'top.?7|top seven' .claude/skills .claude/agents` matches only options-table default rows and their rationale references. |
-| 8 | Published skills stay generic. | `bun run invariants` (skill-genericity rules) passes on every edited skill. |
-| 9 | Repository checks stay green. | `bun run check` and `bun run test` pass. |
+| #  | Claim | Verification |
+| -- | ----- | ------------ |
+| 1  | Trust policy is selectable. | The merge-gate skill defines a trust options table where `trustSource` selects `top-contributors` (default) or `allowlist`, with companion keys `trustContributorCount` (default 7) and `trustAllowlist` (default empty). |
+| 2  | Review rigor is selectable. | The caller protocol defines panel profiles `light`, `standard` (default), and `thorough` keyed by `reviewPanel`, and a severity floor keyed by `reviewBlockingSeverity` with default `medium`. |
+| 3  | Defaults reproduce current behavior. | The default rows carry seven contributors, the current panel sizes (spec: product 3 + technical 3; design and plan: technical 3 + devex 3; implementation: technical 5 + devex 3), and the medium floor. |
+| 4  | The read mechanic has one home. | `rg -n '\.kata/settings' .claude/agents .claude/skills` matches the mechanic's rules only in the shared reference; every other match is a one-line pointer, an options table in an owning skill, or a gate rule in the merge-gate skill. |
+| 5  | The gate treats settings as trust-sensitive. | The merge-gate skill carries the default-branch read rule, the fail-closed rule for unreadable trust configuration, and the human-signal-only rule for `.kata/` diffs as checklist items. |
+| 6  | The invariant stops the line. | The invariant's test fixtures cover an unknown key, an out-of-vocabulary value, and a table-to-vocabulary mismatch (`bun run test`), and `bun run invariants` fails on each. |
+| 7  | No fixed trust literal survives outside a table. | `rg -n 'top.?7\|top seven' .claude/skills .claude/agents` matches only the trust table's default row and its rationale. |
+| 8  | No fixed rigor literal survives outside a table. | `rg -n 'blocker, high, and medium' .claude/skills` matches only the caller protocol's floor vocabulary and default row. |
+| 9  | Setup and orientation name the file. | `rg -l '\.kata/settings' .claude/skills/kata-setup KATA.md` matches both. |
+| 10 | Published skills stay generic. | `bun run invariants` (skill-genericity rules) passes on every edited skill. |
+| 11 | Repository checks stay green. | `bun run check` and `bun run test` pass. |


### PR DESCRIPTION
## What

Lockstep spec + design for `.kata/settings.json`: a repository-owned settings file that lets a hosting installation select among policy options the Kata skills define. Phase 1 covers the two policies with the most cross-installation variance:

- **Trust** — `trustSource` (`top-contributors` default / `allowlist`), `trustContributorCount` (default 7), `trustAllowlist`.
- **Review rigor** — `reviewPanel` profiles (`light` / `standard` default / `thorough`) and `reviewBlockingSeverity` (default `medium`).

The mechanism has no runtime parts. Skills carry options tables with one marked default per policy. The agent reads the file per a single shared reference. Defaults reproduce current behavior, so an installation without the file is untouched. Explicit misconfiguration fails closed at the merge gate: an unreadable trust configuration blocks trust-gated merges instead of silently widening trust back to the contributor ranking. The gate reads the file from the default branch, and `.kata/` diffs merge only on an explicit human signal.

Per lockstep co-execution this single PR carries both `spec.md` and `design-a.md`. No separate spec PR exists.

## Review panel record

Twelve fresh-context reviewers in one batch (spec: product 3 + technical 3; design: technical 3 + devex 3). Zero blockers. Every confirmed consensus finding at medium or above is addressed in the second commit, including: internal reclassification per the work-definition decision test (spec 2210 precedent), a concretely defined `.kata/` security boundary, fail-closed semantics for invalid explicit configuration, scope widened to every surface the success criteria sweep (approval-signals reference, merge-gate references, kata-review's own floor sentence), and a named home for the machine-readable vocabulary. One singleton finding is dismissed with rationale in the commit message: the spec binds exact JSON key names on purpose, because the key vocabulary is the change's public interface.

## STATUS reconciliation needed

This session's environment could not reach the wiki checkout, so the STATUS claim was not pushed. Per the lockstep lifecycle the row should read:

```
2290	spec	draft
```

at claim time, moving to `design draft` now that both artifacts are pushed under review. A wiki-capable session (or `kata-dispatch`) should backfill the `2290` row. The `specs_drafted` and `designs_drafted` metric rows were recorded locally and need the same sync.

Design approval is human-only. This PR carries no approval recommendation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmGxMnNEaixWAsmvKD7zVo)_