### PR TITLE
feat(kata): repository settings file for kata skills (#2290)

### DIFF
--- a/.claude/agents/x-approval-signals.md
+++ b/.claude/agents/x-approval-signals.md
@@ -58,8 +58,9 @@ does not originate. `staff-engineer` may approve plans after a clean
 approval once every target is terminal and its durable signal preserved. The
 human-only rule stays scoped to `spec approved` and `design approved`.
 
-The release engineer's trust gate (top-7 contributor or `kata-agent-team`) is
-canonical. `kata-dispatch` runs the same check before it writes STATUS on a
+The release engineer's trust gate (the kata-release-merge settings
+reference's configured trust source, or the CI app identity) is canonical.
+`kata-dispatch` runs the same check before it writes STATUS on a
 PR-side signal.
 
 ## Signal invalidation

--- a/.claude/agents/x-kata-settings.md
+++ b/.claude/agents/x-kata-settings.md
@@ -1,0 +1,74 @@
+# Kata Settings
+
+`.kata/settings.json` at the repository root selects among policy options
+the kata skills define. This reference is the single home for the read
+mechanic and the `<setting>` block grammar. Each vocabulary lives in the
+owning skill's settings reference.
+
+## The File
+
+One flat JSON object. Each key holds an identifier from its owning options
+table, an integer, or a list of strings. No nesting. No key whose meaning
+depends on another object. The file is optional.
+
+## The Loader
+
+The agent is the loader. A skill that consumes a key instructs the read at
+invocation. No runtime library, harness hook, or environment variable
+participates.
+
+## Absence
+
+An absent file or an absent key selects the marked default. Defaults equal
+current behavior. An installation without the file runs unchanged.
+
+## Misconfiguration
+
+A file that fails to parse, or a known key with an out-of-vocabulary or
+out-of-range value, degrades by consumer class:
+
+- A **non-gate skill** selects the marked default and reports the problem on
+  its coordination surface: a PR comment when the run owns one, the session
+  output otherwise.
+- The **merge gate fails closed**. The gate-side rules live in the
+  `kata-release-merge` skill. This reference does not restate them.
+
+## Unknown Keys
+
+An unknown key has no effect. Report it like an unreadable value.
+
+## `<setting>` Block Grammar
+
+Each configurable key lives in exactly one `<setting>` block in its owning
+skill's settings reference:
+
+- The opening tag carries exactly `key` and `default`, on one line within 74
+  characters.
+- A selector block's body is one table with the option identifiers in column
+  one and exactly one cell suffixed `(default)`. Extra columns are free.
+- A parameter block's body is prose: type, constraints, and applicability in
+  one sentence. The body never restates the default literal. The attribute
+  is that class's one home.
+
+Example of a selector block:
+
+```markdown
+<setting key="exampleKey" default="option-a">
+
+| Option | Meaning |
+| --- | --- |
+| `option-a` (default) | What option-a selects. |
+| `option-b` | What option-b selects. |
+
+</setting>
+```
+
+## Discovery and Owning Tables
+
+`rg '<setting '` enumerates every knob. Phase-1 keys and their owning
+tables:
+
+| Keys | Owning table |
+| --- | --- |
+| `trustSource`, `trustContributorCount`, `trustAllowlist` | `kata-release-merge` `references/settings.md` |
+| `reviewPanel`, `reviewBlockingSeverity` | `kata-review` `references/settings.md` |

--- a/.claude/agents/x-kata-settings.md
+++ b/.claude/agents/x-kata-settings.md
@@ -46,8 +46,8 @@ skill's settings reference:
   characters.
 - A selector block's body is one table with the option identifiers in column
   one and exactly one cell suffixed `(default)`. Extra columns are free.
-- A parameter block's body is prose: type, constraints, and applicability in
-  one sentence. The body never restates the default literal. The attribute
+- A parameter block's body is short prose: type, constraints, and
+  applicability. The body never restates the default literal. The attribute
   is that class's one home.
 
 Example of a selector block:

--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -57,7 +57,9 @@ is no commitment to implement. A design then has nothing to shape.
 - [ ] Run the repository formatter and commit the changes.
 - [ ] Complete a clean sub-agent review panel of `design-a.md` through
       [`kata-review`](../kata-review/SKILL.md) (fresh context, panel size per
-      caller protocol). Address every blocker/high/medium finding.
+      caller protocol). Address every confirmed finding at or above the
+      configured blocking severity floor
+      ([caller protocol](../kata-review/references/caller-protocol.md)).
 
 </do_confirm_checklist>
 
@@ -168,7 +170,9 @@ architectural choice names a rejected alternative.
 Follow the [`kata-review` caller
 protocol](../kata-review/references/caller-protocol.md). Invoke it on the local
 `design-a.md` before push. Tell each reviewer not to invoke `kata-design`.
-Address every confirmed blocker/high/medium finding before you open the PR. The
+Address every confirmed finding at or above the configured blocking severity
+floor ([caller protocol](../kata-review/references/caller-protocol.md))
+before you open the PR. The
 PR should not become visible to `kata-dispatch` until the panel is clean.
 
 ### Step 6: Open a design PR

--- a/.claude/skills/kata-implement/SKILL.md
+++ b/.claude/skills/kata-implement/SKILL.md
@@ -57,10 +57,11 @@ alongside the skill-specific rules below.
 - [ ] Spec-specific verification commands from the plan pass.
 - [ ] Review the full diff against the spec's success criteria. Confirm every
       criterion is met.
-- [ ] Complete a clean sub-agent review panel of the full diff through
-      [`kata-review`](../kata-review/SKILL.md) (fresh context, no prior bias,
-      panel size per caller protocol). Address every **blocker**, **high**,
-      and **medium** finding.
+- [ ] Complete a clean sub-agent review panel of the diff through
+      [`kata-review`](../kata-review/SKILL.md) (fresh context, panel size per
+      caller protocol). Address every confirmed finding at or above the
+      configured blocking severity floor
+      ([caller protocol](../kata-review/references/caller-protocol.md)).
 
 </do_confirm_checklist>
 
@@ -156,7 +157,9 @@ After all tasks are complete, run the DO-CONFIRM checklist above.
 
 Follow the [`kata-review` caller
 protocol](../kata-review/references/caller-protocol.md). Tell each reviewer not
-to invoke `kata-implement`. Address every confirmed blocker/high/medium finding
+to invoke `kata-implement`. Address every confirmed finding at or above the
+configured blocking severity floor
+([caller protocol](../kata-review/references/caller-protocol.md))
 before you advance.
 
 ### Step 8: Open an implementation PR

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -167,12 +167,12 @@ verifiable. Decompose into parts if large (see § Large plan decomposition).
 
 ### Step 5: Clean sub-agent review panel
 
-Follow the [`kata-review` caller
-protocol](../kata-review/references/caller-protocol.md). Invoke it on the
-local `plan-a.md` (and any parts) before you push. Tell each reviewer not to
-invoke `kata-plan`. Address every confirmed finding at or above the
-configured blocking severity floor (caller protocol) before you open the PR. The PR should not become visible to `kata-dispatch`
-until the panel is clean.
+Follow the
+[`kata-review` caller protocol](../kata-review/references/caller-protocol.md).
+Invoke it on the local `plan-a.md` (and any parts) before you push. Tell each
+reviewer not to invoke `kata-plan`. Address every confirmed finding at or above
+the configured blocking severity floor (caller protocol) before you open the PR.
+The PR should not become visible to `kata-dispatch` until the panel is clean.
 
 ### Step 6: Open a plan PR
 

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -48,9 +48,9 @@ there is no architectural direction to translate into implementation steps.
 
 - [ ] Plan meets the criteria in § Writing a Plan.
 - [ ] Complete a clean sub-agent review panel of `plan-a.md` and parts
-      through [`kata-review`](../kata-review/SKILL.md) (fresh context, panel
-      size per caller protocol). Address every confirmed finding at or above
-      the configured severity floor
+      through [`kata-review`](../kata-review/SKILL.md) (panel size per
+      caller protocol). Address every confirmed finding at or above the
+      configured blocking severity floor
       ([caller protocol](../kata-review/references/caller-protocol.md)).
 
 </do_confirm_checklist>

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -47,10 +47,11 @@ there is no architectural direction to translate into implementation steps.
 <do_confirm_checklist goal="Verify plan quality before recommending approval">
 
 - [ ] Plan meets the criteria in § Writing a Plan.
-- [ ] Complete a clean sub-agent review panel of `plan-a.md` (and any
-      parts) through [`kata-review`](../kata-review/SKILL.md), with fresh
-      context, no prior bias, and panel size per caller protocol. Address
-      every **blocker**, **high**, and **medium** finding.
+- [ ] Complete a clean sub-agent review panel of `plan-a.md` and parts
+      through [`kata-review`](../kata-review/SKILL.md) (fresh context, panel
+      size per caller protocol). Address every confirmed finding at or above
+      the configured severity floor
+      ([caller protocol](../kata-review/references/caller-protocol.md)).
 
 </do_confirm_checklist>
 
@@ -169,8 +170,8 @@ verifiable. Decompose into parts if large (see § Large plan decomposition).
 Follow the [`kata-review` caller
 protocol](../kata-review/references/caller-protocol.md). Invoke it on the
 local `plan-a.md` (and any parts) before you push. Tell each reviewer not to
-invoke `kata-plan`. Address every confirmed blocker/high/medium finding
-before you open the PR. The PR should not become visible to `kata-dispatch`
+invoke `kata-plan`. Address every confirmed finding at or above the
+configured blocking severity floor (caller protocol) before you open the PR. The PR should not become visible to `kata-dispatch`
 until the panel is clean.
 
 ### Step 6: Open a plan PR

--- a/.claude/skills/kata-release-merge/SKILL.md
+++ b/.claude/skills/kata-release-merge/SKILL.md
@@ -31,7 +31,7 @@ PR's trust check.
       merges with reason `settings unreadable`. Never widen back to the
       default ranking.
 - [ ] A diff that touches `.kata/` merges only on a trusted human's explicit
-      signal pinned to the current head. No agent approval qualifies.
+      signal pinned to the approved head. No agent approval qualifies.
 - [ ] PR type parsed from the title prefix, and the classification label
       (`product` / `internal`) present.
 - [ ] All CI checks pass, after mechanical fixes if needed.
@@ -89,10 +89,10 @@ Under `allowlist`, the trusted set is exactly `trustAllowlist`. An empty list
 trusts no human.
 
 The PR author must appear in the trusted set. If the author does not appear,
-mark the PR **blocked**. Run this resolution on every classified PR. On a
-parse failure or an out-of-vocabulary trust value, fail closed: block every
-trust-gated merge with reason `settings unreadable`, owned by a trusted
-human. Never fall back to the ranking.
+mark the PR **blocked**. Run this resolution on every classified PR. On a parse
+failure, or an out-of-vocabulary or out-of-range trust value, fail closed:
+block every trust-gated merge with reason `settings unreadable`, owned by a
+trusted human. Never fall back to the ranking.
 
 ### Step 3: Classify PR Type
 

--- a/.claude/skills/kata-release-merge/SKILL.md
+++ b/.claude/skills/kata-release-merge/SKILL.md
@@ -23,22 +23,24 @@ PR's trust check.
 
 <do_confirm_checklist goal="Verify all gates pass before merging a PR">
 
-- [ ] Confirm the author is trusted by CI app identity or by the top-7
-      contributor lookup.
-- [ ] Parse the PR type from the title prefix.
-- [ ] Confirm all CI checks pass, after mechanical fixes if needed.
-- [ ] Confirm the `wiki/STATUS.md` row for the spec id shows the classified
-      phase at `approved`, or at `implemented` for the terminal plan row.
-- [ ] For phase PRs (spec/design/plan), confirm an approval signal of the
-      required class verifiably covers the current head, per
-      `references/review-transfer.md`.
-- [ ] For implementation PRs, confirm the parent spec's `plan-a.md` exists on
-      `main`.
-- [ ] Confirm no unresolved trusted-human concern remains in the PR comment
-      thread.
-- [ ] Confirm the PR carries a classification label (`product` / `internal`).
-- [ ] Confirm the coordinating issue, if there is one, names the PR. Self-heal
-      the link when it is missing.
+- [ ] Author trusted: CI app identity, or the trusted set resolved from the
+      configured trust source (`references/settings.md`).
+- [ ] Settings read from the default branch, never from a PR head or a
+      worktree that contains PR content.
+- [ ] On unreadable trust configuration, fail closed: block trust-gated
+      merges with reason `settings unreadable`. Never widen back to the
+      default ranking.
+- [ ] A diff that touches `.kata/` merges only on a trusted human's explicit
+      signal pinned to the current head. No agent approval qualifies.
+- [ ] PR type parsed from the title prefix, and the classification label
+      (`product` / `internal`) present.
+- [ ] All CI checks pass, after mechanical fixes if needed.
+- [ ] The `wiki/STATUS.md` row shows the classified phase at `approved`, or
+      `implemented` for the terminal plan row. For phase PRs, a signal of the
+      required class covers the head per `references/review-transfer.md`.
+- [ ] For implementation PRs, the parent spec's `plan-a.md` exists on `main`.
+- [ ] No unresolved trusted-human concern in the PR thread. Self-heal the
+      coordinating-issue link when it is missing.
 
 </do_confirm_checklist>
 
@@ -66,16 +68,31 @@ Skip PRs authored by `app/dependabot`. `kata-security-update` handles them.
 
 `read` the change's author
 ([work-trackers.md](../../agents/x-work-trackers.md)). If the author is
-`app/kata-agent-team`, the PR is **trusted by definition**. Otherwise, look up
-the top 7 human contributors:
+`app/kata-agent-team`, the PR is **trusted by definition**. Otherwise,
+resolve the trusted set from the configured trust source
+([`references/settings.md`](references/settings.md)). Read the settings from
+the default branch, never from a PR head:
+
+```sh
+git show origin/<default-branch>:.kata/settings.json
+```
+
+Under `top-contributors`, look up the top `trustContributorCount` human
+contributors:
 
 ```sh
 gh api repos/{owner}/{repo}/contributors \
-  --jq '[.[] | select(.type == "User")] | .[0:7] | .[].login'
+  --jq '[.[] | select(.type == "User")] | .[0:<trustContributorCount>] | .[].login'
 ```
 
-The PR author must appear in that list. If the author does not appear, mark the
-PR **blocked**. Run this lookup on every classified PR.
+Under `allowlist`, the trusted set is exactly `trustAllowlist`. An empty list
+trusts no human.
+
+The PR author must appear in the trusted set. If the author does not appear,
+mark the PR **blocked**. Run this resolution on every classified PR. On a
+parse failure or an out-of-vocabulary trust value, fail closed: block every
+trust-gated merge with reason `settings unreadable`, owned by a trusted
+human. Never fall back to the ranking.
 
 ### Step 3: Classify PR Type
 
@@ -179,12 +196,18 @@ outside [`references/review-transfer.md`](references/review-transfer.md), whose
 this rule directly. See
 [`approval-signals.md`](../../agents/x-approval-signals.md).
 
+**Settings diffs.** A diff that touches `.kata/` is a trust-policy change. It
+merges only on a trusted human's explicit signal on that change, pinned to
+the approved head, per the existing approval-signal classes
+([`approval-signals.md`](../../agents/x-approval-signals.md)). No
+agent-originated approval qualifies, whatever the PR's type or phase.
+
 ### Step 7: Open Comment Gate
 
-A top-7 contributor's most-recent PR comment may be an unresolved concern. If
-no **later** comment from the same human accepts it, mark the PR **blocked**
-(`awaiting trusted-contributor reply`). See
-[`comment-gate.md`](references/comment-gate.md).
+A trusted human contributor's most-recent PR comment (the Step 2 trusted set)
+may be an unresolved concern. If no **later** comment from the same human
+accepts it, mark the PR **blocked** (`awaiting trusted-contributor reply`).
+See [`comment-gate.md`](references/comment-gate.md).
 
 ### Step 8: Coordinating Issue Announcement (self-heal)
 

--- a/.claude/skills/kata-release-merge/references/comment-gate.md
+++ b/.claude/skills/kata-release-merge/references/comment-gate.md
@@ -8,7 +8,7 @@ a thread on behalf of a human who did not react yet.
 
 `read` the change's discussion thread
 ([work-trackers.md](../../../agents/x-work-trackers.md)).
-For each top-7 human contributor (kata-release-merge Step 2 lookup) who
+For each trusted human contributor (kata-release-merge Step 2 resolution) who
 commented on the PR, read their **most recent** comment. If it raises a
 concern, question, or objection, look for a **later** comment from the **same**
 human that acknowledges or accepts the response. If no such comment exists,

--- a/.claude/skills/kata-release-merge/references/reping-rule.md
+++ b/.claude/skills/kata-release-merge/references/reping-rule.md
@@ -62,6 +62,7 @@ the PR. Role → login resolution reuses existing mechanisms, with no new logic:
 | Gate (attribute)     | Gate (block reason)                | `owner` role on the re-ping                        |
 | -------------------- | ---------------------------------- | -------------------------------------------------- |
 | trust                | Untrusted Author                   | A trusted human (configured trust source) who can review |
+| trust                | Settings Unreadable                | A trusted human who can fix `.kata/settings.json`  |
 | type                 | Unsupported PR Type                | A trusted human who can re-title or close the PR   |
 | CI                   | CI Failing                         | The PR author (agent or human)                     |
 | mechanical readiness | Substantive Conflict               | The PR author                                      |
@@ -71,5 +72,6 @@ the PR. Role → login resolution reuses existing mechanisms, with no new logic:
 The **CI** and **mechanical readiness** rows resolve to the PR author. The
 **open comments** row resolves to the unresolved-concern author through
 [`comment-gate.md`](comment-gate.md). The **trust**, **type**, and **approval**
-rows name a role drawn from the Step 2 trusted set. Those rows stay role-level
-and name no single login.
+rows name a role drawn from the Step 2 trusted set; the Settings Unreadable
+row names a trusted human directly, because the configured set itself is
+unreadable. Those rows stay role-level and name no single login.

--- a/.claude/skills/kata-release-merge/references/reping-rule.md
+++ b/.claude/skills/kata-release-merge/references/reping-rule.md
@@ -61,7 +61,7 @@ the PR. Role → login resolution reuses existing mechanisms, with no new logic:
 
 | Gate (attribute)     | Gate (block reason)                | `owner` role on the re-ping                        |
 | -------------------- | ---------------------------------- | -------------------------------------------------- |
-| trust                | Untrusted Author                   | A trusted human (top-7 contributor) who can review |
+| trust                | Untrusted Author                   | A trusted human (configured trust source) who can review |
 | type                 | Unsupported PR Type                | A trusted human who can re-title or close the PR   |
 | CI                   | CI Failing                         | The PR author (agent or human)                     |
 | mechanical readiness | Substantive Conflict               | The PR author                                      |
@@ -71,5 +71,5 @@ the PR. Role → login resolution reuses existing mechanisms, with no new logic:
 The **CI** and **mechanical readiness** rows resolve to the PR author. The
 **open comments** row resolves to the unresolved-concern author through
 [`comment-gate.md`](comment-gate.md). The **trust**, **type**, and **approval**
-rows name a role drawn from the Step 2 top-7 list. Those rows stay role-level
+rows name a role drawn from the Step 2 trusted set. Those rows stay role-level
 and name no single login.

--- a/.claude/skills/kata-release-merge/references/settings.md
+++ b/.claude/skills/kata-release-merge/references/settings.md
@@ -1,0 +1,28 @@
+# Merge-Gate Trust Settings
+
+These keys select the merge gate's trust policy. The read mechanic lives in
+the shared [kata-settings reference](../../../agents/x-kata-settings.md).
+
+<setting key="trustSource" default="top-contributors">
+
+| Option | Meaning |
+| --- | --- |
+| `top-contributors` (default) | Trust the top `trustContributorCount` humans by contributor ranking. |
+| `allowlist` | Trust exactly the logins in `trustAllowlist`. Empty list: no human. |
+
+</setting>
+
+<setting key="trustContributorCount" default="7">
+
+Integer, minimum 1. Applies under `trustSource: top-contributors`; ignored
+otherwise. Counts humans only; the CI app identity stays trusted.
+
+</setting>
+
+<setting key="trustAllowlist" default="[]">
+
+String list of tracker logins. Applies under `trustSource: allowlist`;
+ignored otherwise. An empty list trusts no human. The CI app identity stays
+trusted under every source.
+
+</setting>

--- a/.claude/skills/kata-release-merge/references/templates.md
+++ b/.claude/skills/kata-release-merge/references/templates.md
@@ -10,7 +10,8 @@ shown and post it.
 
 ### Untrusted Author
 
-> Release merge: skipped. Author `<login>` is not in the top 7 contributors.
+> Release merge: skipped. Author `<login>` is not in the trusted set (trust
+> source: `<trustSource>`).
 > This PR requires human review.
 
 ### Unsupported PR Type
@@ -62,7 +63,7 @@ Post it as a `comment` on the change
 
 | Block reason | `<state>` | `<owner>` | `<next-action>` |
 | --- | --- | --- | --- |
-| Untrusted Author | author `<login>` not in the top 7 contributors | a trusted top-7 contributor | review and merge, or close the PR |
+| Untrusted Author | author `<login>` not in the trusted set (trust source: `<trustSource>`) | a trusted contributor per the configured trust source | review and merge, or close the PR |
 | Unsupported PR Type | PR type `<type>` unsupported | a trusted human | re-title to a supported `type(scope): subject`, or close |
 | CI Failing | checks `<failing-checks>` still red | the PR author | push a fix. The next sweep re-checks |
 | Substantive Conflict | conflicts in `<files>`, so it is not mergeable | the PR author | rebase on `main` and resolve the files |
@@ -88,7 +89,7 @@ the summary. Do not report it as merged.
 | #fix-a | fix(parser): schema validation | fix  | alice  | green | n/a            | merged  | All gates pass                  |
 | #spec-b| spec(security): SSRF hardening | spec | bob    | green | spec draft     | blocked | STATUS row not at spec approved |
 | #feat-c| feat(export): export feature   | feat | carol  | red   | plan approved  | blocked | CI failing: format check        |
-| #fix-d | fix(ui): color contrast        | fix  | eve    | green | n/a            | blocked | Author not in top contributors  |
+| #fix-d | fix(ui): color contrast        | fix  | eve    | green | n/a            | blocked | Author not in trusted set       |
 | #dsgn-e| design(map): ingest pipeline   | design| dan   | green | design draft   | re-pinged | Awaiting approval signal; silent >3 days |
 ```
 

--- a/.claude/skills/kata-release-merge/references/templates.md
+++ b/.claude/skills/kata-release-merge/references/templates.md
@@ -3,8 +3,8 @@
 Comment templates and report formats for the merge gate.
 
 Each template is a `comment` on a change or issue
-([work-trackers.md](../../../agents/x-work-trackers.md)). Fill the body
-shown and post it.
+([work-trackers.md](../../../agents/x-work-trackers.md)). Fill and post the
+body.
 
 ## Skip Comments
 
@@ -17,6 +17,11 @@ shown and post it.
 ### Unsupported PR Type
 
 > Release merge: skipped. PR type `<type>` requires human review.
+
+### Settings Unreadable
+
+> Release merge: blocked. `.kata/settings.json` on the default branch is
+> unreadable. The gate fails closed until a trusted human fixes it.
 
 ### Awaiting Approval Signal
 
@@ -42,9 +47,9 @@ comment that names the PR
 verb to the PR's state at gate time:
 
 > Release merge (announcement backstop): PR #<pr-number>, `<title>`, is in
-> flight for this issue and reached the merge gate. The gate posted this
-> cross-link because no prior comment here named the PR. The gate recorded an
-> adherence miss per coordination-protocol.md fix-in-flight markers.
+> flight for this issue and reached the merge gate. No prior comment here
+> named the PR. The gate recorded an adherence miss per
+> coordination-protocol.md fix-in-flight markers.
 
 ## Re-ping Comments
 
@@ -64,6 +69,7 @@ Post it as a `comment` on the change
 | Block reason | `<state>` | `<owner>` | `<next-action>` |
 | --- | --- | --- | --- |
 | Untrusted Author | author `<login>` not in the trusted set (trust source: `<trustSource>`) | a trusted contributor per the configured trust source | review and merge, or close the PR |
+| Settings Unreadable | trust configuration unreadable | a trusted human | fix `.kata/settings.json` on the default branch |
 | Unsupported PR Type | PR type `<type>` unsupported | a trusted human | re-title to a supported `type(scope): subject`, or close |
 | CI Failing | checks `<failing-checks>` still red | the PR author | push a fix. The next sweep re-checks |
 | Substantive Conflict | conflicts in `<files>`, so it is not mergeable | the PR author | rebase on `main` and resolve the files |
@@ -89,7 +95,6 @@ the summary. Do not report it as merged.
 | #fix-a | fix(parser): schema validation | fix  | alice  | green | n/a            | merged  | All gates pass                  |
 | #spec-b| spec(security): SSRF hardening | spec | bob    | green | spec draft     | blocked | STATUS row not at spec approved |
 | #feat-c| feat(export): export feature   | feat | carol  | red   | plan approved  | blocked | CI failing: format check        |
-| #fix-d | fix(ui): color contrast        | fix  | eve    | green | n/a            | blocked | Author not in trusted set       |
 | #dsgn-e| design(map): ingest pipeline   | design| dan   | green | design draft   | re-pinged | Awaiting approval signal; silent >3 days |
 ```
 
@@ -98,5 +103,5 @@ the summary. Do not report it as merged.
 row per re-pinged PR. That value is distinct from `blocked`. A blocked PR still
 inside its 3-day silence window stays `blocked`.
 
-**Flag PRs blocked across 3+ consecutive runs** prominently above the table.
-These may need human escalation.
+**Flag PRs blocked across 3+ consecutive runs** above the table for human
+escalation.

--- a/.claude/skills/kata-review/SKILL.md
+++ b/.claude/skills/kata-review/SKILL.md
@@ -34,20 +34,20 @@ findings instead.
 This is the canonical definition of review severity for the spec → design →
 plan → implement arc. Grade every finding with exactly one level:
 
-- **Blocker** — The work is broken, dangerous, or materially wrong. You must
-  fix it before you advance (approve the spec, advance status, merge code).
+- **Blocker** — The work is broken, dangerous, or materially wrong.
 - **High** — A correctness or clarity problem. If you ship it, it causes
-  rework, confusion, or bugs downstream. Fix it before you advance.
+  rework, confusion, or bugs downstream.
 - **Medium** — A real quality or consistency issue. It is worth a fix now
-  while the context is fresh. Fix it before you advance.
-- **Low** — Nit or preference. The fix is optional. Document it if you dismiss
-  it.
+  while the context is fresh.
+- **Low** — Nit or preference.
 
 The caller must **verify** every finding against the actual artifact before it
 acts. Sub-agent reviewers operate without prior conversation context. They can
 misread intent, miss nearby code, or flag false positives. After it verifies a
-finding, the caller must address every confirmed **blocker**, **high**, and
-**medium** finding before it advances. **Low** findings are optional.
+finding, the caller addresses every confirmed finding at or above the
+configured blocking severity floor
+([caller protocol](references/caller-protocol.md)) before it advances.
+Findings below the floor are optional, and a dismissal is documented.
 
 ## Process
 

--- a/.claude/skills/kata-review/references/caller-protocol.md
+++ b/.claude/skills/kata-review/references/caller-protocol.md
@@ -1,25 +1,24 @@
 # Sub-Agent Review Protocol
 
-Callers of `kata-review` share this protocol:
-
-- `kata-spec` Step 5 — product + technical panels, 3 each
-- `kata-design` / `kata-plan` Step 5 — technical + devex panels, 3 each
-- `kata-implement` Step 7 — technical panel of 5 + devex panel of 3
+Callers of `kata-review` share this protocol.
 
 ## Panel Composition
 
-Each panel has a role (`subagent_type`) and a size.
+Each panel has a role (`subagent_type`) and a size. Panel sizes come from the
+`reviewPanel` profile selected in [settings.md](settings.md) (read mechanic:
+shared kata-settings reference). The consensus threshold stays ≥⌈N/2⌉ for any
+panel size.
 
-| Caller           | Artifact                    | Panel     | `subagent_type`   | Reviewers |
-| ---------------- | --------------------------- | --------- | ----------------- | --------- |
-| `kata-spec`      | `spec.md`                   | product   | `product-manager` | 3         |
-| `kata-spec`      | `spec.md`                   | technical | engineering agent  | 3         |
-| `kata-design`    | `design-a.md`               | technical | engineering agent  | 3         |
-| `kata-design`    | `design-a.md`               | devex     | `devex-engineer`  | 3         |
-| `kata-plan`      | `plan-a.md` (+ parts)       | technical | engineering agent  | 3         |
-| `kata-plan`      | `plan-a.md` (+ parts)       | devex     | `devex-engineer`  | 3         |
-| `kata-implement` | diff (`origin/main...HEAD`) | technical | engineering agent  | 5         |
-| `kata-implement` | diff (`origin/main...HEAD`) | devex     | `devex-engineer`  | 3         |
+| Caller           | Artifact                    | Panel     | `subagent_type`   |
+| ---------------- | --------------------------- | --------- | ----------------- |
+| `kata-spec`      | `spec.md`                   | product   | `product-manager` |
+| `kata-spec`      | `spec.md`                   | technical | engineering agent  |
+| `kata-design`    | `design-a.md`               | technical | engineering agent  |
+| `kata-design`    | `design-a.md`               | devex     | `devex-engineer`  |
+| `kata-plan`      | `plan-a.md` (+ parts)       | technical | engineering agent  |
+| `kata-plan`      | `plan-a.md` (+ parts)       | devex     | `devex-engineer`  |
+| `kata-implement` | diff (`origin/main...HEAD`) | technical | engineering agent  |
+| `kata-implement` | diff (`origin/main...HEAD`) | devex     | `devex-engineer`  |
 
 Rationale for panels, sizes, and scope:
 [panel-rationale.md](panel-rationale.md).
@@ -63,9 +62,10 @@ diffs, a commit hash replaces `file:line`.
 3. **Pick severity by mode. Tie-break high.** Vote count reflects reach.
    Severity reflects seriousness.
 4. **Partition by vote count:**
-   - **Consensus (≥⌈N/2⌉):** verify and address all confirmed blocker/high/
-     medium findings in the same turn.
-   - **Minority (>1, <⌈N/2⌉):** empty for N=3. For N=5, verify with extra care.
+   - **Consensus (≥⌈N/2⌉):** verify and address all confirmed findings at or
+     above the configured blocking severity floor (`reviewBlockingSeverity`)
+     in the same turn.
+   - **Minority (>1, <⌈N/2⌉):** verify with extra care.
    - **Singleton (1):** verify each. Address or record a dismissal rationale.
 5. **Scope-creep guard.** Dismiss findings that raise concerns outside the
    artifact's declared scope (spec scope for design/plan, plan scope for diffs;
@@ -76,10 +76,10 @@ diffs, a commit hash replaces `file:line`.
 
 - **Verify** every unique finding against the actual artifact before you act.
   The caller is accountable. The panel is not.
-- **Proceed. Do not pause.** Address every confirmed consensus
-  **blocker**/**high**/**medium** finding in the same turn. Do not stop for
-  user permission. Re-run the panel if the fix is substantial. Then advance.
-- **Low** findings are optional. Document it if you dismiss one.
+- **Proceed. Do not pause.** Address every confirmed consensus finding at or
+  above the configured floor in the same turn. Do not stop for user
+  permission. Re-run the panel if the fix is substantial. Then advance.
+- Findings below the floor are optional. Document it if you dismiss one.
 - **False positives.** Record a one-line rationale in the commit message or
   artifact, then continue. Never dismiss one silently.
 - **Disagreement with a consensus blocker.** Revise the artifact to address the

--- a/.claude/skills/kata-review/references/caller-protocol.md
+++ b/.claude/skills/kata-review/references/caller-protocol.md
@@ -66,7 +66,8 @@ diffs, a commit hash replaces `file:line`.
      above the configured blocking severity floor (`reviewBlockingSeverity`)
      in the same turn.
    - **Minority (>1, <⌈N/2⌉):** verify with extra care.
-   - **Singleton (1):** verify each. Address or record a dismissal rationale.
+   - **Singleton (1, below the consensus threshold):** verify each. Address
+     or record a dismissal rationale.
 5. **Scope-creep guard.** Dismiss findings that raise concerns outside the
    artifact's declared scope (spec scope for design/plan, plan scope for diffs;
    user intent for specs). Exception: consensus "scope-creep in the diff"

--- a/.claude/skills/kata-review/references/panel-rationale.md
+++ b/.claude/skills/kata-review/references/panel-rationale.md
@@ -1,8 +1,9 @@
 # Panel Rationale
 
 This document explains why `kata-review` callers use review panels. It also
-explains why each panel has the size and scope it does. The normative procedure
-lives in [caller-protocol.md](caller-protocol.md).
+explains the intent behind each `reviewPanel` profile. The normative procedure
+lives in [caller-protocol.md](caller-protocol.md), and the profile table in
+[settings.md](settings.md).
 
 ## Why a Panel
 
@@ -10,11 +11,15 @@ Cold sub-agents produce uncorrelated errors. A finding that ≥⌈N/2⌉ reviewe
 flag is high-signal. The caller verifies singletons, but they often prove to be
 noise. An odd N lets the panel vote by majority.
 
-## Why These Sizes
+## Why These Profiles
 
-Implementation diffs get 5 reviewers. The artifact is larger. The step is
-irreversible, because code lands on `main`. The bug and security surface is
-largest. Earlier artifacts get an implicit second pass at the next phase.
+`standard` reproduces the panel sizes the spec → design → plan → implement arc
+used before the settings file existed. `light` serves solo maintainers and
+teams on metered tokens. `thorough` serves risk-averse organizations. In every
+profile the implementation panels are never smaller than the other panels in
+the same profile: the artifact is larger, the step is irreversible because
+code lands on `main`, and the bug and security surface is largest. Earlier
+artifacts get an implicit second pass at the next phase.
 
 The product panel applies only to specs. Specs decide product alignment.
 Downstream phases inherit it through the cross-phase fidelity check.
@@ -27,6 +32,7 @@ question asks whether the change leaves the codebase healthy. A healthy
 codebase is consistent, free of duplication and dead paths, and carries no new
 debt. So debt review gets a separate panel. A lens inside the technical panel
 would collapse the two verdicts into one. The DevEx panel runs on design, plan,
-and implementation (never specs, which carry no code). It uses size 3 across
-all three phases. Debt findings are lower-variance than the bug and security
-surface that earns the implementation technical panel its size of 5.
+and implementation (never specs, which carry no code). Its sizes come from the
+same profile table. Debt findings are lower-variance than the implementation
+bug and security surface, so no profile gives devex a larger panel than the
+technical panel it accompanies.

--- a/.claude/skills/kata-review/references/settings.md
+++ b/.claude/skills/kata-review/references/settings.md
@@ -1,0 +1,29 @@
+# Review Rigor Settings
+
+These keys select review rigor for every `kata-review` caller. The read
+mechanic lives in the shared
+[kata-settings reference](../../../agents/x-kata-settings.md).
+
+<setting key="reviewPanel" default="standard">
+
+| Profile | Spec panels | Design/plan panels | Implementation panels |
+| --- | --- | --- | --- |
+| `light` | product 1 + technical 1 | technical 1 + devex 1 | technical 1 + devex 1 |
+| `standard` (default) | product 3 + technical 3 | technical 3 + devex 3 | technical 5 + devex 3 |
+| `thorough` | product 5 + technical 5 | technical 5 + devex 5 | technical 5 + devex 5 |
+
+</setting>
+
+<setting key="reviewBlockingSeverity" default="medium">
+
+| Option | Meaning |
+| --- | --- |
+| `blocker` | Address every confirmed consensus finding graded blocker. |
+| `high` | Address blocker and high. |
+| `medium` (default) | Address blocker, high, and medium. |
+| `low` | Address every confirmed consensus finding. |
+
+</setting>
+
+The floor means: address every confirmed consensus finding at the floor
+severity or above.

--- a/.claude/skills/kata-setup/SKILL.md
+++ b/.claude/skills/kata-setup/SKILL.md
@@ -190,6 +190,10 @@ Setup is verified when the repository is green. Files on disk do not verify it:
 Summarize what you created and the next steps:
 
 - Customize agent profiles if you use the defaults
+- An optional `.kata/settings.json` selects trust policy and review rigor.
+  The options tables live in the `kata-release-merge` and `kata-review`
+  settings references, the read mechanic in the shared kata-settings agent
+  reference
 - Adjust schedules after you observe the first runs
 - Emergency stop: set `KATA_KILLSWITCH` to a truthy value. Unset it to resume
 - Read the [Kata Agent Team](https://www.kata.team/) site for the PDSA rhythm

--- a/.claude/skills/kata-setup/SKILL.md
+++ b/.claude/skills/kata-setup/SKILL.md
@@ -190,10 +190,9 @@ Setup is verified when the repository is green. Files on disk do not verify it:
 Summarize what you created and the next steps:
 
 - Customize agent profiles if you use the defaults
-- An optional `.kata/settings.json` selects trust policy and review rigor.
-  The options tables live in the `kata-release-merge` and `kata-review`
-  settings references, the read mechanic in the shared kata-settings agent
-  reference
+- Select trust policy and review rigor in an optional `.kata/settings.json`.
+  Options tables: the `kata-release-merge` and `kata-review` settings
+  references; read mechanic: the shared kata-settings agent reference
 - Adjust schedules after you observe the first runs
 - Emergency stop: set `KATA_KILLSWITCH` to a truthy value. Unset it to resume
 - Read the [Kata Agent Team](https://www.kata.team/) site for the PDSA rhythm

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -172,8 +172,8 @@ protocol](../kata-review/references/caller-protocol.md). Invoke it on the local
 `kata-spec`. Address every confirmed finding at or above the configured
 blocking severity floor
 ([caller protocol](../kata-review/references/caller-protocol.md))
-before you open the PR. The PR should not become visible to `kata-dispatch` until the
-panel is clean.
+before you open the PR. The PR should not become visible to `kata-dispatch`
+until the panel is clean.
 
 ### Step 6: Open a spec PR
 

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -53,9 +53,10 @@ asked for. If they ask for a spec, write the spec and stop.
 
 - [ ] Spec meets the criteria in § Writing a Spec.
 - [ ] The clean sub-agent review panel of `spec.md` through
-      [`kata-review`](../kata-review/SKILL.md) is complete (fresh context, no
-      prior bias, panel size per caller protocol). Every **blocker**,
-      **high**, and **medium** finding is addressed.
+      [`kata-review`](../kata-review/SKILL.md) is complete (fresh context,
+      panel size per caller protocol). Address every confirmed finding at or
+      above the configured blocking severity floor
+      ([caller protocol](../kata-review/references/caller-protocol.md)).
 
 </do_confirm_checklist>
 
@@ -168,8 +169,10 @@ claimed in Step 1. Do not push yet.
 Follow the [`kata-review` caller
 protocol](../kata-review/references/caller-protocol.md). Invoke it on the local
 `specs/NNN/spec.md` before you push. Tell each reviewer not to invoke
-`kata-spec`. Address every confirmed blocker/high/medium finding before you
-open the PR. The PR should not become visible to `kata-dispatch` until the
+`kata-spec`. Address every confirmed finding at or above the configured
+blocking severity floor
+([caller protocol](../kata-review/references/caller-protocol.md))
+before you open the PR. The PR should not become visible to `kata-dispatch` until the
 panel is clean.
 
 ### Step 6: Open a spec PR

--- a/.jidoka/invariants/kata-settings.rules.mjs
+++ b/.jidoka/invariants/kata-settings.rules.mjs
@@ -1,0 +1,301 @@
+// Invariant: kata-settings — the machine-readable copy of the
+// `.kata/settings.json` key vocabulary. It validates the settings file
+// when one exists, and checks every `<setting>` options block
+// in the skill and agent references against the vocabulary. The prose
+// grammar lives in .claude/agents/x-kata-settings.md; the owning tables in
+// .claude/skills/kata-release-merge/references/settings.md and
+// .claude/skills/kata-review/references/settings.md. Consumer repositories
+// are governed by the read mechanic's degradation rules; this invariant is
+// this repository's stop-the-line gate.
+
+export const VOCABULARY = {
+  trustSource: {
+    kind: "select",
+    options: ["top-contributors", "allowlist"],
+    default: "top-contributors",
+  },
+  trustContributorCount: { kind: "integer", min: 1, default: 7 },
+  trustAllowlist: { kind: "string-list", default: [] },
+  reviewPanel: {
+    kind: "select",
+    options: ["light", "standard", "thorough"],
+    default: "standard",
+  },
+  reviewBlockingSeverity: {
+    kind: "select",
+    options: ["blocker", "high", "medium", "low"],
+    default: "medium",
+  },
+};
+
+// A vocabulary default serialized the way the `default` attribute writes it:
+// strings verbatim, everything else as JSON (`[]`, `7`).
+const defaultAttr = (key) => {
+  const d = VOCABULARY[key].default;
+  return typeof d === "string" ? d : JSON.stringify(d);
+};
+
+// Blank out fenced code blocks and keep the line numbers, so the grammar
+// example in the shared reference never registers as a real block.
+const stripFences = (text) => {
+  let inFence = false;
+  return text.split("\n").map((line) => {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      return "";
+    }
+    return inFence ? "" : line;
+  });
+};
+
+const OPEN_TAG = /^<setting\s/;
+const OPEN_TAG_ONE_LINE = /^<setting((?:\s+\w+="[^"]*")+)\s*>$/;
+const CLOSE_TAG = /^<\/setting>$/;
+
+// Parse a one-line opening tag into `{ key, default }`, or `{ tagError }`
+// when the tag spans lines or carries the wrong attributes.
+function parseOpenTag(line) {
+  const m = line.match(OPEN_TAG_ONE_LINE);
+  if (!m) return { tagError: "opening tag does not parse on one line" };
+  const attrs = [...m[1].matchAll(/(\w+)="([^"]*)"/g)];
+  const names = attrs.map((a) => a[1]);
+  if (names.join(",") !== "key,default") {
+    return {
+      tagError: `attributes are [${names.join(", ")}], not exactly [key, default]`,
+    };
+  }
+  return { key: attrs[0][2], default: attrs[1][2] };
+}
+
+// Collect a block's option-table rows (first-column identifier plus
+// `(default)` mark) up to its closing tag. `closedAt` is -1 when the next
+// opening tag or the end of the file arrives first.
+function collectBody(lines, from) {
+  const options = [];
+  for (let j = from; j < lines.length; j++) {
+    const body = lines[j].trimEnd();
+    if (OPEN_TAG.test(body)) return { options, closedAt: -1 };
+    if (CLOSE_TAG.test(body)) return { options, closedAt: j };
+    const row = body.match(/^\|\s*`([^`]+)`\s*(\(default\))?\s*\|/);
+    if (row) options.push({ id: row[1], isDefault: !!row[2] });
+  }
+  return { options, closedAt: -1 };
+}
+
+// Extract every `<setting>` block from one stripped file. A malformed block
+// carries `tagError` instead of a parsed key.
+function extractBlocks(lines) {
+  const blocks = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trimEnd();
+    if (!OPEN_TAG.test(line)) continue;
+    const block = { lineNo: i + 1, ...parseOpenTag(line) };
+    const { options, closedAt } = collectBody(lines, i + 1);
+    block.options = options;
+    if (closedAt === -1) {
+      block.tagError ??= "no paired closing </setting> tag";
+    } else {
+      i = closedAt;
+    }
+    blocks.push(block);
+  }
+  return blocks;
+}
+
+// One flat object of identifiers, integers, and string lists. Returns the
+// shape problems, empty when conformant.
+function fileShapeProblems(parsed) {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return ["the file is not one flat JSON object"];
+  }
+  const problems = [];
+  for (const [key, value] of Object.entries(parsed)) {
+    const ok =
+      typeof value === "string" ||
+      typeof value === "number" ||
+      (Array.isArray(value) && value.every((v) => typeof v === "string"));
+    if (!ok)
+      problems.push(
+        `key "${key}" holds neither an identifier, an integer, nor a string list`,
+      );
+  }
+  return problems;
+}
+
+// Per-key value validation against the vocabulary entry's kind.
+function valueProblem(key, value) {
+  const spec = VOCABULARY[key];
+  if (spec.kind === "select") {
+    if (typeof value !== "string" || !spec.options.includes(value))
+      return `"${value}" is not one of: ${spec.options.join(", ")}`;
+  }
+  if (spec.kind === "integer") {
+    if (!Number.isInteger(value)) return `"${value}" is not an integer`;
+    if (value < spec.min) return `${value} is under the minimum ${spec.min}`;
+  }
+  if (spec.kind === "string-list") {
+    if (!Array.isArray(value) || value.some((v) => typeof v !== "string"))
+      return `"${value}" is not a string list`;
+  }
+  return null;
+}
+
+export default {
+  name: "kata-settings",
+
+  build({ root, scan, readText }) {
+    const fileSubjects = [];
+    const raw = readText(".kata/settings.json");
+    if (raw != null) {
+      const path = `${root}/.kata/settings.json`;
+      let parsed = null;
+      let parseError = null;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (err) {
+        parseError = err.message;
+      }
+      fileSubjects.push({ kind: "file", path, raw, parsed, parseError });
+      if (!parseError && parsed && typeof parsed === "object") {
+        for (const [key, value] of Object.entries(parsed)) {
+          const lineNo =
+            raw.split("\n").findIndex((l) => l.includes(`"${key}"`)) + 1;
+          fileSubjects.push({ kind: "key", path, key, value, lineNo });
+        }
+      }
+    }
+
+    const blocks = scan({
+      dirs: [".claude/skills", ".claude/agents"],
+      match: (n) => n.endsWith(".md"),
+      read: true,
+    }).flatMap(({ path, text }) =>
+      extractBlocks(stripFences(text)).map((b) => ({
+        kind: "block",
+        path,
+        ...b,
+      })),
+    );
+
+    return {
+      subjects: {
+        "settings-file": fileSubjects,
+        "setting-block": [...blocks, { kind: "inventory", blocks }],
+      },
+    };
+  },
+
+  rules: [
+    {
+      id: "kata-settings.file-invalid",
+      scope: "settings-file",
+      severity: "fail",
+      when: (s) => s.kind === "file",
+      check: (s) => {
+        if (s.parseError) return { detail: `not valid JSON: ${s.parseError}` };
+        const problems = fileShapeProblems(s.parsed);
+        return problems.length ? problems.map((detail) => ({ detail })) : null;
+      },
+      message: (_s, item) => item.detail,
+      hint: "make .kata/settings.json one flat JSON object of identifiers, integers, and string lists",
+    },
+    {
+      id: "kata-settings.unknown-key",
+      scope: "settings-file",
+      severity: "fail",
+      when: (s) => s.kind === "key" && !(s.key in VOCABULARY),
+      check: (s) => ({ detail: `unknown key "${s.key}"` }),
+      message: (_s, item) => item.detail,
+      hint: "use only the keys the owning <setting> tables define",
+    },
+    {
+      id: "kata-settings.invalid-value",
+      scope: "settings-file",
+      severity: "fail",
+      when: (s) => s.kind === "key" && s.key in VOCABULARY,
+      check: (s) => {
+        const problem = valueProblem(s.key, s.value);
+        return problem ? { detail: `${s.key}: ${problem}` } : null;
+      },
+      message: (_s, item) => item.detail,
+      hint: "select a value from the key's owning <setting> table",
+    },
+    {
+      id: "kata-settings.block-grammar",
+      scope: "setting-block",
+      severity: "fail",
+      when: (s) => s.kind === "block" && s.tagError,
+      check: (s) => ({ detail: s.tagError }),
+      message: (_s, item) => item.detail,
+      hint: "a <setting> opening tag carries exactly key and default on one line and pairs with </setting> (x-kata-settings.md)",
+    },
+    {
+      id: "kata-settings.block-key-drift",
+      scope: "setting-block",
+      severity: "fail",
+      when: (s) => s.kind === "inventory",
+      check: (s) => {
+        const keys = s.blocks.filter((b) => !b.tagError).map((b) => b.key);
+        const items = [];
+        for (const key of Object.keys(VOCABULARY)) {
+          const n = keys.filter((k) => k === key).length;
+          if (n === 0) items.push({ detail: `no <setting> block for ${key}` });
+          if (n > 1) items.push({ detail: `${n} <setting> blocks for ${key}` });
+        }
+        for (const key of new Set(keys)) {
+          if (!(key in VOCABULARY))
+            items.push({
+              detail: `<setting> block for unknown key ${key}`,
+            });
+        }
+        return items.length ? items : null;
+      },
+      message: (_s, item) => item.detail,
+      hint: "keep exactly one <setting> block per vocabulary key (kata-settings.rules.mjs VOCABULARY)",
+    },
+    {
+      id: "kata-settings.default-drift",
+      scope: "setting-block",
+      severity: "fail",
+      when: (s) => s.kind === "block" && !s.tagError && s.key in VOCABULARY,
+      check: (s) =>
+        s.default === defaultAttr(s.key)
+          ? null
+          : {
+              detail: `${s.key} default attribute is "${s.default}", vocabulary says "${defaultAttr(s.key)}"`,
+            },
+      message: (_s, item) => item.detail,
+      hint: "align the block's default attribute with the vocabulary default",
+    },
+    {
+      id: "kata-settings.table-drift",
+      scope: "setting-block",
+      severity: "fail",
+      when: (s) =>
+        s.kind === "block" &&
+        !s.tagError &&
+        VOCABULARY[s.key]?.kind === "select",
+      check: (s) => {
+        const items = [];
+        const ids = s.options.map((o) => o.id);
+        const expected = VOCABULARY[s.key].options;
+        if (JSON.stringify(ids) !== JSON.stringify(expected))
+          items.push({
+            detail: `${s.key} option column is [${ids.join(", ")}], vocabulary says [${expected.join(", ")}]`,
+          });
+        const marked = s.options.filter((o) => o.isDefault);
+        if (marked.length !== 1)
+          items.push({
+            detail: `${s.key} table carries ${marked.length} (default) marks, not exactly one`,
+          });
+        else if (marked[0].id !== s.default)
+          items.push({
+            detail: `${s.key} marks "${marked[0].id}" as default, the attribute says "${s.default}"`,
+          });
+        return items.length ? items : null;
+      },
+      message: (_s, item) => item.detail,
+      hint: "make the selector table's option column and (default) mark match the vocabulary and the default attribute",
+    },
+  ],
+};

--- a/.jidoka/invariants/kata-settings.rules.mjs
+++ b/.jidoka/invariants/kata-settings.rules.mjs
@@ -73,7 +73,7 @@ function parseOpenTag(line) {
 function collectBody(lines, from) {
   const options = [];
   for (let j = from; j < lines.length; j++) {
-    const body = lines[j].trimEnd();
+    const body = lines[j].trim();
     if (OPEN_TAG.test(body)) return { options, closedAt: -1 };
     if (CLOSE_TAG.test(body)) return { options, closedAt: j };
     const row = body.match(/^\|\s*`([^`]+)`\s*(\(default\))?\s*\|/);
@@ -83,11 +83,12 @@ function collectBody(lines, from) {
 }
 
 // Extract every `<setting>` block from one stripped file. A malformed block
-// carries `tagError` instead of a parsed key.
+// carries `tagError` instead of a parsed key. Lines are fully trimmed before
+// the tag match, so an indented block cannot slip past extraction.
 function extractBlocks(lines) {
   const blocks = [];
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trimEnd();
+    const line = lines[i].trim();
     if (!OPEN_TAG.test(line)) continue;
     const block = { lineNo: i + 1, ...parseOpenTag(line) };
     const { options, closedAt } = collectBody(lines, i + 1);
@@ -156,10 +157,16 @@ export default {
         parseError = err.message;
       }
       fileSubjects.push({ kind: "file", path, raw, parsed, parseError });
-      if (!parseError && parsed && typeof parsed === "object") {
+      const flat =
+        !parseError &&
+        parsed &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed);
+      if (flat) {
+        const lines = raw.split("\n");
         for (const [key, value] of Object.entries(parsed)) {
-          const lineNo =
-            raw.split("\n").findIndex((l) => l.includes(`"${key}"`)) + 1;
+          const keyLine = new RegExp(`^\\s*"${key}"\\s*:`);
+          const lineNo = lines.findIndex((l) => keyLine.test(l)) + 1;
           fileSubjects.push({ kind: "key", path, key, value, lineNo });
         }
       }
@@ -177,6 +184,10 @@ export default {
       })),
     );
 
+    // The inventory subject carries the cross-subject view for the
+    // key-drift rule. A ctx-side map alone cannot report a missing block
+    // when zero blocks exist, because rules fire per subject; the
+    // inventory subject is always present, so the rule always can.
     return {
       subjects: {
         "settings-file": fileSubjects,

--- a/KATA.md
+++ b/KATA.md
@@ -295,8 +295,14 @@ graph TD
 | `spec`           | Specification document only     | Trusted agents, never the contributor |
 | Everything else  | Nothing — requires human review | N/A                                   |
 
-Top-7 contributors pass the trust gate. The gate trusts `kata-agent-team` PRs
-by identity.
+The trust gate resolves its trusted set from the configured trust source. The
+owning table in the kata-release-merge settings reference marks the default.
+The gate trusts `kata-agent-team` PRs by identity.
+
+The optional `.kata/settings.json` file selects among policy options the
+skills define (phase 1: trust source and review rigor). Each vocabulary lives
+in the owning skill's settings reference. An absent file selects the marked
+defaults, which reproduce current behavior.
 
 **Retention PRs** preserve this boundary. The archivist opens a
 `retention(specs)` PR to remove terminal spec directories. The archivist never

--- a/products/README.md
+++ b/products/README.md
@@ -14,7 +14,7 @@ impact on their organizations.
 | **gemba**    | Stand up and operate an agent team — the runtime platform's command family (harness, trace, benchmark, selfedit, wiki, xmr) and CI actions. They consume the runtime libraries.       |
 | **guide**    | Conversational agent that grounds career guidance and quality review in your organization's engineering standard.                                                                     |
 | **jidoka**   | Build quality into agent instructions — the jidoka CLI and CI action stop the line the moment an instruction layer drifts, a jobs block goes stale, or a repository invariant breaks. |
-| **kata**     | Run an autonomous, continuously improving development team through a daily Plan-Do-Study-Act loop. Kata ships as a skill pack under .claude/skills/kata-\*/.                          |
+| **kata**     | Run an autonomous, continuously improving development team through a daily Plan-Do-Study-Act loop. Kata ships as a skill pack under .claude/skills/kata-*/.                           |
 | **landmark** | Surface engineering progress from activity evidence — outcomes visible without singling out individuals.                                                                              |
 | **map**      | Validate, store, and publish agent-aligned engineering standards so expectations are operational instead of tribal.                                                                   |
 | **outpost**  | Personal operations center — context assembled from email, calendar, and knowledge so preparation is continuous instead of a morning scramble.                                        |

--- a/products/README.md
+++ b/products/README.md
@@ -14,7 +14,7 @@ impact on their organizations.
 | **gemba**    | Stand up and operate an agent team — the runtime platform's command family (harness, trace, benchmark, selfedit, wiki, xmr) and CI actions. They consume the runtime libraries.       |
 | **guide**    | Conversational agent that grounds career guidance and quality review in your organization's engineering standard.                                                                     |
 | **jidoka**   | Build quality into agent instructions — the jidoka CLI and CI action stop the line the moment an instruction layer drifts, a jobs block goes stale, or a repository invariant breaks. |
-| **kata**     | Run an autonomous, continuously improving development team through a daily Plan-Do-Study-Act loop. Kata ships as a skill pack under .claude/skills/kata-*/.                           |
+| **kata**     | Run an autonomous, continuously improving development team through a daily Plan-Do-Study-Act loop. Kata ships as a skill pack under .claude/skills/kata-\*/.                          |
 | **landmark** | Surface engineering progress from activity evidence — outcomes visible without singling out individuals.                                                                              |
 | **map**      | Validate, store, and publish agent-aligned engineering standards so expectations are operational instead of tribal.                                                                   |
 | **outpost**  | Personal operations center — context assembled from email, calendar, and knowledge so preparation is continuous instead of a morning scramble.                                        |

--- a/tests/kata-settings-invariant.test.js
+++ b/tests/kata-settings-invariant.test.js
@@ -1,0 +1,284 @@
+// Prove each kata-settings failure mode fires through the same engine
+// `jidoka invariants` runs. Every case builds a scratch repository, runs
+// the rule module through runRuleModules, and asserts the finding ids. A
+// failing settings file can never sit committed on `main`, so these
+// fixture runs demonstrate that the invariant stops the line.
+import { test, describe, afterEach } from "node:test";
+import assert from "node:assert";
+import { rmSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { runRuleModules } from "@forwardimpact/libinvariant";
+import { createTestRuntime } from "@forwardimpact/libmock";
+
+import mod, { VOCABULARY } from "../.jidoka/invariants/kata-settings.rules.mjs";
+import { fsSync, withRepo } from "../libraries/libinvariant/test/helpers.js";
+
+const TRUST_REF = `# Trust Settings
+
+<setting key="trustSource" default="top-contributors">
+
+| Option | Meaning |
+| --- | --- |
+| \`top-contributors\` (default) | Trust the ranking. |
+| \`allowlist\` | Trust the list. |
+
+</setting>
+
+<setting key="trustContributorCount" default="7">
+
+Integer, minimum 1.
+
+</setting>
+
+<setting key="trustAllowlist" default="[]">
+
+String list of tracker logins.
+
+</setting>
+`;
+
+const RIGOR_REF = `# Rigor Settings
+
+<setting key="reviewPanel" default="standard">
+
+| Profile | Spec panels |
+| --- | --- |
+| \`light\` | product 1 |
+| \`standard\` (default) | product 3 |
+| \`thorough\` | product 5 |
+
+</setting>
+
+<setting key="reviewBlockingSeverity" default="medium">
+
+| Option | Meaning |
+| --- | --- |
+| \`blocker\` | Blocker only. |
+| \`high\` | Blocker and high. |
+| \`medium\` (default) | Blocker, high, and medium. |
+| \`low\` | Every confirmed finding. |
+
+</setting>
+`;
+
+const CLEAN_REFS = {
+  ".claude/skills/kata-release-merge/references/settings.md": TRUST_REF,
+  ".claude/skills/kata-review/references/settings.md": RIGOR_REF,
+};
+
+const roots = [];
+
+function runOn(layout) {
+  const root = withRepo(layout);
+  roots.push(root);
+  const runtime = createTestRuntime({ fsSync });
+  return runRuleModules([mod], {
+    root,
+    runtime,
+    dir: resolve(root, ".jidoka/invariants"),
+  });
+}
+
+const ids = (findings) => findings.map((f) => f.id).sort();
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true });
+});
+
+describe("kata-settings invariant", () => {
+  test("clean: valid file and blocks that match VOCABULARY", async () => {
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".kata/settings.json": JSON.stringify({
+        trustSource: "allowlist",
+        trustAllowlist: ["alice"],
+        reviewPanel: "light",
+      }),
+    });
+    assert.deepEqual(findings, []);
+  });
+
+  test("absent settings file is clean", async () => {
+    const findings = await runOn(CLEAN_REFS);
+    assert.deepEqual(findings, []);
+  });
+
+  test("unknown key in the settings file", async () => {
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".kata/settings.json": JSON.stringify({ cadence: "daily" }),
+    });
+    assert.deepEqual(ids(findings), ["kata-settings.unknown-key"]);
+  });
+
+  test("out-of-vocabulary value", async () => {
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".kata/settings.json": JSON.stringify({ trustSource: "ranking" }),
+    });
+    assert.deepEqual(ids(findings), ["kata-settings.invalid-value"]);
+  });
+
+  test("under-minimum integer and non-list allowlist give two findings", async () => {
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".kata/settings.json": JSON.stringify({
+        trustContributorCount: 0,
+        trustAllowlist: "alice",
+      }),
+    });
+    assert.deepEqual(ids(findings), [
+      "kata-settings.invalid-value",
+      "kata-settings.invalid-value",
+    ]);
+  });
+
+  test("unparseable settings file", async () => {
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".kata/settings.json": "{ not json",
+    });
+    assert.deepEqual(ids(findings), ["kata-settings.file-invalid"]);
+  });
+
+  test("non-flat settings value", async () => {
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".kata/settings.json": JSON.stringify({ trust: { source: "x" } }),
+    });
+    assert.ok(ids(findings).includes("kata-settings.file-invalid"));
+  });
+
+  test("selector table option column differs from the vocabulary", async () => {
+    const brokenRigor = RIGOR_REF.replace("| `thorough` | product 5 |\n", "");
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".claude/skills/kata-review/references/settings.md": brokenRigor,
+    });
+    assert.deepEqual(ids(findings), ["kata-settings.table-drift"]);
+  });
+
+  test("zero (default) marks", async () => {
+    const noMark = TRUST_REF.replace(
+      "| `top-contributors` (default) |",
+      "| `top-contributors` |",
+    );
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".claude/skills/kata-release-merge/references/settings.md": noMark,
+    });
+    assert.deepEqual(ids(findings), ["kata-settings.table-drift"]);
+  });
+
+  test("mark on a row that is not the default attribute", async () => {
+    const wrongMark = RIGOR_REF.replace(
+      "| `light` | product 1 |",
+      "| `light` (default) | product 1 |",
+    ).replace("| `standard` (default) |", "| `standard` |");
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".claude/skills/kata-review/references/settings.md": wrongMark,
+    });
+    assert.deepEqual(ids(findings), ["kata-settings.table-drift"]);
+  });
+
+  test("block default attribute differs from the vocabulary default", async () => {
+    const wrongDefault = TRUST_REF.replace(
+      '<setting key="trustContributorCount" default="7">',
+      '<setting key="trustContributorCount" default="5">',
+    );
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".claude/skills/kata-release-merge/references/settings.md": wrongDefault,
+    });
+    assert.deepEqual(ids(findings), ["kata-settings.default-drift"]);
+  });
+
+  test("missing and duplicate blocks", async () => {
+    const trustTwice = TRUST_REF.replace(
+      '<setting key="trustAllowlist" default="[]">\n\nString list of tracker logins.\n\n</setting>\n',
+      `<setting key="trustSource" default="top-contributors">
+
+| Option | Meaning |
+| --- | --- |
+| \`top-contributors\` (default) | Trust the ranking. |
+| \`allowlist\` | Trust the list. |
+
+</setting>
+`,
+    );
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".claude/skills/kata-release-merge/references/settings.md": trustTwice,
+    });
+    const drift = findings.filter(
+      (f) => f.id === "kata-settings.block-key-drift",
+    );
+    assert.equal(drift.length, 2);
+    assert.ok(drift.some((f) => f.message.includes("trustAllowlist")));
+    assert.ok(drift.some((f) => f.message.includes("2 <setting> blocks")));
+  });
+
+  test("malformed opening tag and unclosed block", async () => {
+    const broken = `${TRUST_REF}
+<setting key="trustSource" default="top-contributors" type="select">
+
+</setting>
+
+<setting key="reviewPanel"
+  default="standard">
+
+</setting>
+`;
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".claude/skills/kata-release-merge/references/settings.md": broken,
+    });
+    const grammar = findings.filter(
+      (f) => f.id === "kata-settings.block-grammar",
+    );
+    assert.equal(grammar.length, 2);
+  });
+
+  test("fenced example blocks do not register", async () => {
+    const fenced = `# Reference
+
+\`\`\`markdown
+<setting key="exampleKey" default="option-a">
+
+| Option | Meaning |
+| --- | --- |
+| \`option-a\` (default) | Example. |
+
+</setting>
+\`\`\`
+`;
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".claude/agents/x-kata-settings.md": fenced,
+    });
+    assert.deepEqual(findings, []);
+  });
+
+  test("live repository run is clean", async () => {
+    const root = resolve(import.meta.dirname, "..");
+    const runtime = createTestRuntime({ fsSync });
+    const findings = await runRuleModules([mod], {
+      root,
+      runtime,
+      dir: resolve(root, ".jidoka/invariants"),
+    });
+    assert.deepEqual(findings, []);
+  });
+
+  test("VOCABULARY carries the five phase-1 keys", () => {
+    assert.deepEqual(Object.keys(VOCABULARY).sort(), [
+      "reviewBlockingSeverity",
+      "reviewPanel",
+      "trustAllowlist",
+      "trustContributorCount",
+      "trustSource",
+    ]);
+  });
+});

--- a/tests/kata-settings-invariant.test.js
+++ b/tests/kata-settings-invariant.test.js
@@ -2,7 +2,9 @@
 // `jidoka invariants` runs. Every case builds a scratch repository, runs
 // the rule module through runRuleModules, and asserts the finding ids. A
 // failing settings file can never sit committed on `main`, so these
-// fixture runs demonstrate that the invariant stops the line.
+// fixture runs demonstrate that the invariant stops the line. The live
+// tree is not re-run here: `bun run invariants` is that enforcement
+// (CONTRIBUTING.md § Testing).
 import { test, describe, afterEach } from "node:test";
 import assert from "node:assert";
 import { rmSync } from "node:fs";
@@ -11,7 +13,7 @@ import { resolve } from "node:path";
 import { runRuleModules } from "@forwardimpact/libinvariant";
 import { createTestRuntime } from "@forwardimpact/libmock";
 
-import mod, { VOCABULARY } from "../.jidoka/invariants/kata-settings.rules.mjs";
+import mod from "../.jidoka/invariants/kata-settings.rules.mjs";
 import { fsSync, withRepo } from "../libraries/libinvariant/test/helpers.js";
 
 const TRUST_REF = `# Trust Settings
@@ -261,24 +263,15 @@ describe("kata-settings invariant", () => {
     assert.deepEqual(findings, []);
   });
 
-  test("live repository run is clean", async () => {
-    const root = resolve(import.meta.dirname, "..");
-    const runtime = createTestRuntime({ fsSync });
-    const findings = await runRuleModules([mod], {
-      root,
-      runtime,
-      dir: resolve(root, ".jidoka/invariants"),
+  test("two (default) marks", async () => {
+    const twoMarks = RIGOR_REF.replace(
+      "| `light` | product 1 |",
+      "| `light` (default) | product 1 |",
+    );
+    const findings = await runOn({
+      ...CLEAN_REFS,
+      ".claude/skills/kata-review/references/settings.md": twoMarks,
     });
-    assert.deepEqual(findings, []);
-  });
-
-  test("VOCABULARY carries the five phase-1 keys", () => {
-    assert.deepEqual(Object.keys(VOCABULARY).sort(), [
-      "reviewBlockingSeverity",
-      "reviewPanel",
-      "trustAllowlist",
-      "trustContributorCount",
-      "trustSource",
-    ]);
+    assert.deepEqual(ids(findings), ["kata-settings.table-drift"]);
   });
 });


### PR DESCRIPTION
Implements spec 2290 (`specs/2290-kata-settings-file/plan-a.md`, all nine steps).

## Summary

- **Three new homes.** The shared read-mechanic reference (`.claude/agents/x-kata-settings.md`), the trust options reference (`kata-release-merge/references/settings.md`: `trustSource`, `trustContributorCount`, `trustAllowlist`), and the rigor options reference (`kata-review/references/settings.md`: `reviewPanel`, `reviewBlockingSeverity`).
- **Gate rules.** The merge gate resolves the trusted set through the configured trust source, reads settings from the default branch, fails closed on unreadable trust configuration (with a `settings unreadable` block template and re-ping route), and gates `.kata/` diffs on an explicit human signal pinned to the approved head.
- **Clean break.** Every fixed trust and rigor literal outside the owning tables is deleted: merge-gate skill and its references, the approval-signals reference, the review caller protocol and panel rationale, and both floor restatements in each of the four phase skills. `rg 'top.?7|top seven'` over `.claude/skills` and `.claude/agents` returns zero matches.
- **Enforcement.** `.jidoka/invariants/kata-settings.rules.mjs` holds the machine vocabulary and seven rules; `tests/kata-settings-invariant.test.js` proves each failure mode through `runRuleModules` (15 fixture cases).
- **Orientation.** `kata-setup`'s report step and KATA.md § Trust Boundary name the optional file and point at the owning tables.

## Notes for the merge gate

- Spec criterion 8's "caller protocol" reads as the protocol plus the settings reference it points at, per design-a § Key decisions (block placement). The floor vocabulary's sole `blocker, high, and medium` match is the `reviewBlockingSeverity` table's default row.
- Plan deviations, each noted in its commit message: layer caps forced small wording trims in the phase-skill checklist items (commit 7568c04); plan-a Step 7's "live repository run" case and a VOCABULARY shape test were removed because CONTRIBUTING.md § Testing forbids duplicating an invariant enforcement in a unit test (commit b4f2aeb).
- Commits 8d4715f and 03eeea6 cancel out: a `products/README.md` regeneration and its revert. The revert documents a pre-existing escaping drift between the workspace jidoka (`node_modules/.bin/jidoka`) and the pinned gear binary jidoka@v0.2.0 that CI's jtbd gate runs. The committed README matches the pinned binary and this PR leaves it untouched.

## Review

A clean eight-reviewer panel (technical 5 + devex 3, per the `kata-review` caller protocol, `standard` profile) reviewed the full diff. No blockers or highs. Every consensus and verified finding at or above the medium floor is addressed in commit b4f2aeb, which also records the dismissal rationales.

## Verification

CI is green on head 03eeea6 (all 50 checks). `bun run test` passes (5723 tests), and the spec's criterion sweeps (4, 7, 8, 9) return the expected match sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159TmKomYtrXbXbebnvtT4M