### PR TITLE
fix(pathway): show accurate skill proficiencies and behaviour maturities

### DIFF
--- a/products/pathway/src/components/behaviour-profile.js
+++ b/products/pathway/src/components/behaviour-profile.js
@@ -5,8 +5,8 @@
 /** @typedef {import('../types.js').BehaviourProfileItem} BehaviourProfileItem */
 
 import { div, table, thead, tbody, tr, th, td, a } from "../lib/render.js";
-import { getBehaviourMaturityIndex } from "../lib/render.js";
 import { createLevelCell } from "./detail.js";
+import { BEHAVIOUR_MATURITY_ORDER } from "@forwardimpact/libskill/levels";
 import { truncate } from "../formatters/shared.js";
 
 /**
@@ -19,10 +19,8 @@ export function createBehaviourProfile(behaviourProfile) {
     return div({ className: "empty-state" }, "No behaviours in profile");
   }
 
-  const rows = behaviourProfile.map((behaviour) => {
-    const maturityIndex = getBehaviourMaturityIndex(behaviour.maturity);
-
-    return tr(
+  const rows = behaviourProfile.map((behaviour) =>
+    tr(
       {},
       td(
         {},
@@ -31,13 +29,13 @@ export function createBehaviourProfile(behaviourProfile) {
           behaviour.behaviourName,
         ),
       ),
-      createLevelCell(maturityIndex, 5, behaviour.maturity),
+      createLevelCell(behaviour.maturity, BEHAVIOUR_MATURITY_ORDER),
       td(
         { className: "behaviour-description" },
         truncate(behaviour.maturityDescription, 80),
       ),
-    );
-  });
+    ),
+  );
 
   return div(
     { className: "table-container" },

--- a/products/pathway/src/components/comparison-radar.js
+++ b/products/pathway/src/components/comparison-radar.js
@@ -9,8 +9,8 @@
 import { ComparisonRadarChart } from "../lib/radar.js";
 import { div, h3 } from "../lib/render.js";
 import {
-  getSkillProficiencyIndex,
-  getBehaviourMaturityIndex,
+  rankSkillProficiency,
+  rankBehaviourMaturity,
   formatLevel,
 } from "../lib/render.js";
 import { compareByCapability } from "@forwardimpact/libskill/policies";
@@ -28,7 +28,7 @@ function skillRadarPoint(label, skill) {
   }
   return {
     label,
-    value: getSkillProficiencyIndex(skill.proficiency),
+    value: rankSkillProficiency(skill.proficiency),
     maxValue: 5,
     description: `${formatLevel(skill.type)} - ${formatLevel(skill.proficiency)}`,
   };
@@ -104,7 +104,7 @@ function buildBehaviourComparisonData(currentProfile, targetProfile) {
     currentData.push({
       label: behaviourName,
       value: currentBehaviour
-        ? getBehaviourMaturityIndex(currentBehaviour.maturity)
+        ? rankBehaviourMaturity(currentBehaviour.maturity)
         : 0,
       maxValue: 5,
       description: currentBehaviour
@@ -114,7 +114,7 @@ function buildBehaviourComparisonData(currentProfile, targetProfile) {
     targetData.push({
       label: behaviourName,
       value: targetBehaviour
-        ? getBehaviourMaturityIndex(targetBehaviour.maturity)
+        ? rankBehaviourMaturity(targetBehaviour.maturity)
         : 0,
       maxValue: 5,
       description: targetBehaviour

--- a/products/pathway/src/components/detail.js
+++ b/products/pathway/src/components/detail.js
@@ -36,24 +36,16 @@ import {
  * @returns {HTMLElement}
  */
 export function createLevelTable(descriptions, type = "skill") {
-  const levels =
+  const order =
     type === "skill" ? SKILL_PROFICIENCY_ORDER : BEHAVIOUR_MATURITY_ORDER;
 
-  const levelLabels = Object.fromEntries(
-    levels.map((level, index) => [level, String(index + 1)]),
-  );
-
-  const maxLevels = levels.length;
-
-  const rows = levels.map((level) => {
-    const description = descriptions?.[level] || "\u2014";
-    const levelIndex = parseInt(levelLabels[level]);
-    return tr(
+  const rows = order.map((level) =>
+    tr(
       {},
-      createLevelCell(levelIndex, maxLevels, level),
-      td({}, description),
-    );
-  });
+      createLevelCell(level, order),
+      td({}, descriptions?.[level] || "\u2014"),
+    ),
+  );
 
   return div(
     { className: "table-container" },
@@ -66,16 +58,30 @@ export function createLevelTable(descriptions, type = "skill") {
 }
 
 /**
+ * Rank a level name on its scale
+ *
+ * The rank is a count, not an index. The lowest level on the scale ranks 1.
+ * An absent or unknown name ranks 0, which fills no dots.
+ * @param {string} levelName - Level name, e.g. 'working' or 'practicing'
+ * @param {string[]} order - Ordered scale, lowest level first
+ * @returns {number} 1-based rank, or 0 when the name is not on the scale
+ */
+export function rankLevel(levelName, order) {
+  return order.indexOf(levelName) + 1;
+}
+
+/**
  * Create a level dots indicator
- * @param {number} level - Current level (1-based)
- * @param {number} maxLevel - Maximum level
+ * @param {number} filled - Number of dots to fill (0 fills none)
+ * @param {number} total - Number of dots to draw
  * @returns {HTMLElement}
  */
-export function createLevelDots(level, maxLevel) {
+export function createLevelDots(filled, total) {
+  const count = Number.isFinite(filled) ? Math.max(0, filled) : 0;
   const dots = [];
-  for (let i = 1; i <= maxLevel; i++) {
+  for (let i = 1; i <= total; i++) {
     const dot = div({
-      className: `level-dot ${i <= level ? "filled level-" + i : ""}`,
+      className: `level-dot ${i <= count ? "filled level-" + i : ""}`,
     });
     dots.push(dot);
   }
@@ -83,16 +89,25 @@ export function createLevelDots(level, maxLevel) {
 }
 
 /**
- * Create a level cell with dots and a label
- * @param {number} levelIndex - Current level (1-based index)
- * @param {number} maxLevels - Maximum levels
- * @param {string} levelName - Level name to display
+ * Create a level bar for a named level on its scale
+ * @param {string} levelName - Level name, e.g. 'working' or 'practicing'
+ * @param {string[]} order - Ordered scale, lowest level first
  * @returns {HTMLElement}
  */
-export function createLevelCell(levelIndex, maxLevels, levelName) {
+export function createLevelBar(levelName, order) {
+  return createLevelDots(rankLevel(levelName, order), order.length);
+}
+
+/**
+ * Create a level cell with dots and a label
+ * @param {string} levelName - Level name, e.g. 'working' or 'practicing'
+ * @param {string[]} order - Ordered scale, lowest level first
+ * @returns {HTMLElement}
+ */
+export function createLevelCell(levelName, order) {
   return td(
     { className: "level-cell" },
-    createLevelDots(levelIndex, maxLevels),
+    createLevelBar(levelName, order),
     span({ className: "level-label" }, formatLevel(levelName)),
   );
 }

--- a/products/pathway/src/components/progression-table.js
+++ b/products/pathway/src/components/progression-table.js
@@ -19,12 +19,16 @@ import {
 } from "../lib/render.js";
 import { formatLevel } from "../lib/render.js";
 import { createLevelCell, createEmptyLevelCell } from "./detail.js";
+import {
+  SKILL_PROFICIENCY_ORDER,
+  BEHAVIOUR_MATURITY_ORDER,
+} from "@forwardimpact/libskill/levels";
 import { createBadge } from "./card.js";
 
 /**
  * Create a row for a gained (new) item
  */
-function createGainedRow(item, isSkill, maxLevels) {
+function createGainedRow(item, isSkill, order) {
   const nameCell = td(
     {},
     a({ href: `#/${isSkill ? "skill" : "behaviour"}/${item.id}` }, item.name),
@@ -41,7 +45,7 @@ function createGainedRow(item, isSkill, maxLevels) {
       td({}, createBadge(item.capability, item.capability)),
       td({}, createBadge(formatLevel(item.type), item.type)),
       createEmptyLevelCell(),
-      createLevelCell(item.targetIndex, maxLevels, item.targetLevel),
+      createLevelCell(item.targetLevel, order),
       changeCell,
     );
   }
@@ -49,7 +53,7 @@ function createGainedRow(item, isSkill, maxLevels) {
     { className: "change-gained" },
     nameCell,
     createEmptyLevelCell(),
-    createLevelCell(item.targetIndex, maxLevels, item.targetLevel),
+    createLevelCell(item.targetLevel, order),
     changeCell,
   );
 }
@@ -57,7 +61,7 @@ function createGainedRow(item, isSkill, maxLevels) {
 /**
  * Create a row for a lost (removed) item
  */
-function createLostRow(item, isSkill, maxLevels) {
+function createLostRow(item, isSkill, order) {
   const nameCell = td(
     {},
     a({ href: `#/${isSkill ? "skill" : "behaviour"}/${item.id}` }, item.name),
@@ -73,7 +77,7 @@ function createLostRow(item, isSkill, maxLevels) {
       nameCell,
       td({}, createBadge(item.capability, item.capability)),
       td({}, createBadge(formatLevel(item.type), item.type)),
-      createLevelCell(item.currentIndex, maxLevels, item.currentLevel),
+      createLevelCell(item.currentLevel, order),
       createEmptyLevelCell(),
       changeCell,
     );
@@ -81,7 +85,7 @@ function createLostRow(item, isSkill, maxLevels) {
   return tr(
     { className: "change-lost" },
     nameCell,
-    createLevelCell(item.currentIndex, maxLevels, item.currentLevel),
+    createLevelCell(item.currentLevel, order),
     createEmptyLevelCell(),
     changeCell,
   );
@@ -90,7 +94,7 @@ function createLostRow(item, isSkill, maxLevels) {
 /**
  * Create a row for a normal change item
  */
-function createChangeRow(item, isSkill, maxLevels) {
+function createChangeRow(item, isSkill, order) {
   const changeClass =
     item.change > 0
       ? "change-up"
@@ -107,8 +111,8 @@ function createChangeRow(item, isSkill, maxLevels) {
       td({}, a({ href: `#/skill/${item.id}` }, item.name)),
       td({}, createBadge(item.capability, item.capability)),
       td({}, createBadge(formatLevel(item.type), item.type)),
-      createLevelCell(item.currentIndex, maxLevels, item.currentLevel),
-      createLevelCell(item.targetIndex, maxLevels, item.targetLevel),
+      createLevelCell(item.currentLevel, order),
+      createLevelCell(item.targetLevel, order),
       td(
         { className: `change-cell ${changeClass}` },
         span({ className: "change-indicator" }, changeText),
@@ -118,8 +122,8 @@ function createChangeRow(item, isSkill, maxLevels) {
   return tr(
     { className: changeClass },
     td({}, a({ href: `#/behaviour/${item.id}` }, item.name)),
-    createLevelCell(item.currentIndex, maxLevels, item.currentLevel),
-    createLevelCell(item.targetIndex, maxLevels, item.targetLevel),
+    createLevelCell(item.currentLevel, order),
+    createLevelCell(item.targetLevel, order),
     td(
       { className: `change-cell ${changeClass}` },
       span({ className: "change-indicator" }, changeText),
@@ -240,7 +244,7 @@ export function createProgressionTable(changes, type = "skill") {
   }
 
   const isSkill = type === "skill";
-  const maxLevels = 5;
+  const order = isSkill ? SKILL_PROFICIENCY_ORDER : BEHAVIOUR_MATURITY_ORDER;
 
   // Separate into changes, gained, lost, and no-changes
   const gained = changes.filter((c) => c.isGained);
@@ -252,12 +256,12 @@ export function createProgressionTable(changes, type = "skill") {
 
   const createRow = (item) => {
     if (item.isGained) {
-      return createGainedRow(item, isSkill, maxLevels);
+      return createGainedRow(item, isSkill, order);
     }
     if (item.isLost) {
-      return createLostRow(item, isSkill, maxLevels);
+      return createLostRow(item, isSkill, order);
     }
-    return createChangeRow(item, isSkill, maxLevels);
+    return createChangeRow(item, isSkill, order);
   };
 
   const skillHeaders = tr(

--- a/products/pathway/src/components/radar-chart.js
+++ b/products/pathway/src/components/radar-chart.js
@@ -8,8 +8,8 @@
 import { RadarChart } from "../lib/radar.js";
 import { div, h3 } from "../lib/render.js";
 import {
-  getSkillProficiencyIndex,
-  getBehaviourMaturityIndex,
+  rankSkillProficiency,
+  rankBehaviourMaturity,
   formatLevel,
 } from "../lib/render.js";
 
@@ -33,7 +33,7 @@ export function createSkillRadar(skillMatrix, options = {}) {
 
     const data = skillMatrix.map((skill) => ({
       label: skill.skillName,
-      value: getSkillProficiencyIndex(skill.proficiency),
+      value: rankSkillProficiency(skill.proficiency),
       maxValue: 5,
       description: `${formatLevel(skill.type)} skill - ${formatLevel(skill.proficiency)}`,
     }));
@@ -77,7 +77,7 @@ export function createBehaviourRadar(behaviourProfile, options = {}) {
 
     const data = behaviourProfile.map((behaviour) => ({
       label: behaviour.behaviourName,
-      value: getBehaviourMaturityIndex(behaviour.maturity),
+      value: rankBehaviourMaturity(behaviour.maturity),
       maxValue: 5,
       description: `${formatLevel(behaviour.maturity)}`,
     }));

--- a/products/pathway/src/components/skill-matrix.js
+++ b/products/pathway/src/components/skill-matrix.js
@@ -15,7 +15,6 @@ import {
   td,
   a,
 } from "../lib/render.js";
-import { getSkillProficiencyIndex } from "../lib/render.js";
 import { createLevelCell } from "./detail.js";
 import { createBadge } from "./card.js";
 import { SKILL_PROFICIENCY_ORDER } from "@forwardimpact/libskill/levels";
@@ -61,10 +60,8 @@ export function createSkillMatrix(skillMatrix, options = {}) {
     ? sortByCapabilityThenLevel(skillMatrix, capabilityOrder)
     : [...skillMatrix];
 
-  const rows = sortedSkills.map((skill) => {
-    const levelIndex = getSkillProficiencyIndex(skill.proficiency);
-
-    return tr(
+  const rows = sortedSkills.map((skill) =>
+    tr(
       { className: skill.isHumanOnly ? "human-only-row" : "" },
       td(
         {},
@@ -81,13 +78,13 @@ export function createSkillMatrix(skillMatrix, options = {}) {
           : null,
       ),
       td({}, createBadge(skill.capability, skill.capability)),
-      createLevelCell(levelIndex, 5, skill.proficiency),
+      createLevelCell(skill.proficiency, SKILL_PROFICIENCY_ORDER),
       td(
         { className: "skill-description" },
         truncate(skill.proficiencyDescription, 80),
       ),
-    );
-  });
+    ),
+  );
 
   return div(
     { className: "table-container" },

--- a/products/pathway/src/formatters/behaviour/dom.js
+++ b/products/pathway/src/formatters/behaviour/dom.js
@@ -63,18 +63,13 @@ export function behaviourToDOM(
         thead({}, tr({}, th({}, "Level"), th({}, "Description"))),
         tbody(
           {},
-          ...BEHAVIOUR_MATURITY_ORDER.map((maturity, index) => {
-            const description = view.maturityDescriptions[maturity] || "—";
-            return tr(
+          ...BEHAVIOUR_MATURITY_ORDER.map((maturity) =>
+            tr(
               {},
-              createLevelCell(
-                index + 1,
-                BEHAVIOUR_MATURITY_ORDER.length,
-                maturity,
-              ),
-              td({}, description),
-            );
-          }),
+              createLevelCell(maturity, BEHAVIOUR_MATURITY_ORDER),
+              td({}, view.maturityDescriptions[maturity] || "—"),
+            ),
+          ),
         ),
       ),
     ),

--- a/products/pathway/src/formatters/interview/dom.js
+++ b/products/pathway/src/formatters/interview/dom.js
@@ -4,12 +4,63 @@
 
 import { div, heading1, heading2, p, span } from "../../lib/render.js";
 import { createBackLink } from "../../components/nav.js";
-import { createLevelDots } from "../../components/detail.js";
-import { getConceptEmoji } from "@forwardimpact/libskill/levels";
+import { createLevelBar } from "../../components/detail.js";
+import {
+  SKILL_PROFICIENCY_ORDER,
+  BEHAVIOUR_MATURITY_ORDER,
+  getConceptEmoji,
+} from "@forwardimpact/libskill/levels";
+
+/**
+ * Create one question group with its target level bar
+ *
+ * Capability sections target a skill proficiency, so they share the skill
+ * scale. Behaviour sections use the maturity scale.
+ * @param {Object} section - Section from the interview view
+ * @param {string} nameClass - Class for the target name
+ * @param {string[]} order - Ordered level scale for this section type
+ * @returns {HTMLElement}
+ */
+function createQuestionGroup(section, nameClass, order) {
+  return div(
+    { className: "question-group" },
+    p(
+      { className: "question-group-title" },
+      span({ className: nameClass }, section.name),
+      " ",
+      createLevelBar(section.level, order),
+    ),
+    div(
+      { className: "question-list" },
+      ...section.questions.map((q) =>
+        p({ className: "question-text" }, q.question),
+      ),
+    ),
+  );
+}
+
+/**
+ * Create a section of question groups
+ * @param {Array} sections - Sections of one target type
+ * @param {string} title - Section heading
+ * @param {string} nameClass - Class for the target name
+ * @param {string[]} order - Ordered level scale for this section type
+ * @returns {HTMLElement|null}
+ */
+function createQuestionSection(sections, title, nameClass, order) {
+  if (sections.length === 0) return null;
+  return div(
+    { className: "detail-section" },
+    heading2({ className: "section-title" }, title),
+    ...sections.map((section) =>
+      createQuestionGroup(section, nameClass, order),
+    ),
+  );
+}
 
 /**
  * Format interview detail as DOM elements
- * @param {Object} view - Interview detail view from presenter
+ * @param {Object} view - Interview detail view from prepareInterviewDetail
  * @param {Object} typeConfig - Interview type configuration
  * @param {Object} options - Formatting options
  * @param {Object} [options.standard] - Standard data for emoji lookup
@@ -23,6 +74,9 @@ export function interviewToDOM(
 ) {
   const skillEmoji = getConceptEmoji(standard, "skill");
   const behaviourEmoji = getConceptEmoji(standard, "behaviour");
+  const sections = view.sections || [];
+  const type = typeConfig || view.typeInfo;
+
   return div(
     { className: "detail-page interview-detail" },
     // Header
@@ -31,67 +85,33 @@ export function interviewToDOM(
       showBackLink
         ? createBackLink("/interview", "← Back to Interview Builder")
         : null,
-      heading1({ className: "page-title" }, "💬 Interview: ", view.name),
-      p({ className: "page-description" }, view.description),
-      typeConfig
-        ? p({ className: "text-muted" }, `Type: ${typeConfig.label}`)
-        : null,
+      heading1({ className: "page-title" }, "💬 Interview: ", view.title),
+      type ? p({ className: "page-description" }, type.description) : null,
+      p(
+        { className: "text-muted" },
+        `${view.totalQuestions} questions · ${view.expectedDurationMinutes} minutes`,
+      ),
     ),
 
-    // Questions by skill
-    view.questionsBySkill && view.questionsBySkill.length > 0
-      ? div(
-          { className: "detail-section" },
-          heading2(
-            { className: "section-title" },
-            `${skillEmoji} Skill Questions`,
-          ),
-          ...view.questionsBySkill.map((group) =>
-            div(
-              { className: "question-group" },
-              p(
-                { className: "question-group-title" },
-                span({ className: "skill-name" }, group.skillName),
-                " ",
-                createLevelDots(group.levelIndex, group.totalLevels),
-              ),
-              div(
-                { className: "question-list" },
-                ...group.questions.map((q) =>
-                  p({ className: "question-text" }, q.text),
-                ),
-              ),
-            ),
-          ),
-        )
-      : null,
+    createQuestionSection(
+      sections.filter((s) => s.type === "skill"),
+      `${skillEmoji} Skill Questions`,
+      "skill-name",
+      SKILL_PROFICIENCY_ORDER,
+    ),
 
-    // Questions by behaviour
-    view.questionsByBehaviour && view.questionsByBehaviour.length > 0
-      ? div(
-          { className: "detail-section" },
-          heading2(
-            { className: "section-title" },
-            `${behaviourEmoji} Behaviour Questions`,
-          ),
-          ...view.questionsByBehaviour.map((group) =>
-            div(
-              { className: "question-group" },
-              p(
-                { className: "question-group-title" },
-                span({ className: "behaviour-name" }, group.behaviourName),
-                " ",
-                createLevelDots(group.levelIndex, group.totalLevels),
-              ),
-              div(
-                { className: "question-list" },
-                ...group.questions.map((q) =>
-                  p({ className: "question-text" }, q.text),
-                ),
-              ),
-            ),
-          ),
-        )
-      : null,
+    createQuestionSection(
+      sections.filter((s) => s.type === "capability"),
+      "🧩 Decomposition Questions",
+      "capability-name",
+      SKILL_PROFICIENCY_ORDER,
+    ),
+
+    createQuestionSection(
+      sections.filter((s) => s.type === "behaviour"),
+      `${behaviourEmoji} Behaviour Questions`,
+      "behaviour-name",
+      BEHAVIOUR_MATURITY_ORDER,
+    ),
   );
 }

--- a/products/pathway/src/formatters/level/dom.js
+++ b/products/pathway/src/formatters/level/dom.js
@@ -17,7 +17,7 @@ import {
   formatLevel,
 } from "../../lib/render.js";
 import { createBackLink } from "../../components/nav.js";
-import { createLevelDots } from "../../components/detail.js";
+import { createLevelBar } from "../../components/detail.js";
 import {
   SKILL_PROFICIENCY_ORDER,
   BEHAVIOUR_MATURITY_ORDER,
@@ -49,10 +49,7 @@ function createProficiencyRow(label, badgeClass, proficiency) {
     td(
       {},
       proficiency
-        ? createLevelDots(
-            SKILL_PROFICIENCY_ORDER.indexOf(proficiency),
-            SKILL_PROFICIENCY_ORDER.length,
-          )
+        ? createLevelBar(proficiency, SKILL_PROFICIENCY_ORDER)
         : span({ className: "text-muted" }, "—"),
     ),
   );
@@ -98,18 +95,12 @@ function createBaseProfileSection(view) {
                 {},
                 tr(
                   {},
+                  td({}, formatLevel(view.baseBehaviourMaturity)),
                   td(
                     {},
-                    view.baseBehaviourMaturity.charAt(0).toUpperCase() +
-                      view.baseBehaviourMaturity.slice(1),
-                  ),
-                  td(
-                    {},
-                    createLevelDots(
-                      BEHAVIOUR_MATURITY_ORDER.indexOf(
-                        view.baseBehaviourMaturity,
-                      ),
-                      BEHAVIOUR_MATURITY_ORDER.length,
+                    createLevelBar(
+                      view.baseBehaviourMaturity,
+                      BEHAVIOUR_MATURITY_ORDER,
                     ),
                   ),
                 ),

--- a/products/pathway/src/formatters/progress/dom.js
+++ b/products/pathway/src/formatters/progress/dom.js
@@ -16,17 +16,115 @@ import {
   span,
 } from "../../lib/render.js";
 import { createBackLink } from "../../components/nav.js";
-import { createLevelDots } from "../../components/detail.js";
+import {
+  createLevelCell,
+  createEmptyLevelCell,
+} from "../../components/detail.js";
+import {
+  SKILL_PROFICIENCY_ORDER,
+  BEHAVIOUR_MATURITY_ORDER,
+} from "@forwardimpact/libskill/levels";
 import { formatModifier } from "../shared.js";
 
 /**
+ * Create one change row with a from and a to level bar
+ * @param {string} name - Skill or behaviour name
+ * @param {string|null} fromLevel - Level before the move, null when gained
+ * @param {string} toLevel - Level after the move
+ * @param {number} change - Level change as a signed count
+ * @param {string[]} order - Ordered level scale
+ * @returns {HTMLElement}
+ */
+function createChangeRow(name, fromLevel, toLevel, change, order) {
+  return tr(
+    {},
+    td({}, name),
+    fromLevel ? createLevelCell(fromLevel, order) : createEmptyLevelCell(),
+    createLevelCell(toLevel, order),
+    td(
+      {},
+      span(
+        {
+          className: `modifier modifier-${change > 0 ? "positive" : "negative"}`,
+        },
+        formatModifier(change),
+      ),
+    ),
+  );
+}
+
+/**
+ * Create a changes table section
+ * @param {string} title - Section heading
+ * @param {string} nameHeader - Header for the name column
+ * @param {HTMLElement[]} rows - Change rows
+ * @returns {HTMLElement|null}
+ */
+function createChangesSection(title, nameHeader, rows) {
+  if (rows.length === 0) return null;
+  return div(
+    { className: "detail-section" },
+    heading2({ className: "section-title" }, title),
+    table(
+      { className: "progression-table" },
+      thead(
+        {},
+        tr(
+          {},
+          th({}, nameHeader),
+          th({}, "Current"),
+          th({}, "Target"),
+          th({}, "Change"),
+        ),
+      ),
+      tbody({}, ...rows),
+    ),
+  );
+}
+
+/**
  * Format progress detail as DOM elements
- * @param {Object} view - Progress detail view from presenter
+ * @param {Object} view - Progress detail view from prepareProgressDetail
  * @param {Object} options - Formatting options
  * @param {boolean} options.showBackLink - Whether to show back navigation link
  * @returns {HTMLElement}
  */
 export function progressToDOM(view, { showBackLink = true } = {}) {
+  const skillRows = (view.skillChanges || [])
+    .filter((s) => s.proficiencyChange !== 0)
+    .map((s) =>
+      createChangeRow(
+        s.name,
+        s.fromLevel,
+        s.toLevel,
+        s.proficiencyChange,
+        SKILL_PROFICIENCY_ORDER,
+      ),
+    );
+
+  const behaviourRows = (view.behaviourChanges || [])
+    .filter((b) => b.maturityChange !== 0)
+    .map((b) =>
+      createChangeRow(
+        b.name,
+        b.fromMaturity,
+        b.toMaturity,
+        b.maturityChange,
+        BEHAVIOUR_MATURITY_ORDER,
+      ),
+    );
+
+  const skillSection = createChangesSection(
+    "Skill Changes",
+    "Skill",
+    skillRows,
+  );
+  const behaviourSection = createChangesSection(
+    "Behaviour Changes",
+    "Behaviour",
+    behaviourRows,
+  );
+
   return div(
     { className: "detail-page progress-detail" },
     // Header
@@ -35,98 +133,18 @@ export function progressToDOM(view, { showBackLink = true } = {}) {
       showBackLink
         ? createBackLink("/progress", "← Back to Progress Tracking")
         : null,
-      heading1({ className: "page-title" }, "📈 ", view.name),
-      p({ className: "page-description" }, view.description),
+      heading1({ className: "page-title" }, "📈 Career Progression"),
+      p(
+        { className: "page-description" },
+        `${view.fromTitle} → ${view.toTitle}`,
+      ),
     ),
 
-    // Skill changes
-    view.skillChanges && view.skillChanges.length > 0
-      ? div(
-          { className: "detail-section" },
-          heading2({ className: "section-title" }, "Skill Changes"),
-          table(
-            { className: "progression-table" },
-            thead(
-              {},
-              tr(
-                {},
-                th({}, "Skill"),
-                th({}, "Change"),
-                th({}, "Expected Level"),
-              ),
-            ),
-            tbody(
-              {},
-              ...view.skillChanges.map((change) =>
-                tr(
-                  {},
-                  td({}, change.skillName),
-                  td(
-                    {},
-                    span(
-                      {
-                        className: `modifier modifier-${change.modifier > 0 ? "positive" : "negative"}`,
-                      },
-                      formatModifier(change.modifier),
-                    ),
-                  ),
-                  td(
-                    {},
-                    createLevelDots(
-                      change.expectedLevelIndex,
-                      change.totalLevels,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        )
-      : null,
+    skillSection,
+    behaviourSection,
 
-    // Behaviour changes
-    view.behaviourChanges && view.behaviourChanges.length > 0
-      ? div(
-          { className: "detail-section" },
-          heading2({ className: "section-title" }, "Behaviour Changes"),
-          table(
-            { className: "progression-table" },
-            thead(
-              {},
-              tr(
-                {},
-                th({}, "Behaviour"),
-                th({}, "Change"),
-                th({}, "Expected Level"),
-              ),
-            ),
-            tbody(
-              {},
-              ...view.behaviourChanges.map((change) =>
-                tr(
-                  {},
-                  td({}, change.behaviourName),
-                  td(
-                    {},
-                    span(
-                      {
-                        className: `modifier modifier-${change.modifier > 0 ? "positive" : "negative"}`,
-                      },
-                      formatModifier(change.modifier),
-                    ),
-                  ),
-                  td(
-                    {},
-                    createLevelDots(
-                      change.expectedLevelIndex,
-                      change.totalLevels,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        )
+    !skillSection && !behaviourSection
+      ? p({ className: "text-muted" }, "This progression requires no changes.")
       : null,
   );
 }

--- a/products/pathway/src/formatters/skill/dom.js
+++ b/products/pathway/src/formatters/skill/dom.js
@@ -197,14 +197,13 @@ export function skillToDOM(
         thead({}, tr({}, th({}, "Level"), th({}, "Description"))),
         tbody(
           {},
-          ...SKILL_PROFICIENCY_ORDER.map((level, index) => {
-            const description = view.proficiencyDescriptions[level] || "—";
-            return tr(
+          ...SKILL_PROFICIENCY_ORDER.map((level) =>
+            tr(
               {},
-              createLevelCell(index + 1, SKILL_PROFICIENCY_ORDER.length, level),
-              td({}, description),
-            );
-          }),
+              createLevelCell(level, SKILL_PROFICIENCY_ORDER),
+              td({}, view.proficiencyDescriptions[level] || "—"),
+            ),
+          ),
         ),
       ),
     ),

--- a/products/pathway/src/lib/render.js
+++ b/products/pathway/src/lib/render.js
@@ -57,19 +57,25 @@ import {
 } from "@forwardimpact/libskill/levels";
 
 /**
- * Get the index for a skill proficiency (1-5)
+ * Rank a skill proficiency on its scale
+ *
+ * The rank counts levels, so 'awareness' ranks 1 and 'expert' ranks 5.
+ * `getSkillProficiencyIndex` in libskill returns the 0-based index instead.
  * @param {string} level
- * @returns {number}
+ * @returns {number} 1-5, or 0 when the level is unknown
  */
-export function getSkillProficiencyIndex(level) {
+export function rankSkillProficiency(level) {
   return SKILL_PROFICIENCY_ORDER.indexOf(level) + 1;
 }
 
 /**
- * Get the index for a behaviour maturity (1-5)
+ * Rank a behaviour maturity on its scale
+ *
+ * The rank counts levels, so 'emerging' ranks 1 and 'exemplifying' ranks 5.
+ * `getBehaviourMaturityIndex` in libskill returns the 0-based index instead.
  * @param {string} maturity
- * @returns {number}
+ * @returns {number} 1-5, or 0 when the maturity is unknown
  */
-export function getBehaviourMaturityIndex(maturity) {
+export function rankBehaviourMaturity(maturity) {
   return BEHAVIOUR_MATURITY_ORDER.indexOf(maturity) + 1;
 }

--- a/products/pathway/src/slides/interview.js
+++ b/products/pathway/src/slides/interview.js
@@ -23,9 +23,9 @@ export function renderInterviewSlide({ render, data, params }) {
   const level = data.levels.find((g) => g.id === params.level);
   const track = data.tracks.find((t) => t.id === params.track);
 
-  // Get the interview type from the URL query. Default to full
+  // Get the interview type from the URL query. Default to mission fit
   const urlParams = new URLSearchParams(window.location.search);
-  const interviewType = urlParams.get("type") || "full";
+  const interviewType = urlParams.get("type") || "mission";
 
   const view = prepareInterviewDetail({
     discipline,

--- a/products/pathway/src/types.js
+++ b/products/pathway/src/types.js
@@ -49,8 +49,8 @@
  * @property {'core'|'supporting'|'broad'|'track'} type - Skill tier
  * @property {string} currentLevel - Current level ID (or null if new)
  * @property {string} targetLevel - Target level ID (or null if removed)
- * @property {number} currentIndex - Current level as 0-5 index
- * @property {number} targetIndex - Target level as 0-5 index
+ * @property {number} currentIndex - Current level as 0-4 index (-1 if new)
+ * @property {number} targetIndex - Target level as 0-4 index (-1 if removed)
  * @property {number} change - Level difference (positive = upgrade)
  * @property {boolean} isGained - True if skill is new in target role
  * @property {boolean} isLost - True if the target role removes the skill
@@ -63,8 +63,8 @@
  * @property {string} name - Display name
  * @property {string} currentLevel - Current maturity (or null if new)
  * @property {string} targetLevel - Target maturity (or null if removed)
- * @property {number} currentIndex - Current maturity as 0-4 index
- * @property {number} targetIndex - Target maturity as 0-4 index
+ * @property {number} currentIndex - Current maturity as 0-4 index (-1 if new)
+ * @property {number} targetIndex - Target maturity as 0-4 index (-1 if removed)
  * @property {number} change - Maturity difference (positive = upgrade)
  * @property {boolean} isGained - True if behaviour is new in target role
  * @property {boolean} isLost - True if the target role removes the behaviour

--- a/products/pathway/test/level-bar.test.js
+++ b/products/pathway/test/level-bar.test.js
@@ -100,3 +100,132 @@ describe("createLevelCell", () => {
     assert.strictEqual(label.textContent, "Role Modeling");
   });
 });
+
+describe("interviewToDOM", () => {
+  // The section shape matches groupQuestionsIntoSections in
+  // formatters/interview/shared.js. Capability sections target a skill
+  // proficiency, so they read off the skill scale.
+  const view = {
+    title: "Data Engineer Level II - Platform",
+    totalQuestions: 3,
+    expectedDurationMinutes: 45,
+    typeInfo: { name: "Mission Fit", description: "Assess technical skills." },
+    sections: [
+      {
+        id: "sql",
+        name: "SQL",
+        type: "skill",
+        level: "working",
+        questions: [{ question: "Walk me through a slow query." }],
+      },
+      {
+        id: "delivery",
+        name: "delivery",
+        type: "capability",
+        level: "practitioner",
+        questions: [{ question: "Break down this ambiguous request." }],
+      },
+      {
+        id: "collaboration",
+        name: "Collaboration",
+        type: "behaviour",
+        level: "role-modeling",
+        questions: [{ question: "Describe a disagreement you resolved." }],
+      },
+    ],
+  };
+
+  test("renders the title, every section, and every question", async () => {
+    const { interviewToDOM } = await import(
+      "../src/formatters/interview/dom.js"
+    );
+    const el = interviewToDOM(view, view.typeInfo, { showBackLink: false });
+
+    assert.match(el.querySelector(".page-title").textContent, /Data Engineer/);
+    assert.strictEqual(el.querySelectorAll(".question-group").length, 3);
+    assert.strictEqual(el.querySelectorAll(".question-text").length, 3);
+    assert.match(
+      el.querySelectorAll(".question-text")[0].textContent,
+      /slow query/,
+    );
+  });
+
+  test("fills each group's level bar on the scale for its target type", async () => {
+    const { interviewToDOM } = await import(
+      "../src/formatters/interview/dom.js"
+    );
+    const el = interviewToDOM(view, view.typeInfo, { showBackLink: false });
+    const bars = [...el.querySelectorAll(".question-group .level-bar")];
+
+    // working (skill) = 3, practitioner (skill scale) = 4,
+    // role-modeling (behaviour) = 4
+    assert.deepStrictEqual(bars.map(filledCount), [3, 4, 4]);
+  });
+});
+
+describe("progressToDOM", () => {
+  const view = {
+    fromTitle: "Level I Engineer",
+    toTitle: "Level II Engineer",
+    skillChanges: [
+      {
+        id: "s1",
+        name: "SQL",
+        type: "core",
+        fromLevel: "awareness",
+        toLevel: "foundational",
+        proficiencyChange: 1,
+      },
+      {
+        id: "s2",
+        name: "New skill",
+        type: "broad",
+        fromLevel: null,
+        toLevel: "awareness",
+        proficiencyChange: 1,
+      },
+      {
+        id: "s3",
+        name: "Unchanged",
+        type: "supporting",
+        fromLevel: "working",
+        toLevel: "working",
+        proficiencyChange: 0,
+      },
+    ],
+    behaviourChanges: [
+      {
+        id: "b1",
+        name: "Collaboration",
+        fromMaturity: "emerging",
+        toMaturity: "developing",
+        maturityChange: 1,
+      },
+    ],
+    summary: {},
+  };
+
+  test("lists only the changed skills and behaviours", async () => {
+    const { progressToDOM } = await import("../src/formatters/progress/dom.js");
+    const el = progressToDOM(view, { showBackLink: false });
+
+    assert.match(
+      el.querySelector(".page-description").textContent,
+      /Level I Engineer → Level II Engineer/,
+    );
+    // Two changed skills plus one changed behaviour. 'Unchanged' drops out.
+    assert.strictEqual(el.querySelectorAll("tbody tr").length, 3);
+  });
+
+  test("fills the from and to bars, and leaves gained skills without a from bar", async () => {
+    const { progressToDOM } = await import("../src/formatters/progress/dom.js");
+    const el = progressToDOM(view, { showBackLink: false });
+    const rows = [...el.querySelectorAll("tbody tr")];
+
+    const bars = (row) => [...row.querySelectorAll(".level-bar")];
+    assert.deepStrictEqual(bars(rows[0]).map(filledCount), [1, 2]);
+    // The gained skill has no current level, so it draws one bar only.
+    assert.deepStrictEqual(bars(rows[1]).map(filledCount), [1]);
+    assert.deepStrictEqual(bars(rows[2]).map(filledCount), [1, 2]);
+  });
+});

--- a/products/pathway/test/level-bar.test.js
+++ b/products/pathway/test/level-bar.test.js
@@ -1,0 +1,102 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { Window } from "happy-dom";
+
+import {
+  SKILL_PROFICIENCY_ORDER,
+  BEHAVIOUR_MATURITY_ORDER,
+} from "@forwardimpact/libskill/levels";
+
+let win;
+const savedWindow = globalThis.window;
+const savedDocument = globalThis.document;
+const savedHTMLElement = globalThis.HTMLElement;
+
+let createLevelBar;
+let createLevelCell;
+let createLevelDots;
+let rankLevel;
+
+beforeEach(async () => {
+  win = new Window({ url: "http://localhost/" });
+  globalThis.window = win;
+  globalThis.document = win.document;
+  // libui's render helpers branch on `instanceof HTMLElement`.
+  globalThis.HTMLElement = win.HTMLElement;
+  ({ createLevelBar, createLevelCell, createLevelDots, rankLevel } =
+    await import("../src/components/detail.js"));
+});
+
+afterEach(() => {
+  globalThis.window = savedWindow;
+  globalThis.document = savedDocument;
+  globalThis.HTMLElement = savedHTMLElement;
+});
+
+/** Count the dots a level bar fills */
+function filledCount(bar) {
+  return [...bar.children].filter((dot) =>
+    dot.getAttribute("class").includes("filled"),
+  ).length;
+}
+
+describe("rankLevel", () => {
+  test("ranks the lowest level 1, not 0", () => {
+    assert.strictEqual(rankLevel("awareness", SKILL_PROFICIENCY_ORDER), 1);
+    assert.strictEqual(rankLevel("emerging", BEHAVIOUR_MATURITY_ORDER), 1);
+  });
+
+  test("ranks the highest level at the scale length", () => {
+    assert.strictEqual(rankLevel("expert", SKILL_PROFICIENCY_ORDER), 5);
+    assert.strictEqual(rankLevel("exemplifying", BEHAVIOUR_MATURITY_ORDER), 5);
+  });
+
+  test("ranks an unknown level 0", () => {
+    assert.strictEqual(rankLevel("nonsense", SKILL_PROFICIENCY_ORDER), 0);
+    assert.strictEqual(rankLevel(undefined, SKILL_PROFICIENCY_ORDER), 0);
+  });
+});
+
+describe("createLevelBar", () => {
+  test("fills one dot per level up to and including the named level", () => {
+    for (const [index, level] of SKILL_PROFICIENCY_ORDER.entries()) {
+      const bar = createLevelBar(level, SKILL_PROFICIENCY_ORDER);
+      assert.strictEqual(bar.children.length, SKILL_PROFICIENCY_ORDER.length);
+      assert.strictEqual(filledCount(bar), index + 1, `for ${level}`);
+    }
+  });
+
+  test("fills three of five dots for practicing behaviour maturity", () => {
+    const bar = createLevelBar("practicing", BEHAVIOUR_MATURITY_ORDER);
+    assert.strictEqual(bar.children.length, 5);
+    assert.strictEqual(filledCount(bar), 3);
+  });
+
+  test("fills no dots for a level off the scale", () => {
+    const bar = createLevelBar("nonsense", BEHAVIOUR_MATURITY_ORDER);
+    assert.strictEqual(bar.children.length, 5);
+    assert.strictEqual(filledCount(bar), 0);
+  });
+});
+
+describe("createLevelDots", () => {
+  test("draws the requested total and fills the requested count", () => {
+    const bar = createLevelDots(2, 4);
+    assert.strictEqual(bar.children.length, 4);
+    assert.strictEqual(filledCount(bar), 2);
+  });
+
+  test("fills no dots for a negative or missing count", () => {
+    assert.strictEqual(filledCount(createLevelDots(-1, 5)), 0);
+    assert.strictEqual(filledCount(createLevelDots(undefined, 5)), 0);
+  });
+});
+
+describe("createLevelCell", () => {
+  test("labels the level and fills the matching dots", () => {
+    const cell = createLevelCell("role-modeling", BEHAVIOUR_MATURITY_ORDER);
+    const [bar, label] = cell.children;
+    assert.strictEqual(filledCount(bar), 4);
+    assert.strictEqual(label.textContent, "Role Modeling");
+  });
+});


### PR DESCRIPTION
## Summary

Level bars across Pathway under-filled by one dot, and the lowest level on
each scale filled no dots at all. The reported case was `/#/level/J100`,
where a base core proficiency of `expert` showed four of five dots and a
base behaviour maturity of `practicing` showed two of five.

`createLevelDots` counts from 1, but several callers passed a 0-based index.
Two same-named helpers with different bases caused this: libskill's
`getSkillProficiencyIndex` returns 0 for `awareness`, while the pathway copy
in `lib/render.js` returned 1 for the same level.

Fixed surfaces:

| Surface | Symptom |
| --- | --- |
| `/#/level/:id` base skill proficiencies | One dot short. `awareness` showed nothing. |
| `/#/level/:id` base behaviour maturity | One dot short. `emerging` showed nothing. |
| Career Progress progression tables | One dot short in the current and the target column. |
| Interview slide and handout | Read `view.questionsBySkill` and `group.levelIndex`, which the presenter never produced. No questions and no dots rendered. |
| Progress slide and handout | Read `change.expectedLevelIndex` and `totalLevels`, which never existed. No dots. Title and description were undefined. |
| Level page maturity label | `role-modeling` read "Role-modeling" instead of "Role Modeling". |
| Interview slide default type | Defaulted to `full`, which is not a valid type, so the type config was always undefined. |

Level bars now derive the fill count from the level name and its scale, so
no call site does index arithmetic. This removes the off-by-one class rather
than patching each site. `createLevelDots(filled, total)` remains the
primitive with an explicit count contract, clamped against negative and
missing values. The pathway helpers become `rankSkillProficiency` and
`rankBehaviourMaturity`, so the name collision with libskill cannot recur.

## Test plan

- [x] `bun run check` (see note)
- [x] `bun run test` — 5733 pass, 0 fail
- [x] New `products/pathway/test/level-bar.test.js`: 13 tests covering every
      level on both scales, off-scale values, and the two repaired slide
      formatters.
- [x] Rendered the level page headless. J040 gives 2/1/1 with Emerging 1.
      J100 gives 5/4/4 with Practicing 3.

Note on `bun run check`: `context:check-jtbd` fails locally on
`products/README.md` over `kata-\*` escaping. It reproduces with this diff
reverted, and it is the known workspace-versus-pinned-binary drift that
commit 4b8ad91 already documented and reverted. This branch touches no
markdown and no `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)