### PR TITLE
chore(pathway): bump to 0.26.10

### DIFF
--- a/products/pathway/package.json
+++ b/products/pathway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/pathway",
-  "version": "0.26.9",
+  "version": "0.26.10",
   "description": "Explore roles, generate agent profiles, and surface career expectations so progression and team configuration are visible instead of guessed.",
   "keywords": [
     "career",


### PR DESCRIPTION
## Summary

- Releases the level-bar display fix from #2023 (merged as `e50fea027`).
- Pathway is pre-1.0, so any change takes a patch bump: `0.26.9` → `0.26.10`.

The fix touches `products/pathway/src` only. It reads the level scales from
`libskill@6.2.0`, which is already published and unchanged, so no dependency
release precedes this one.

After merge, `pathway@v0.26.10` gets tagged through the `Release: Tag`
workflow per CONTRIBUTING § Releasing.

## Test plan

- [x] `bun install` — lockfile unchanged, 1 package installed
- [x] `bun run check` — passes except the known local-only
      `products/README.md` `kata-\*` escaping drift, which CI's `jtbd` job
      passed on `e50fea027`

🤖 Generated with [Claude Code](https://claude.com/claude-code)