### PR TITLE
chore(actions): repin gemba-* refs to the new-lineage releases

### DIFF
--- a/products/gemba/actions/gemba-benchmark/.github/workflows/benchmark.yml
+++ b/products/gemba/actions/gemba-benchmark/.github/workflows/benchmark.yml
@@ -115,13 +115,13 @@ jobs:
       LIBHARNESS_WORK_TRACKER: filesystem
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/gemba-bootstrap@71bd75533e5bc5f3046004839ab1b1c36261b033 # v1.0.17
+      - uses: forwardimpact/gemba-bootstrap@3e7b7c78737414a54143882375bc543e4b4f2c36 # v1.0.19
         with:
           # gemba-benchmark runs the benchmark binary straight off PATH. The
           # action has no bunx/npx fallback. It needs a gemba-bootstrap pin whose
           # gear release publishes the gemba-* binaries.
           clis: gemba-benchmark
-      - uses: forwardimpact/gemba-benchmark@v1.0.8
+      - uses: forwardimpact/gemba-benchmark@v1.0.9
         with:
           mode: run
           family: ${{ inputs.family }}
@@ -159,7 +159,7 @@ jobs:
           curl -fsSL "https://github.com/forwardimpact/monorepo/releases/download/${GEAR_RELEASE}/fit-install.sh" \
             | bash -s -- --only gemba-benchmark
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - uses: forwardimpact/gemba-benchmark@v1.0.8
+      - uses: forwardimpact/gemba-benchmark@v1.0.9
         with:
           mode: merge
           # family is a required action input but unused in merge mode.

--- a/products/kata/actions/kata-agent/action.yml
+++ b/products/kata/actions/kata-agent/action.yml
@@ -162,7 +162,7 @@ runs:
     # ./scripts/bootstrap.sh. The `token:` input gates wiki checkout. Leave it
     # empty to skip wiki sync. forwardimpact/gemba-wiki below pushes the wiki back
     # after the agent run.
-    - uses: forwardimpact/gemba-bootstrap@a5d9098c2a1e68277f02fad39583a34ee003d9c9 # v1.0.18
+    - uses: forwardimpact/gemba-bootstrap@3e7b7c78737414a54143882375bc543e4b4f2c36 # v1.0.19
       with:
         token: ${{ inputs.wiki == 'true' && steps.ci-app.outputs.token || '' }}
         app-slug: ${{ inputs.app-slug }}
@@ -187,7 +187,7 @@ runs:
 
     - name: Assess and Act
       id: assess
-      uses: forwardimpact/gemba-harness@f1943c61188049a86436913af157852b70331813 # v1.0.4
+      uses: forwardimpact/gemba-harness@8570a09c2eab3a82879535c039bdf89bfab76c9e # v1.0.5
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         GH_TOKEN: ${{ steps.ci-app.outputs.token }}

--- a/products/kata/actions/kata-interview/action.yml
+++ b/products/kata/actions/kata-interview/action.yml
@@ -126,7 +126,7 @@ runs:
     # fit-terrain now also provides the generic substrate bring-up, so this
     # step does NOT install fit-map. A consumer's FI substrate command runs it
     # with bunx as its own documented exception.
-    - uses: forwardimpact/gemba-bootstrap@a5d9098c2a1e68277f02fad39583a34ee003d9c9 # v1.0.18
+    - uses: forwardimpact/gemba-bootstrap@3e7b7c78737414a54143882375bc543e4b4f2c36 # v1.0.19
       with:
         token: ${{ steps.ci-app.outputs.token }}
         app-slug: ${{ inputs.app-slug }}
@@ -181,7 +181,7 @@ runs:
 
     - name: Run interview
       id: interview
-      uses: forwardimpact/gemba-harness@f1943c61188049a86436913af157852b70331813 # v1.0.4
+      uses: forwardimpact/gemba-harness@8570a09c2eab3a82879535c039bdf89bfab76c9e # v1.0.5
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         GH_TOKEN: ${{ steps.ci-app.outputs.token }}


### PR DESCRIPTION
Closes the manual-pin follow-up from the spec 2280 release runbook (#2021).

## Why

The `gemba-*` prefix rename re-seeded each split lineage. Dependabot scopes the
`github-actions` ecosystem to `/` and `/.github/actions/*`, so it carries the
new-lineage SHAs to everything under `.github/workflows/`. These three files sit
outside that scope and need a manual bump.

## Pins bumped

| File | Ref | From | To |
|---|---|---|---|
| `products/kata/actions/kata-agent/action.yml` | gemba-bootstrap | v1.0.18 | v1.0.19 |
| `products/kata/actions/kata-agent/action.yml` | gemba-harness | v1.0.4 | v1.0.5 |
| `products/kata/actions/kata-interview/action.yml` | gemba-bootstrap | v1.0.18 | v1.0.19 |
| `products/kata/actions/kata-interview/action.yml` | gemba-harness | v1.0.4 | v1.0.5 |
| `products/gemba/actions/gemba-benchmark/.github/workflows/benchmark.yml` | gemba-bootstrap | v1.0.17 | v1.0.19 |
| `products/gemba/actions/gemba-benchmark/.github/workflows/benchmark.yml` | gemba-benchmark | v1.0.8 | v1.0.9 |

The four new sibling releases were cut on the re-seeded lineage before this PR,
and each `v1` alias now tracks it:

- `gemba-bootstrap@v1.0.19` -> `3e7b7c787`
- `gemba-harness@v1.0.5` -> `8570a09c2`
- `gemba-wiki@v1.0.3` -> `36bcf7256`
- `gemba-benchmark@v1.0.9` -> `397410616`

`gemba-wiki@v1` references inside kata-agent stay on the mutable alias, which
now resolves to the new lineage. Per `.github/CLAUDE.md`, the SHA-pin policy
governs workflow `uses:` only; a sibling governs its own internal `uses:`.

## Follow-up

Merging this moves `kata-agent` and `kata-interview` main past their current
tags. A `kata-agent` release plus a repin of `.github/workflows/kata-*.yml` is
needed before a Kata run picks up these internals.