### PR TITLE
chore(workflows): repin kata-agent, kata-interview, and gemba-benchmark

### DIFF
--- a/.github/workflows/eval-jidoka.yml
+++ b/.github/workflows/eval-jidoka.yml
@@ -17,7 +17,7 @@ jobs:
   # This caller only picks the family and shard count. The filesystem
   # work-tracker is the reusable workflow's env contract.
   benchmark:
-    uses: forwardimpact/gemba-benchmark/.github/workflows/benchmark.yml@027b1a5947f5e1bf6752fba7b68a753d8957fde9 # v1.0.8
+    uses: forwardimpact/gemba-benchmark/.github/workflows/benchmark.yml@957c1160820c3ee33e0d9a5be82bb7ff3df5e4b9 # v1.0.10
     with:
       family: ./benchmarks/jidoka-skills
       runs: "5"

--- a/.github/workflows/eval-kata.yml
+++ b/.github/workflows/eval-kata.yml
@@ -18,7 +18,7 @@ jobs:
   # reusable workflow's env contract. This caller only picks the family and
   # shard count.
   benchmark:
-    uses: forwardimpact/gemba-benchmark/.github/workflows/benchmark.yml@027b1a5947f5e1bf6752fba7b68a753d8957fde9 # v1.0.8
+    uses: forwardimpact/gemba-benchmark/.github/workflows/benchmark.yml@957c1160820c3ee33e0d9a5be82bb7ff3df5e4b9 # v1.0.10
     with:
       family: ./benchmarks/kata-skills
       runs: "5"

--- a/.github/workflows/eval-wiki.yml
+++ b/.github/workflows/eval-wiki.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           # gemba-benchmark runs the benchmark binary straight off PATH.
           clis: gemba-benchmark
-      - uses: forwardimpact/gemba-benchmark@027b1a5947f5e1bf6752fba7b68a753d8957fde9 # v1.0.8
+      - uses: forwardimpact/gemba-benchmark@957c1160820c3ee33e0d9a5be82bb7ff3df5e4b9 # v1.0.10
         with:
           family: ./benchmarks/fit-wiki
           runs: "5"

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # kata-agent runs the killswitch first and reports run cost last.
-      - uses: forwardimpact/kata-agent@ffa13d0213523e310605cd4301e364cd70f8393d # v1.0.8
+      - uses: forwardimpact/kata-agent@ae8d86f64ae7a8edaba059d1314e97e4dc652d35 # v1.0.9
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -51,7 +51,7 @@ jobs:
       # and the issued token name. `bunx fit-map substrate stage` is the sole
       # remaining `fit-map` exception. fit-map ships in the map release. It is
       # absent from the gear bundle on PATH.
-      - uses: forwardimpact/kata-interview@83505dd60725cacd5b4be4120eca7d21d179d9b1 # v1.0.1
+      - uses: forwardimpact/kata-interview@03b304ae3b7dbecee0c8dd6a12aa260936fd758c # v1.0.2
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}

--- a/.github/workflows/kata-shift.yml
+++ b/.github/workflows/kata-shift.yml
@@ -39,7 +39,7 @@ jobs:
           - { name: improvement-coach }
     steps:
       # kata-agent runs the killswitch first and reports run cost last.
-      - uses: forwardimpact/kata-agent@ffa13d0213523e310605cd4301e364cd70f8393d # v1.0.8
+      - uses: forwardimpact/kata-agent@ae8d86f64ae7a8edaba059d1314e97e4dc652d35 # v1.0.9
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # kata-agent runs the killswitch first and reports run cost last.
-      - uses: forwardimpact/kata-agent@ffa13d0213523e310605cd4301e364cd70f8393d # v1.0.8
+      - uses: forwardimpact/kata-agent@ae8d86f64ae7a8edaba059d1314e97e4dc652d35 # v1.0.9
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Tail of the spec 2280 pin chain (#2021). #2025 repinned the action *internals*; this releases them into this repo's own workflow pins.

| Ref | From | To |
|---|---|---|
| kata-agent | v1.0.8 `ffa13d021` | v1.0.9 `ae8d86f64` |
| kata-interview | v1.0.1 `83505dd60` | v1.0.2 `03b304ae3` |
| gemba-benchmark | v1.0.8 `027b1a594` | v1.0.10 `957c11608` |

Each new tag was cut on the sibling main that `publish-actions` produced from
the #2025 merge, so these pins carry the new-lineage `gemba-bootstrap@v1.0.19`
and `gemba-harness@v1.0.5` internals.

## Deliberately not in this PR

The `gemba-bootstrap` (27), `gemba-harness` (2), and `gemba-wiki` (2) pins under
`.github/workflows/` stay on old-lineage tags. Those sit inside Dependabot's
`github-actions` scope (`/`), which is how plan-a-05 designs the carry. They
resolve correctly today because the pre-rename tags anchor the old lineage.

This PR touches no action home, so it triggers no further `publish-actions`
mirror. The chain terminates here.